### PR TITLE
Refactor output paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,23 +30,23 @@ jobs:
           # Increase this key to trigger cache invalidation
           cache-environment-key: 1
 
+      # Linter
+      - name: "Run pre-commit tests"
+        run: "pre-commit run --all-files"
+
+      # Check out repos resquired for unit tests.
       - name: "Check out pm_icecon repository"
         uses: "actions/checkout@v3"
         with:
           repository: "nsidc/pm_icecon"
           ref: "main"
           path: "pm_icecon"
-
       - name: "Check out pm_tb_data repository"
         uses: "actions/checkout@v3"
         with:
           repository: "nsidc/pm_tb_data"
           ref: "main"
           path: "pm_tb_data"
-
-      # Linter
-      - name: "Run pre-commit tests"
-        run: "pre-commit run --all-files"
 
       # Unit tests
       - name: "Run typecheck and tests"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,14 +5,14 @@ default_language_version:
 repos:
 
   - repo: "https://github.com/pre-commit/pre-commit-hooks"
-    rev: "v4.4.0"
+    rev: "v4.5.0"
     hooks:
       - id: "check-added-large-files"
       - id: "check-vcs-permalinks"
       - id: "end-of-file-fixer"
 
   - repo: "https://github.com/charliermarsh/ruff-pre-commit"
-    rev: "v0.0.291"
+    rev: "v0.1.3"
     hooks:
       - id: "ruff"
         # NOTE: "--exit-non-zero-on-fix" is important for CI to function
@@ -20,11 +20,11 @@ repos:
         args: ["--fix", "--exit-non-zero-on-fix"]
 
   - repo: "https://github.com/psf/black"
-    rev: "23.9.1"
+    rev: "23.10.1"
     hooks:
       - id: "black"
 
   - repo: "https://github.com/jendrikseipp/vulture"
-    rev: "v2.9.1"
+    rev: "v2.10"
     hooks:
       - id: "vulture"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: "ruff"
         # NOTE: "--exit-non-zero-on-fix" is important for CI to function
         # correctly!
-        args: ["--fix", "--exit-non-zero-on-fix"]
+        args: ["--fix", "--exit-non-zero-on-fix", "--verbose"]
 
   - repo: "https://github.com/psf/black"
     rev: "23.10.1"

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -13,7 +13,7 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: e710a4183920576623e32630d1ff06d6ffddf942b6f5f41095f91561483c657d
+    linux-64: 28d12ccf792508979bfdd3f602348a537ab23aa7f92b49ed411ecf707cf211ef
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -680,10 +680,10 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-hcb278e6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
   hash:
-    md5: 681105bccc2a3f7f1a837d47d39c9179
-    sha256: ccf61e61d58a8a7b2d66822d5568e2dc9387883dd9b2da61e1d787ece4c4979a
+    md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
+    sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
   category: main
   optional: false
 - name: nspr
@@ -700,16 +700,16 @@ package:
   category: main
   optional: false
 - name: openssl
-  version: 3.1.3
+  version: 3.1.4
   manager: conda
   platform: linux-64
   dependencies:
     ca-certificates: ''
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.3-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.4-hd590300_0.conda
   hash:
-    md5: 7bb88ce04c8deb9f7d763ae04a1da72f
-    sha256: f4e35f506c7e8ab7dfdc47255b0d5aa8ce0c99028ae0affafd274333042c4f70
+    md5: 412ba6938c3e2abaca8b1129ea82e238
+    sha256: d15b3e83ce66c6f6fbb4707f2f5c53337124c01fb03bfda1cf25c5b41123efc7
   category: main
   optional: false
 - name: pixman
@@ -1060,20 +1060,20 @@ package:
   category: main
   optional: false
 - name: libnghttp2
-  version: 1.52.0
+  version: 1.55.1
   manager: conda
   platform: linux-64
   dependencies:
-    c-ares: '>=1.18.1,<2.0a0'
+    c-ares: '>=1.20.1,<2.0a0'
     libev: '>=4.33,<4.34.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.0.8,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.52.0-h61bc06f_0.conda
+    openssl: '>=3.1.4,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.55.1-h47da74e_0.conda
   hash:
-    md5: 613955a50485812985c059e7b269f42e
-    sha256: ecd6b08c2b5abe7d1586428c4dd257dcfa00ee53700d79cdc8bca098fdfbd79a
+    md5: a802251d1eaeeae041c867faf0f94fa8
+    sha256: 5e60b852dbde156ef1fa939af2491fe0e9eb3000de146786dede7cda8991ae4c
   category: main
   optional: false
 - name: libpng
@@ -1573,7 +1573,7 @@ package:
   category: main
   optional: false
 - name: python
-  version: 3.10.12
+  version: 3.10.13
   manager: conda
   platform: linux-64
   dependencies:
@@ -1581,20 +1581,20 @@ package:
     ld_impl_linux-64: '>=2.36.1'
     libffi: '>=3.4,<4.0a0'
     libgcc-ng: '>=12'
-    libnsl: '>=2.0.0,<2.1.0a0'
-    libsqlite: '>=3.42.0,<4.0a0'
+    libnsl: '>=2.0.1,<2.1.0a0'
+    libsqlite: '>=3.43.2,<4.0a0'
     libuuid: '>=2.38.1,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     ncurses: '>=6.4,<7.0a0'
-    openssl: '>=3.1.1,<4.0a0'
+    openssl: '>=3.1.4,<4.0a0'
     readline: '>=8.2,<9.0a0'
-    tk: '>=8.6.12,<8.7.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
     xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.12-hd12c33a_0_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.13-hd12c33a_0_cpython.conda
   hash:
-    md5: eb6f1df105f37daedd6dca78523baa75
-    sha256: 05e2a7ce916d259f11979634f770f31027d0a5d18463b094e64a30500f900699
+    md5: f3a8c32aa764c3e7188b4b810fc9d6ce
+    sha256: a53410f459f314537b379982717b1c5911efc2f0cc26d63c4d6f831bcb31c964
   category: main
   optional: false
 - name: sqlite
@@ -1743,18 +1743,6 @@ package:
     sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
   category: main
   optional: false
-- name: backcall
-  version: 0.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 6006a6d08a3fa99268a2681c7fb55213
-    sha256: ee62d6434090c1327a48551734e06bd10e65a64ef7f3b6e68719500dab0e42b9
-  category: main
-  optional: false
 - name: backports
   version: '1.0'
   manager: conda
@@ -1846,15 +1834,15 @@ package:
   category: main
   optional: false
 - name: charset-normalizer
-  version: 3.3.1
+  version: 3.3.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 985378f74689fccce52f158027bd9acd
-    sha256: a31739c49c4b1c8e0cbdec965ba152683d36ce6e23bdaefcfee99937524dabd1
+    md5: 7f4a9e3fcff3f6356ae99244a014da6a
+    sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
   category: main
   optional: false
 - name: click
@@ -1957,27 +1945,27 @@ package:
   category: main
   optional: false
 - name: executing
-  version: 1.2.0
+  version: 2.0.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 4c1bc140e2be5c8ba6e3acab99e25c50
-    sha256: 9c03425cd58c474af20e179c9ba121a82984d6c4bfc896bbc992f5ed75dd7539
+    md5: e16be50e378d8a4533b989035b196ab8
+    sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
   category: main
   optional: false
 - name: filelock
-  version: 3.12.4
+  version: 3.13.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.12.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 5173d4b8267a0699a43d73231e0b6596
-    sha256: 7463c64364c14b34a7a69a7550a880ccd1ec6d3014001e55913e6e4e8b0c7395
+    md5: 0c1729b74a8152fde6a38ba0a2ab9f45
+    sha256: 4d742d91412d1f163e5399d2b50c5d479694ebcd309127abb549ca3977f89d2b
   category: main
   optional: false
 - name: fontconfig
@@ -2459,15 +2447,15 @@ package:
   category: main
   optional: false
 - name: phonenumbers
-  version: 8.13.23
+  version: 8.13.24
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/phonenumbers-8.13.23-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/phonenumbers-8.13.24-pyhd8ed1ab_0.conda
   hash:
-    md5: 6b3759fa8c3396db388235508e1e6ff8
-    sha256: 5fefcad0dde871a43b6c15f6ec965eeadb418143c537163e240030a634c81a78
+    md5: 17eabf196e90b2e75284b30108c69981
+    sha256: 6e036520e34894b50d5e02798e1de034332c0102bba002f2cf17ddaaeca1c6b3
   category: main
   optional: false
 - name: pickleshare
@@ -2793,15 +2781,15 @@ package:
   category: main
   optional: false
 - name: traitlets
-  version: 5.11.2
+  version: 5.13.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.11.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
   hash:
-    md5: bd3f90f7551e1cffb1f402880eb2cef1
-    sha256: 81f2675ebc2bd6016c304770c81812aab8947953b0f0cca766077b127cc7e8f1
+    md5: 8a9953c15e1e5a7c1baddbbf4511a567
+    sha256: 7ac67960ba2e8c16818043cc65ac6190fa4fd95f5b24357df58e4f73d5e60a10
   category: main
   optional: false
 - name: typing_extensions
@@ -3002,16 +2990,16 @@ package:
   category: main
   optional: false
 - name: asttokens
-  version: 2.4.0
+  version: 2.4.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.5'
     six: '>=1.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 056f04e51dd63337e8d7c425c18c86f1
-    sha256: e7e91e3fa26abe502be690371893f205d87a82c225668ea6e9a1ba26870388ee
+    md5: 5f25798dcefd8252ce5f9dc494d5f571
+    sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
   category: main
   optional: false
 - name: backports.functools_lru_cache
@@ -3539,7 +3527,7 @@ package:
   category: main
   optional: false
 - name: pytest
-  version: 7.4.2
+  version: 7.4.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -3550,10 +3538,10 @@ package:
     pluggy: '>=0.12,<2.0'
     python: '>=3.7'
     tomli: '>=1.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 6dd662ff5ac9a783e5c940ce9f3fe649
-    sha256: 150bfb2a86dffd4ce1e91c2d61dde5779fb3ee338675e210fec4ef508ffff28c
+    md5: 5bdca0aca30b0ee62bb84854e027eae0
+    sha256: 14e948e620ec87d9e62a8d9c21d40084b4805a939cfee322be7d457379dc96a0
   category: main
   optional: false
 - name: python-dateutil
@@ -3597,7 +3585,7 @@ package:
   category: main
   optional: false
 - name: ruamel.yaml
-  version: 0.17.39
+  version: 0.18.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -3606,10 +3594,10 @@ package:
     python_abi: 3.10.*
     ruamel.yaml.clib: '>=0.1.2'
     setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.17.39-py310h2372a71_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.3-py310h2372a71_0.conda
   hash:
-    md5: 7e10c23928a18d055177d33877b9b533
-    sha256: 34df48852982d6017540b8da7aac7bcfafe788176c765f3fd5c1f1eb023928fa
+    md5: b6034297118a17700f63967807b4e0c0
+    sha256: 9eb0cf088daad5f80c74258cc1edd1fed97450b07cd6c63861f56c3695da5392
   category: main
   optional: false
 - name: sip
@@ -3715,7 +3703,7 @@ package:
   category: main
   optional: false
 - name: botocore
-  version: 1.31.17
+  version: 1.31.64
   manager: conda
   platform: linux-64
   dependencies:
@@ -3723,26 +3711,26 @@ package:
     python: '>=3.7'
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,<1.27'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.31.17-pyhd8ed1ab_3.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.31.64-pyhd8ed1ab_0.conda
   hash:
-    md5: 929cb539ebd6d4b569646a2ba72f875f
-    sha256: 1e03dc796b6ae7b5177c90b44c860cad3b42905732ce41af028b639141067d7d
+    md5: b208e9509d3a523b914fa21cd46e4ae2
+    sha256: f73692d2c9d4c38796d07b92b509dd9a14b036c83f520672c608d9d79eb440ba
   category: main
   optional: false
 - name: cryptography
-  version: 41.0.4
+  version: 41.0.5
   manager: conda
   platform: linux-64
   dependencies:
     cffi: '>=1.12'
     libgcc-ng: '>=12'
-    openssl: '>=3.1.3,<4.0a0'
+    openssl: '>=3.1.4,<4.0a0'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-41.0.4-py310h75e40e8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-41.0.5-py310h75e40e8_0.conda
   hash:
-    md5: ad06c4db71ba0b6d153c66de88a41fdc
-    sha256: 62480313c6944b301c7763a667893f31a18e8c16be8bd9528180ef2d5f07e9ad
+    md5: 33f090627d17c47493b88a5f7d2834e8
+    sha256: b81a6dd15052379775c43997a48f4a85db5c0448a80a75ba74c3af78cf33c0da
   category: main
   optional: false
 - name: geotiff
@@ -4158,16 +4146,16 @@ package:
   category: main
   optional: false
 - name: wcwidth
-  version: 0.2.8
+  version: 0.2.9
   manager: conda
   platform: linux-64
   dependencies:
     backports.functools_lru_cache: ''
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
   hash:
-    md5: 367386d2575a0e62412448eda1012efd
-    sha256: e3b6d2041b4d175a1437dccc71b4ef2e53111dfcc64b219fef4bed379e6ef236
+    md5: 8e8280dec091763dfdc29e066de52270
+    sha256: 7552f6545ed212b9ae5d023870481fc377c7f18b4854b63160699b95a420c42e
   category: main
   optional: false
 - name: aiohttp
@@ -4206,7 +4194,7 @@ package:
   category: main
   optional: false
 - name: cftime
-  version: 1.6.2
+  version: 1.6.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -4214,10 +4202,10 @@ package:
     numpy: '>=1.22.4,<2.0a0'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.2-py310h1f7b6fc_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.3-py310h1f7b6fc_0.conda
   hash:
-    md5: 7925aaa4330045bc32d334b20f446902
-    sha256: 182a5e5584167a51625617775a2c641784985a5e769e74e3dd445bd6f1c0e7e1
+    md5: 31beda75384647959d5792a1a7dc571a
+    sha256: 0983d88068e4bd589031582769ef7d05617edda3a7daa1f4847492f4c3538aad
   category: main
   optional: false
 - name: contourpy
@@ -4289,16 +4277,16 @@ package:
   category: main
   optional: false
 - name: identify
-  version: 2.5.30
+  version: 2.5.31
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
     ukkonen: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.30-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.31-pyhd8ed1ab_0.conda
   hash:
-    md5: b7a2e3bb89bda8c69839485c20aabadf
-    sha256: dc9901654af0556209bb5b4194ef2deb643bc641ac859a31f13c41b945b60150
+    md5: fea10604a45e974b110ea15a88913ebc
+    sha256: a56ec678a4e58d0a450174fd813581e961829def274453e093c9dae836b80cee
   category: main
   optional: false
 - name: libgdal
@@ -4433,30 +4421,30 @@ package:
   category: main
   optional: false
 - name: python-fsutil
-  version: 0.10.0
+  version: 0.11.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.5'
     requests: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fsutil-0.10.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-fsutil-0.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 130046bfa768d689c26afe90efd67632
-    sha256: 49ba379b728e1a80f9e64417af6c4e6960f036cd1244957577346f57b3972598
+    md5: 52d13eb9da0c35391bfb03e159847a20
+    sha256: 13159d879030b76e31debd3e3c05d2ec32d127ee712816532a40982e0be456f3
   category: main
   optional: false
 - name: rich-click
-  version: 1.7.0
+  version: 1.7.1
   manager: conda
   platform: linux-64
   dependencies:
     click: '>=7,<9'
     python: '>=3.7'
     rich: '>=10'
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-click-1.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-click-1.7.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 564af8d7ea5992556df52e4da16f2719
-    sha256: e70a1953d2a30d1fcf04c2dd63a862e0b9ac64375f584563111de857cbf7f1a6
+    md5: 2795aab9e8b40af88c799fb2355194f9
+    sha256: e783d0f6bdc851e1a1fdba1fb1ab045462e03f8a9a3aaf9b7a63ecb4a9478341
   category: main
   optional: false
 - name: scipy
@@ -4546,15 +4534,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    aiohttp: '>=3.3.1,<4.0.0'
+    aiohttp: '>=3.7.4.post0,<4.0.0'
     aioitertools: '>=0.5.1,<1.0.0'
-    botocore: '>=1.31.17,<1.31.18'
-    python: '>=3.7'
+    botocore: '>=1.31.16,<1.31.65'
+    python: '>=3.8'
     wrapt: '>=1.10.10,<2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.7.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.7.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 273a1a421309871b051acd6aef346b63
-    sha256: b9f835ad1c95d220f4f7a72e1155d027f5a57c1d109d5eceedd33333562add06
+    md5: eb36e010b948b1e8e5b891ba52d7c9e1
+    sha256: b827f1f0666abd25bc01a14828379804692603f30e999ce0eac3b0d15858efb5
   category: main
   optional: false
 - name: bump-my-version
@@ -4871,21 +4859,21 @@ package:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     matplotlib-base: '>=3.4'
-    numpy: '>=1.21.6,<2.0a0'
+    numpy: '>=1.22.4,<2.0a0'
     packaging: '>=20'
     pyproj: '>=3.1.0'
     pyshp: '>=2.1'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     shapely: '>=1.7'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.22.0-py310h7cbd5c2_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.22.0-py310hcc13569_1.conda
   hash:
-    md5: 7bfbace0788f477da1c26e10a358692d
-    sha256: c4b7d3c8d2f9af249f282191eef81e23bcf57a8fb64c018c8f0ff6841366f52b
+    md5: 31ef447724fb19066a9d00a660dab1bd
+    sha256: ec73372b3945634920c115f9d04b4543cc2d459c583df329aa32be813ca21380
   category: main
   optional: false
 - name: conda-lock
-  version: 2.4.1
+  version: 2.4.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -4913,10 +4901,10 @@ package:
     typing_extensions: ''
     urllib3: '>=1.26.5,<2.0'
     virtualenv: '>=20.0.26'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.4.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.4.2-pyhd8ed1ab_0.conda
   hash:
-    md5: deb6e2f8d8b4de933563cc681165b833
-    sha256: 08cd768d033db260e043982ba91de007213adbde5210a76fd2decad3c135e666
+    md5: 068b8ae6928d477a0d216254f6eacd34
+    sha256: c3a684affc774d45e6bef61306d1005a3fab75862bbe4f2adceb995e14a07193
   category: main
   optional: false
 - name: fiona
@@ -4975,12 +4963,11 @@ package:
   category: main
   optional: false
 - name: ipython
-  version: 8.16.1
+  version: 8.17.2
   manager: conda
   platform: linux-64
   dependencies:
     __linux: ''
-    backcall: ''
     decorator: ''
     exceptiongroup: ''
     jedi: '>=0.16'
@@ -4993,10 +4980,10 @@ package:
     stack_data: ''
     traitlets: '>=5'
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.16.1-pyh0d859eb_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh41d4057_0.conda
   hash:
-    md5: 7e52cb0dbf01b90365bfe433ec8bd3c0
-    sha256: 2dc119746ddac02cb01644ae7c7ac54a296366e2edf0d178f50f833113aaf94a
+    md5: f39d0b60e268fe547f1367edbab457d4
+    sha256: 31322d58f412787f5beeb01db4d16f10f8ae4e0cc2ec99fafef1e690374fe298
   category: main
   optional: false
 - name: pyqt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ min_confidence = 80
 [tool.ruff]
 target-version = "py310"
 
+extend-fixable = ["I"]
+extend-select = ["I"]
+
 ignore = [
   # D1: Ignore errors requiring docstrings on everything.
   # D203: "1 blank line required before class docstring"

--- a/seaice_ecdr/cli/entrypoint.py
+++ b/seaice_ecdr/cli/entrypoint.py
@@ -1,6 +1,7 @@
 """entrypoint.py  Contains click commands fo seaice_ecdr."""
 import click
 
+from seaice_ecdr.complete_daily_ecdr import cli as complete_daily_cli
 from seaice_ecdr.initial_daily_ecdr import cli as ecdr_cli
 from seaice_ecdr.nrt import nrt_cli
 from seaice_ecdr.temporal_composite_daily import cli as tiecdr_cli
@@ -15,6 +16,7 @@ def cli():
 cli.add_command(ecdr_cli)
 cli.add_command(tiecdr_cli)
 cli.add_command(nrt_cli)
+cli.add_command(complete_daily_cli)
 
 
 if __name__ == "__main__":

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -15,18 +15,9 @@ BASE_OUTPUT_DIR = NSIDC_NFS_SHARE_DIR / f"ecdr_{ECDR_PRODUCT_VERSION}_outputs"
 # (e.g, using input data from AU_SI12)
 STANDARD_BASE_OUTPUT_DIR = BASE_OUTPUT_DIR / "standard"
 
-NRT_BASE_OUTPUT_DIR = BASE_OUTPUT_DIR / "nrt"
-
-INITIAL_DAILY_OUTPUT_DIR = STANDARD_BASE_OUTPUT_DIR / "initial_daily"
-# Daily temporally interpolated output for 'standard' ECDR processing
-TEMPORAL_INTERP_DAILY_OUTPUT_DIR = STANDARD_BASE_OUTPUT_DIR / "temporal_interp_daily"
-
-# Complete daily output for 'standard' ECDR processing
-COMPLETE_DAILY_OUTPUT_DIR = BASE_OUTPUT_DIR / "standard"
-
 # Daily initial/intermiedate output for 'Near Real Time' (NRT) ECDR processing
 # (using data from AU_SI12_NRT_R04)
-NRT_INITIAL_DAILY_OUTPUT_DIR = BASE_OUTPUT_DIR / "nrt" / "initial_daily"
+NRT_BASE_OUTPUT_DIR = BASE_OUTPUT_DIR / "nrt"
 
 # Location of LANCE AMSR2 NRT data files:
 # TODO: nest the subdir under an `ecdr_inputs` or similar?

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -15,6 +15,8 @@ BASE_OUTPUT_DIR = NSIDC_NFS_SHARE_DIR / f"ecdr_{ECDR_PRODUCT_VERSION}_outputs"
 # (e.g, using input data from AU_SI12)
 STANDARD_BASE_OUTPUT_DIR = BASE_OUTPUT_DIR / "standard"
 
+NRT_BASE_OUTPUT_DIR = BASE_OUTPUT_DIR / "nrt"
+
 INITIAL_DAILY_OUTPUT_DIR = STANDARD_BASE_OUTPUT_DIR / "initial_daily"
 # Daily temporally interpolated output for 'standard' ECDR processing
 TEMPORAL_INTERP_DAILY_OUTPUT_DIR = STANDARD_BASE_OUTPUT_DIR / "temporal_interp_daily"

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -13,11 +13,11 @@ BASE_OUTPUT_DIR = NSIDC_NFS_SHARE_DIR / f"ecdr_{ECDR_PRODUCT_VERSION}_outputs"
 
 # Daily initial/intermiedate output for 'standard' (not NRT) ECDR processing
 # (e.g, using input data from AU_SI12)
-INITIAL_DAILY_OUTPUT_DIR = BASE_OUTPUT_DIR / "standard" / "initial_daily"
+STANDARD_BASE_OUTPUT_DIR = BASE_OUTPUT_DIR / "standard"
+
+INITIAL_DAILY_OUTPUT_DIR = STANDARD_BASE_OUTPUT_DIR / "initial_daily"
 # Daily temporally interpolated output for 'standard' ECDR processing
-TEMPORAL_INTERP_DAILY_OUTPUT_DIR = (
-    BASE_OUTPUT_DIR / "standard" / "temporal_interp_daily"
-)
+TEMPORAL_INTERP_DAILY_OUTPUT_DIR = STANDARD_BASE_OUTPUT_DIR / "temporal_interp_daily"
 
 
 # Daily initial/intermiedate output for 'Near Real Time' (NRT) ECDR processing

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -914,9 +914,9 @@ def write_ide_netcdf(
 
 
 @cache
-def get_idecdr_dir(*, cdr_data_dir: Path) -> Path:
+def get_idecdr_dir(*, ecdr_data_dir: Path) -> Path:
     """Daily initial output dir for ECDR processing."""
-    idecdr_dir = cdr_data_dir / "initial_daily"
+    idecdr_dir = ecdr_data_dir / "initial_daily"
     idecdr_dir.mkdir(exist_ok=True)
 
     return idecdr_dir
@@ -926,7 +926,7 @@ def get_idecdr_filepath(
     date: dt.date,
     hemisphere: Hemisphere,
     resolution: AU_SI_RESOLUTIONS,
-    cdr_data_dir: Path,
+    ecdr_data_dir: Path,
 ) -> Path:
     """Yields the filepath of the pass1 -- idecdr -- intermediate file."""
 
@@ -938,7 +938,7 @@ def get_idecdr_filepath(
         algorithm="idecdr",
         resolution=f"{resolution}km",
     )
-    idecdr_dir = get_idecdr_dir(cdr_data_dir=cdr_data_dir)
+    idecdr_dir = get_idecdr_dir(ecdr_data_dir=ecdr_data_dir)
     idecdr_path = idecdr_dir / idecdr_fn
 
     return idecdr_path
@@ -949,7 +949,7 @@ def make_idecdr_netcdf(
     date: dt.date,
     hemisphere: Hemisphere,
     resolution: AU_SI_RESOLUTIONS,
-    cdr_data_dir: Path,
+    ecdr_data_dir: Path,
     excluded_fields: Iterable[str] = [],
 ) -> None:
     logger.info(f"Creating idecdr for {date=}, {hemisphere=}, {resolution=}")
@@ -961,7 +961,7 @@ def make_idecdr_netcdf(
     output_path = get_idecdr_filepath(
         date=date,
         hemisphere=hemisphere,
-        cdr_data_dir=cdr_data_dir,
+        ecdr_data_dir=ecdr_data_dir,
         resolution=resolution,
     )
 
@@ -981,7 +981,7 @@ def create_idecdr_for_date_range(
     start_date: dt.date,
     end_date: dt.date,
     resolution: AU_SI_RESOLUTIONS,
-    cdr_data_dir: Path,
+    ecdr_data_dir: Path,
     verbose_intermed_ncfile: bool = False,
 ) -> None:
     """Generate the initial daily ecdr files for a range of dates."""
@@ -1006,7 +1006,7 @@ def create_idecdr_for_date_range(
                 date=date,
                 hemisphere=hemisphere,
                 resolution=resolution,
-                cdr_data_dir=cdr_data_dir,
+                ecdr_data_dir=ecdr_data_dir,
                 excluded_fields=excluded_fields,
             )
 
@@ -1024,7 +1024,7 @@ def create_idecdr_for_date_range(
                 date=date,
                 hemisphere=hemisphere,
                 resolution=resolution,
-                cdr_data_dir=cdr_data_dir,
+                ecdr_data_dir=ecdr_data_dir,
             )
             err_filename = err_filepath.name + ".error"
             logger.info(f"Writing error info to {err_filename}")
@@ -1054,7 +1054,7 @@ def create_idecdr_for_date_range(
     type=click.Choice(get_args(Hemisphere)),
 )
 @click.option(
-    "--cdr-data-dir",
+    "--ecdr-data-dir",
     required=True,
     type=click.Path(
         exists=True,
@@ -1093,7 +1093,7 @@ def cli(
     *,
     date: dt.date,
     hemisphere: Hemisphere,
-    cdr_data_dir: Path,
+    ecdr_data_dir: Path,
     resolution: AU_SI_RESOLUTIONS,
     verbose_intermed_ncfile: bool,
 ) -> None:
@@ -1108,6 +1108,6 @@ def cli(
         start_date=date,
         end_date=date,
         resolution=resolution,
-        cdr_data_dir=cdr_data_dir,
+        ecdr_data_dir=ecdr_data_dir,
         verbose_intermed_ncfile=verbose_intermed_ncfile,
     )

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import get_args
 
 import click
-from pm_icecon.util import standard_output_filename
 from pm_tb_data._types import Hemisphere
 from pm_tb_data.fetch.au_si import AU_SI_RESOLUTIONS
 from pm_tb_data.fetch.lance_amsr2 import (
@@ -13,9 +12,10 @@ from pm_tb_data.fetch.lance_amsr2 import (
 )
 
 from seaice_ecdr.cli.util import datetime_to_date
-from seaice_ecdr.constants import LANCE_NRT_DATA_DIR, NRT_INITIAL_DAILY_OUTPUT_DIR
+from seaice_ecdr.constants import LANCE_NRT_DATA_DIR, NRT_BASE_OUTPUT_DIR
 from seaice_ecdr.initial_daily_ecdr import (
     compute_initial_daily_ecdr_dataset,
+    get_idecdr_filepath,
     write_ide_netcdf,
 )
 
@@ -94,8 +94,7 @@ def download_latest_nrt_data(*, output_dir: Path, overwrite: bool) -> None:
     type=click.Choice(get_args(Hemisphere)),
 )
 @click.option(
-    "-o",
-    "--output-dir",
+    "--cdr-data-dir",
     required=True,
     type=click.Path(
         exists=True,
@@ -105,8 +104,13 @@ def download_latest_nrt_data(*, output_dir: Path, overwrite: bool) -> None:
         resolve_path=True,
         path_type=Path,
     ),
+    default=NRT_BASE_OUTPUT_DIR,
+    help=(
+        "Base output directory for standard ECDR outputs."
+        " Subdirectories are created for outputs of"
+        " different stages of processing."
+    ),
     show_default=True,
-    default=NRT_INITIAL_DAILY_OUTPUT_DIR,
 )
 @click.option(
     "-r",
@@ -133,7 +137,7 @@ def nrt_initial_daily_ecdr(
     *,
     date: dt.date,
     hemisphere: Hemisphere,
-    output_dir: Path,
+    cdr_data_dir: Path,
     resolution: AU_SI_RESOLUTIONS,
     lance_amsr2_input_dir: Path,
 ):
@@ -148,15 +152,12 @@ def nrt_initial_daily_ecdr(
         lance_amsr2_input_dir=lance_amsr2_input_dir,
     )
 
-    output_fn = standard_output_filename(
+    output_path = get_idecdr_filepath(
         hemisphere=hemisphere,
         date=date,
-        sat="ausi",
-        algorithm="nrt_idecdr",
-        resolution=f"{resolution}km",
+        resolution=resolution,
+        cdr_data_dir=cdr_data_dir,
     )
-
-    output_path = Path(output_dir) / Path(output_fn)
 
     write_ide_netcdf(
         ide_ds=nrt_initial_ecdr_ds,

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -94,7 +94,7 @@ def download_latest_nrt_data(*, output_dir: Path, overwrite: bool) -> None:
     type=click.Choice(get_args(Hemisphere)),
 )
 @click.option(
-    "--cdr-data-dir",
+    "--ecdr-data-dir",
     required=True,
     type=click.Path(
         exists=True,
@@ -137,7 +137,7 @@ def nrt_initial_daily_ecdr(
     *,
     date: dt.date,
     hemisphere: Hemisphere,
-    cdr_data_dir: Path,
+    ecdr_data_dir: Path,
     resolution: AU_SI_RESOLUTIONS,
     lance_amsr2_input_dir: Path,
 ):
@@ -156,7 +156,7 @@ def nrt_initial_daily_ecdr(
         hemisphere=hemisphere,
         date=date,
         resolution=resolution,
-        cdr_data_dir=cdr_data_dir,
+        ecdr_data_dir=ecdr_data_dir,
     )
 
     write_ide_netcdf(

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -349,7 +349,6 @@ def temporally_interpolated_ecdr_dataset_for_au_si_tbs(
 
     # Copy ide_ds to a new xr tiecdr dataset
     tie_ds = ide_ds.copy(deep=True)
-    # ds_varlist = [name for name in tie_ds.data_vars]
 
     # Update the cdr_conc var with temporally interpolated cdr_conc field
     #   by creating a DataArray with conc fields +/- interp_range around date

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -39,9 +39,9 @@ except ValueError:
 
 
 @cache
-def get_tie_dir(*, cdr_data_dir: Path) -> Path:
+def get_tie_dir(*, ecdr_data_dir: Path) -> Path:
     """Daily complete output dir for TIE processing"""
-    tie_dir = cdr_data_dir / "complete_daily"
+    tie_dir = ecdr_data_dir / "complete_daily"
     tie_dir.mkdir(exist_ok=True)
 
     return tie_dir
@@ -51,7 +51,7 @@ def get_tie_filepath(
     date,
     hemisphere,
     resolution,
-    cdr_data_dir: Path,
+    ecdr_data_dir: Path,
     file_label: str,
 ) -> Path:
     """Return the complete daily tie file path."""
@@ -64,7 +64,7 @@ def get_tie_filepath(
         sat="ausi",
         resolution=resolution,
     )
-    tie_dir = get_tie_dir(cdr_data_dir=cdr_data_dir)
+    tie_dir = get_tie_dir(ecdr_data_dir=ecdr_data_dir)
 
     tie_filepath = tie_dir / tie_filename
 
@@ -105,7 +105,7 @@ def read_with_create_initial_daily_ecdr(
     date,
     hemisphere,
     resolution,
-    cdr_data_dir: Path,
+    ecdr_data_dir: Path,
     force_ide_file_creation=False,
 ):
     """Return init daily ecdr field, creating it if necessary."""
@@ -113,7 +113,7 @@ def read_with_create_initial_daily_ecdr(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        cdr_data_dir=cdr_data_dir,
+        ecdr_data_dir=ecdr_data_dir,
     )
 
     if not ide_filepath.is_file() or force_ide_file_creation:
@@ -277,11 +277,11 @@ def read_or_create_and_read_idecdr_ds(
     date: dt.date,
     hemisphere: Hemisphere,
     resolution: AU_SI_RESOLUTIONS,
-    cdr_data_dir: Path,
+    ecdr_data_dir: Path,
 ) -> xr.Dataset:
     """Read an idecdr netCDF file, creating it if it doesn't exist."""
     ide_filepath = get_idecdr_filepath(
-        date, hemisphere, resolution, cdr_data_dir=cdr_data_dir
+        date, hemisphere, resolution, ecdr_data_dir=ecdr_data_dir
     )
     # TODO: Perhaps add an overwrite condition here?
     if not ide_filepath.is_file():
@@ -303,7 +303,7 @@ def read_or_create_and_read_idecdr_ds(
             date=date,
             hemisphere=hemisphere,
             resolution=resolution,
-            cdr_data_dir=cdr_data_dir,
+            ecdr_data_dir=ecdr_data_dir,
             excluded_fields=excluded_idecdr_fields,
         )
     logger.info(f"Reading ideCDR file from: {ide_filepath}")
@@ -325,7 +325,7 @@ def temporally_interpolated_ecdr_dataset_for_au_si_tbs(
     hemisphere: Hemisphere,
     resolution: AU_SI_RESOLUTIONS,
     interp_range: int = 5,
-    cdr_data_dir: Path,
+    ecdr_data_dir: Path,
     fill_the_pole_hole: bool = True,
 ) -> xr.Dataset:
     """Create xr dataset containing the second pass of daily enhanced CDR.
@@ -341,7 +341,7 @@ def temporally_interpolated_ecdr_dataset_for_au_si_tbs(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        cdr_data_dir=cdr_data_dir,
+        ecdr_data_dir=ecdr_data_dir,
     )
 
     # Copy ide_ds to a new xr tiecdr dataset
@@ -357,7 +357,7 @@ def temporally_interpolated_ecdr_dataset_for_au_si_tbs(
                 date=interp_date,
                 hemisphere=hemisphere,
                 resolution=resolution,
-                cdr_data_dir=cdr_data_dir,
+                ecdr_data_dir=ecdr_data_dir,
             )
             this_var = interp_ds.data_vars[interp_varname].copy()
             var_stack = xr.concat([var_stack, this_var], "time")
@@ -493,7 +493,7 @@ def make_tiecdr_netcdf(
     date: dt.date,
     hemisphere: Hemisphere,
     resolution: AU_SI_RESOLUTIONS,
-    cdr_data_dir: Path,
+    ecdr_data_dir: Path,
     interp_range: int = 5,
     fill_the_pole_hole: bool = True,
 ) -> None:
@@ -503,7 +503,7 @@ def make_tiecdr_netcdf(
         hemisphere=hemisphere,
         resolution=resolution,
         interp_range=interp_range,
-        cdr_data_dir=cdr_data_dir,
+        ecdr_data_dir=ecdr_data_dir,
         fill_the_pole_hole=fill_the_pole_hole,
     )
     output_path = get_tie_filepath(
@@ -511,7 +511,7 @@ def make_tiecdr_netcdf(
         hemisphere=hemisphere,
         resolution=resolution,
         file_label="tiecdr",
-        cdr_data_dir=cdr_data_dir,
+        ecdr_data_dir=ecdr_data_dir,
     )
 
     written_tie_ncfile = write_tie_netcdf(
@@ -527,7 +527,7 @@ def create_tiecdr_for_date_range(
     start_date: dt.date,
     end_date: dt.date,
     resolution: AU_SI_RESOLUTIONS,
-    cdr_data_dir: Path,
+    ecdr_data_dir: Path,
 ) -> None:
     """Generate the temporally composited daily ecdr files for a range of dates."""
     for date in date_range(start_date=start_date, end_date=end_date):
@@ -536,7 +536,7 @@ def create_tiecdr_for_date_range(
                 date=date,
                 hemisphere=hemisphere,
                 resolution=resolution,
-                cdr_data_dir=cdr_data_dir,
+                ecdr_data_dir=ecdr_data_dir,
             )
 
         # TODO: either catch and re-throw this exception or throw an error after
@@ -555,7 +555,7 @@ def create_tiecdr_for_date_range(
                 hemisphere=hemisphere,
                 resolution=resolution,
                 file_label="tiecdr",
-                cdr_data_dir=cdr_data_dir,
+                ecdr_data_dir=ecdr_data_dir,
             )
             err_filename = standard_output_filename(
                 hemisphere=hemisphere,
@@ -607,7 +607,7 @@ def create_tiecdr_for_date_range(
     type=click.Choice(get_args(Hemisphere)),
 )
 @click.option(
-    "--cdr-data-dir",
+    "--ecdr-data-dir",
     required=True,
     type=click.Path(
         exists=True,
@@ -636,7 +636,7 @@ def cli(
     date: dt.date,
     end_date: dt.date | None,
     hemisphere: Hemisphere,
-    cdr_data_dir: Path,
+    ecdr_data_dir: Path,
     resolution: AU_SI_RESOLUTIONS,
 ) -> None:
     """Run the temporal composite daily ECDR algorithm with AMSR2 data.
@@ -656,5 +656,5 @@ def cli(
         start_date=date,
         end_date=end_date,
         resolution=resolution,
-        cdr_data_dir=cdr_data_dir,
+        ecdr_data_dir=ecdr_data_dir,
     )

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -7,6 +7,7 @@ import datetime as dt
 import sys
 from pathlib import Path
 from typing import get_args, Iterable, cast
+from functools import cache
 
 import click
 import numpy as np
@@ -20,14 +21,14 @@ from pm_tb_data.fetch.au_si import AU_SI_RESOLUTIONS
 
 from seaice_ecdr.masks import psn_125_near_pole_hole_mask
 from seaice_ecdr.initial_daily_ecdr import (
+    get_idecdr_filepath,
     initial_daily_ecdr_dataset_for_au_si_tbs,
     make_idecdr_netcdf,
     write_ide_netcdf,
 )
 from seaice_ecdr.cli.util import datetime_to_date
 from seaice_ecdr.constants import (
-    INITIAL_DAILY_OUTPUT_DIR,
-    TEMPORAL_INTERP_DAILY_OUTPUT_DIR,
+    STANDARD_BASE_OUTPUT_DIR,
 )
 
 
@@ -38,6 +39,39 @@ try:
 except ValueError:
     logger.debug(f"Started logging in {__name__}")
     logger.add(sys.stderr, level="INFO")
+
+
+@cache
+def get_tie_dir(*, cdr_data_dir: Path) -> Path:
+    """Daily complete output dir for TIE processing"""
+    tie_dir = cdr_data_dir / "complete_daily"
+    tie_dir.mkdir(exist_ok=True)
+
+    return tie_dir
+
+
+def get_tie_filepath(
+    date,
+    hemisphere,
+    resolution,
+    cdr_data_dir: Path,
+    file_label: str,
+) -> Path:
+    """Return the complete daily tie file path."""
+    if "km" not in resolution:
+        resolution = f"{resolution}km"
+    tie_filename = standard_output_filename(
+        algorithm=file_label,
+        hemisphere=hemisphere,
+        date=date,
+        sat="ausi",
+        resolution=resolution,
+    )
+    tie_dir = get_tie_dir(cdr_data_dir=cdr_data_dir)
+
+    tie_filepath = tie_dir / tie_filename
+
+    return tie_filepath
 
 
 def iter_dates_near_date(
@@ -69,44 +103,20 @@ def iter_dates_near_date(
         date += dt.timedelta(days=date_step)
 
 
-def get_standard_initial_daily_ecdr_filename(
-    date,
-    hemisphere,
-    resolution,
-    output_directory: Path,
-):
-    """Return standard ide file name."""
-    # TODO: Perhaps this function should come from seaice_ecdr, not pm_icecon?
-    #       Specifically, the conventions specified in open Trello card
-    standard_initial_daily_ecdr_filename = standard_output_filename(
-        algorithm="idecdr",
-        hemisphere=hemisphere,
-        date=date,
-        sat="ausi",
-        resolution=f"{resolution}km",
-    )
-    initial_daily_ecdr_filename = Path(
-        output_directory,
-        standard_initial_daily_ecdr_filename,
-    )
-
-    return initial_daily_ecdr_filename
-
-
 def read_with_create_initial_daily_ecdr(
     *,
     date,
     hemisphere,
     resolution,
-    ide_dir: Path,
+    cdr_data_dir: Path,
     force_ide_file_creation=False,
 ):
     """Return init daily ecdr field, creating it if necessary."""
-    ide_filepath = get_standard_initial_daily_ecdr_filename(
+    ide_filepath = get_idecdr_filepath(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        output_directory=ide_dir,
+        cdr_data_dir=cdr_data_dir,
     )
 
     if not ide_filepath.is_file() or force_ide_file_creation:
@@ -264,36 +274,18 @@ def temporally_composite_dataarray(
     return temp_comp_da, temporal_flags
 
 
-def get_idecdr_filename(
-    date: dt.date,
-    hemisphere: Hemisphere,
-    resolution: AU_SI_RESOLUTIONS,
-    idecdr_dir: Path,
-) -> Path:
-    """Yields the name of the pass1 -- idecdr -- intermediate file."""
-
-    # TODO: Perhaps this function should come from seaice_ecdr, not pm_icecon?
-    idecdr_fn = standard_output_filename(
-        hemisphere=hemisphere,
-        date=date,
-        sat="ausi",
-        algorithm="idecdr",
-        resolution=f"{resolution}km",
-    )
-    idecdr_path = idecdr_dir / idecdr_fn
-
-    return idecdr_path
-
-
+# TODO: this function also belongs in the intial daily ecdr module.
 def read_or_create_and_read_idecdr_ds(
     *,
     date: dt.date,
     hemisphere: Hemisphere,
     resolution: AU_SI_RESOLUTIONS,
-    ide_dir: Path,
+    cdr_data_dir: Path,
 ) -> xr.Dataset:
     """Read an idecdr netCDF file, creating it if it doesn't exist."""
-    ide_filepath = get_idecdr_filename(date, hemisphere, resolution, idecdr_dir=ide_dir)
+    ide_filepath = get_idecdr_filepath(
+        date, hemisphere, resolution, cdr_data_dir=cdr_data_dir
+    )
     # TODO: Perhaps add an overwrite condition here?
     if not ide_filepath.is_file():
         excluded_idecdr_fields = [
@@ -314,7 +306,7 @@ def read_or_create_and_read_idecdr_ds(
             date=date,
             hemisphere=hemisphere,
             resolution=resolution,
-            output_dir=ide_dir,
+            cdr_data_dir=cdr_data_dir,
             excluded_fields=excluded_idecdr_fields,
         )
     logger.info(f"Reading ideCDR file from: {ide_filepath}")
@@ -336,7 +328,7 @@ def temporally_interpolated_ecdr_dataset_for_au_si_tbs(
     hemisphere: Hemisphere,
     resolution: AU_SI_RESOLUTIONS,
     interp_range: int = 5,
-    ide_dir: Path,
+    cdr_data_dir: Path,
     fill_the_pole_hole: bool = True,
 ) -> xr.Dataset:
     """Create xr dataset containing the second pass of daily enhanced CDR.
@@ -349,7 +341,10 @@ def temporally_interpolated_ecdr_dataset_for_au_si_tbs(
     """
     # Read in the idecdr file for this date
     ide_ds = read_or_create_and_read_idecdr_ds(
-        date=date, hemisphere=hemisphere, resolution=resolution, ide_dir=ide_dir
+        date=date,
+        hemisphere=hemisphere,
+        resolution=resolution,
+        cdr_data_dir=cdr_data_dir,
     )
 
     # Copy ide_ds to a new xr tiecdr dataset
@@ -366,7 +361,7 @@ def temporally_interpolated_ecdr_dataset_for_au_si_tbs(
                 date=interp_date,
                 hemisphere=hemisphere,
                 resolution=resolution,
-                ide_dir=ide_dir,
+                cdr_data_dir=cdr_data_dir,
             )
             this_var = interp_ds.data_vars[interp_varname].copy()
             var_stack = xr.concat([var_stack, this_var], "time")
@@ -502,8 +497,7 @@ def make_tiecdr_netcdf(
     date: dt.date,
     hemisphere: Hemisphere,
     resolution: AU_SI_RESOLUTIONS,
-    output_dir: Path,
-    ide_dir: Path,
+    cdr_data_dir: Path,
     interp_range: int = 5,
     fill_the_pole_hole: bool = True,
 ) -> None:
@@ -513,18 +507,15 @@ def make_tiecdr_netcdf(
         hemisphere=hemisphere,
         resolution=resolution,
         interp_range=interp_range,
-        ide_dir=ide_dir,
+        cdr_data_dir=cdr_data_dir,
         fill_the_pole_hole=fill_the_pole_hole,
     )
-    # TODO: Perhaps this function should come from seaice_ecdr, not pm_icecon?
-    output_fn = standard_output_filename(
-        hemisphere=hemisphere,
+    output_path = get_tie_filepath(
         date=date,
-        sat="ausi",
-        algorithm="tiecdr",
-        resolution=f"{resolution}km",
+        hemisphere=hemisphere,
+        resolution=resolution,
+        file_label="tiecdr",
     )
-    output_path = Path(output_dir) / Path(output_fn)
 
     written_tie_ncfile = write_tie_netcdf(
         tie_ds=tie_ds,
@@ -539,8 +530,7 @@ def create_tiecdr_for_date_range(
     start_date: dt.date,
     end_date: dt.date,
     resolution: AU_SI_RESOLUTIONS,
-    output_dir: Path,
-    ide_dir: Path,
+    cdr_data_dir: Path,
 ) -> None:
     """Generate the temporally composited daily ecdr files for a range of dates."""
     for date in date_range(start_date=start_date, end_date=end_date):
@@ -549,8 +539,7 @@ def create_tiecdr_for_date_range(
                 date=date,
                 hemisphere=hemisphere,
                 resolution=resolution,
-                output_dir=output_dir,
-                ide_dir=ide_dir,
+                cdr_data_dir=cdr_data_dir,
             )
 
         # TODO: either catch and re-throw this exception or throw an error after
@@ -564,6 +553,13 @@ def create_tiecdr_for_date_range(
             # `/share/apps/logs/seaice_ecdr`. The `logger` module should be able
             # to handle automatically logging error details to such a file.
             # TODO: Perhaps this function should come from seaice_ecdr
+            err_filepath = get_tie_filepath(
+                date=date,
+                hemisphere=hemisphere,
+                resolution=resolution,
+                file_label="tiecdr",
+                cdr_data_dir=cdr_data_dir,
+            )
             err_filename = standard_output_filename(
                 hemisphere=hemisphere,
                 date=date,
@@ -571,9 +567,9 @@ def create_tiecdr_for_date_range(
                 algorithm="tiecdr",
                 resolution=f"{resolution}km",
             )
-            err_filename += ".error"
+            err_filename = err_filepath.name + ".error"
             logger.info(f"Writing error info to {err_filename}")
-            with open(output_dir / err_filename, "w") as f:
+            with open(err_filepath.parent / err_filename, "w") as f:
                 traceback.print_exc(file=f)
                 traceback.print_exc(file=sys.stdout)
 
@@ -614,8 +610,7 @@ def create_tiecdr_for_date_range(
     type=click.Choice(get_args(Hemisphere)),
 )
 @click.option(
-    "-o",
-    "--output-dir",
+    "--cdr-data-dir",
     required=True,
     type=click.Path(
         exists=True,
@@ -625,7 +620,12 @@ def create_tiecdr_for_date_range(
         resolve_path=True,
         path_type=Path,
     ),
-    default=TEMPORAL_INTERP_DAILY_OUTPUT_DIR,
+    default=STANDARD_BASE_OUTPUT_DIR,
+    help=(
+        "Base output directory for standard ECDR outputs."
+        " Subdirectories are created for outputs of"
+        " different stages of processing."
+    ),
     show_default=True,
 )
 @click.option(
@@ -634,28 +634,13 @@ def create_tiecdr_for_date_range(
     required=True,
     type=click.Choice(get_args(AU_SI_RESOLUTIONS)),
 )
-@click.option(
-    "--initial-daily-ecdr-dir",
-    required=True,
-    type=click.Path(
-        exists=True,
-        file_okay=False,
-        dir_okay=True,
-        writable=True,
-        resolve_path=True,
-        path_type=Path,
-    ),
-    default=INITIAL_DAILY_OUTPUT_DIR,
-    show_default=True,
-)
 def cli(
     *,
     date: dt.date,
     end_date: dt.date | None,
     hemisphere: Hemisphere,
-    output_dir: Path,
+    cdr_data_dir: Path,
     resolution: AU_SI_RESOLUTIONS,
-    initial_daily_ecdr_dir: Path,
 ) -> None:
     """Run the temporal composite daily ECDR algorithm with AMSR2 data.
 
@@ -674,6 +659,5 @@ def cli(
         start_date=date,
         end_date=end_date,
         resolution=resolution,
-        output_dir=output_dir,
-        ide_dir=initial_daily_ecdr_dir,
+        cdr_data_dir=cdr_data_dir,
     )

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -514,6 +514,7 @@ def make_tiecdr_netcdf(
         hemisphere=hemisphere,
         resolution=resolution,
         file_label="tiecdr",
+        cdr_data_dir=cdr_data_dir,
     )
 
     written_tie_ncfile = write_tie_netcdf(

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -41,7 +41,7 @@ except ValueError:
 @cache
 def get_tie_dir(*, ecdr_data_dir: Path) -> Path:
     """Daily complete output dir for TIE processing"""
-    tie_dir = ecdr_data_dir / "complete_daily"
+    tie_dir = ecdr_data_dir / "temporal_interp"
     tie_dir.mkdir(exist_ok=True)
 
     return tie_dir

--- a/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
+++ b/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
@@ -10,11 +10,10 @@ import xarray as xr
 from loguru import logger
 from pm_tb_data._types import NORTH
 
-from seaice_ecdr.initial_daily_ecdr import get_idecdr_filepath
+from seaice_ecdr.initial_daily_ecdr import get_idecdr_filepath, make_idecdr_netcdf
 from seaice_ecdr.initial_daily_ecdr import (
     initial_daily_ecdr_dataset_for_au_si_tbs as compute_idecdr_ds,
 )
-from seaice_ecdr.initial_daily_ecdr import make_idecdr_netcdf
 
 # Set the default minimum log notification to Warning
 logger.remove(0)  # Removes previous logger info

--- a/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
+++ b/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
@@ -129,7 +129,7 @@ def test_cli_idecdr_ncfile_creation(tmpdir):
         date=test_date,
         hemisphere=test_hemisphere,
         resolution=test_resolution,
-        output_dir=tmpdir_path,
+        cdr_data_dir=tmpdir_path,
     )
     output_fn = standard_output_filename(
         hemisphere=test_hemisphere,
@@ -159,7 +159,7 @@ def test_can_drop_fields_from_idecdr_netcdf(
         date=test_date,
         hemisphere=test_hemisphere,
         resolution=test_resolution,
-        output_dir=tmpdir_path,
+        cdr_data_dir=tmpdir_path,
         excluded_fields=(cdr_conc_fieldname,),
     )
     output_fn = standard_output_filename(

--- a/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
+++ b/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
@@ -12,9 +12,9 @@ from loguru import logger
 from seaice_ecdr.initial_daily_ecdr import (
     initial_daily_ecdr_dataset_for_au_si_tbs as compute_idecdr_ds,
     make_idecdr_netcdf,
+    get_idecdr_filepath,
 )
 
-from pm_icecon.util import standard_output_filename
 from pm_tb_data._types import NORTH
 
 # Set the default minimum log notification to Warning
@@ -131,16 +131,14 @@ def test_cli_idecdr_ncfile_creation(tmpdir):
         resolution=test_resolution,
         cdr_data_dir=tmpdir_path,
     )
-    output_fn = standard_output_filename(
+    output_path = get_idecdr_filepath(
         hemisphere=test_hemisphere,
         date=test_date,
-        sat="ausi",
-        algorithm="idecdr",
-        resolution=f"{test_resolution}km",
+        resolution=test_resolution,
+        cdr_data_dir=tmpdir_path,
     )
-    output_path = tmpdir_path / output_fn
 
-    assert output_path.exists()
+    assert output_path.is_file()
 
     ds = xr.open_dataset(output_path)
     assert cdr_conc_fieldname in ds.variables.keys()
@@ -162,14 +160,14 @@ def test_can_drop_fields_from_idecdr_netcdf(
         cdr_data_dir=tmpdir_path,
         excluded_fields=(cdr_conc_fieldname,),
     )
-    output_fn = standard_output_filename(
+    output_path = get_idecdr_filepath(
         hemisphere=test_hemisphere,
         date=test_date,
-        sat="ausi",
-        algorithm="idecdr",
-        resolution=f"{test_resolution}km",
+        resolution=test_resolution,
+        cdr_data_dir=tmpdir_path,
     )
-    output_path = tmpdir_path / output_fn
+
+    assert output_path.is_file()
 
     ds = xr.open_dataset(output_path)
     assert cdr_conc_fieldname not in ds.variables.keys()

--- a/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
+++ b/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
@@ -127,13 +127,13 @@ def test_cli_idecdr_ncfile_creation(tmpdir):
         date=test_date,
         hemisphere=test_hemisphere,
         resolution=test_resolution,
-        cdr_data_dir=tmpdir_path,
+        ecdr_data_dir=tmpdir_path,
     )
     output_path = get_idecdr_filepath(
         hemisphere=test_hemisphere,
         date=test_date,
         resolution=test_resolution,
-        cdr_data_dir=tmpdir_path,
+        ecdr_data_dir=tmpdir_path,
     )
 
     assert output_path.is_file()
@@ -155,14 +155,14 @@ def test_can_drop_fields_from_idecdr_netcdf(
         date=test_date,
         hemisphere=test_hemisphere,
         resolution=test_resolution,
-        cdr_data_dir=tmpdir_path,
+        ecdr_data_dir=tmpdir_path,
         excluded_fields=(cdr_conc_fieldname,),
     )
     output_path = get_idecdr_filepath(
         hemisphere=test_hemisphere,
         date=test_date,
         resolution=test_resolution,
-        cdr_data_dir=tmpdir_path,
+        ecdr_data_dir=tmpdir_path,
     )
 
     assert output_path.is_file()

--- a/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
+++ b/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
@@ -42,7 +42,7 @@ def test_create_ide_file(tmpdir):
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        cdr_data_dir=Path(tmpdir),
+        ecdr_data_dir=Path(tmpdir),
     )
 
     test_ide_ds = initial_daily_ecdr_dataset_for_au_si_tbs(
@@ -62,14 +62,14 @@ def test_read_with_create_ide_file(tmpdir):
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        cdr_data_dir=Path(tmpdir),
+        ecdr_data_dir=Path(tmpdir),
     )
 
     test_ide_ds_with_creation = read_with_create_initial_daily_ecdr(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        cdr_data_dir=Path(tmpdir),
+        ecdr_data_dir=Path(tmpdir),
     )
 
     assert sample_ide_filepath.exists()
@@ -77,7 +77,7 @@ def test_read_with_create_ide_file(tmpdir):
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        cdr_data_dir=Path(tmpdir),
+        ecdr_data_dir=Path(tmpdir),
     )
 
     assert test_ide_ds_with_creation == test_ide_ds_with_reading
@@ -99,6 +99,6 @@ def test_create_tiecdr_file(tmpdir):
         date=test_date,
         hemisphere=hemisphere,
         resolution=resolution,
-        cdr_data_dir=Path(tmpdir),
+        ecdr_data_dir=Path(tmpdir),
         interp_range=2,
     )

--- a/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
+++ b/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
@@ -14,12 +14,12 @@ from pm_tb_data._types import NORTH
 
 
 from seaice_ecdr.temporal_composite_daily import (
-    get_standard_initial_daily_ecdr_filename,
     read_with_create_initial_daily_ecdr,
     make_tiecdr_netcdf,
 )
 
 from seaice_ecdr.initial_daily_ecdr import (
+    get_idecdr_filepath,
     initial_daily_ecdr_dataset_for_au_si_tbs,
     write_ide_netcdf,
 )
@@ -41,8 +41,11 @@ resolution: Final = "12"
 
 def test_create_ide_file(tmpdir):
     """Verify that initial daily ecdr file can be created."""
-    sample_ide_filepath = get_standard_initial_daily_ecdr_filename(
-        date, hemisphere, resolution, output_directory=Path(tmpdir)
+    sample_ide_filepath = get_idecdr_filepath(
+        date=date,
+        hemisphere=hemisphere,
+        resolution=resolution,
+        cdr_data_dir=Path(tmpdir),
     )
 
     test_ide_ds = initial_daily_ecdr_dataset_for_au_si_tbs(
@@ -58,15 +61,18 @@ def test_create_ide_file(tmpdir):
 
 def test_read_with_create_ide_file(tmpdir):
     """Verify that initial daily ecdr file can be created."""
-    sample_ide_filepath = get_standard_initial_daily_ecdr_filename(
-        date, hemisphere, resolution, output_directory=Path(tmpdir)
+    sample_ide_filepath = get_idecdr_filepath(
+        date=date,
+        hemisphere=hemisphere,
+        resolution=resolution,
+        cdr_data_dir=Path(tmpdir),
     )
 
     test_ide_ds_with_creation = read_with_create_initial_daily_ecdr(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        ide_dir=Path(tmpdir),
+        cdr_data_dir=Path(tmpdir),
     )
 
     assert sample_ide_filepath.exists()
@@ -74,7 +80,7 @@ def test_read_with_create_ide_file(tmpdir):
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        ide_dir=Path(tmpdir),
+        cdr_data_dir=Path(tmpdir),
     )
 
     assert test_ide_ds_with_creation == test_ide_ds_with_reading
@@ -90,18 +96,12 @@ def test_create_tiecdr_file(tmpdir):
     data possible.
     """
     test_date = dt.date(2022, 3, 2)
-    tmpdir_path = Path(tmpdir)
-    initial_daily_dir = tmpdir_path / "initial"
-    initial_daily_dir.mkdir()
-    temporal_daily_dir = tmpdir_path / "temporal"
-    temporal_daily_dir.mkdir()
 
     # For the test, only interpolate up to two days forward/back in time
     make_tiecdr_netcdf(
         date=test_date,
         hemisphere=hemisphere,
         resolution=resolution,
-        output_dir=temporal_daily_dir,
+        cdr_data_dir=Path(tmpdir),
         interp_range=2,
-        ide_dir=initial_daily_dir,
     )

--- a/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
+++ b/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
@@ -30,24 +30,21 @@ def test_cdecdr_date_iter_ends_with_target_date():
     assert latest_date == target_date
 
 
-def test_no_melt_onset_for_southern_hemisphere():
+def test_no_melt_onset_for_southern_hemisphere(tmpdir):
     """Verify that melt onset is all fill value when not in melt season."""
     for date in (dt.date(2020, 2, 1), dt.date(2021, 6, 2), dt.date(2020, 10, 3)):
         melt_onset_field = cdecdr.create_melt_onset_field(
             date=date,
             hemisphere=SOUTH,
             resolution="12",
-            tie_dir=Path("./"),
-            cde_dir=Path("./"),
+            cdr_data_dir=Path(tmpdir),
         )
         assert melt_onset_field is None
 
 
-def test_melt_onset_field_outside_melt_season():
+def test_melt_onset_field_outside_melt_season(tmpdir):
     """Verify that melt onset is all fill value when not in melt season."""
     hemisphere = NORTH
-    tie_dir = Path("./")
-    cde_dir = Path("./")
     no_melt_flag = 255
 
     for date in (dt.date(2020, 2, 1), dt.date(2020, 10, 3)):
@@ -55,8 +52,7 @@ def test_melt_onset_field_outside_melt_season():
             date=date,
             hemisphere=hemisphere,
             resolution="12",
-            tie_dir=tie_dir,
-            cde_dir=cde_dir,
+            cdr_data_dir=Path(tmpdir),
             no_melt_flag=no_melt_flag,
         )
         assert np.all(melt_onset_field == no_melt_flag)

--- a/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
+++ b/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
@@ -15,7 +15,7 @@ def test_no_melt_onset_for_southern_hemisphere(tmpdir):
             date=date,
             hemisphere=SOUTH,
             resolution="12",
-            cdr_data_dir=Path(tmpdir),
+            ecdr_data_dir=Path(tmpdir),
         )
         assert melt_onset_field is None
 
@@ -30,7 +30,7 @@ def test_melt_onset_field_outside_melt_season(tmpdir):
             date=date,
             hemisphere=hemisphere,
             resolution="12",
-            cdr_data_dir=Path(tmpdir),
+            ecdr_data_dir=Path(tmpdir),
             no_melt_flag=no_melt_flag,
         )
         assert np.all(melt_onset_field == no_melt_flag)

--- a/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
+++ b/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
@@ -90,15 +90,15 @@ def test_access_to_standard_output_filename(tmpdir):
     date = dt.date(2021, 2, 19)
     resolution: Final = "12"
 
-    cdr_data_dir = Path(tmpdir)
+    ecdr_data_dir = Path(tmpdir)
     sample_ide_filepath = get_idecdr_filepath(
         date=date,
         hemisphere=NORTH,
         resolution=resolution,
-        cdr_data_dir=cdr_data_dir,
+        ecdr_data_dir=ecdr_data_dir,
     )
     expected_filepath = (
-        get_idecdr_dir(cdr_data_dir=cdr_data_dir) / "idecdr_NH_20210219_ausi_12km.nc"
+        get_idecdr_dir(ecdr_data_dir=ecdr_data_dir) / "idecdr_NH_20210219_ausi_12km.nc"
     )
 
     assert sample_ide_filepath == expected_filepath

--- a/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
+++ b/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
@@ -7,15 +7,16 @@ import numpy as np
 import xarray as xr
 import pandas as pd
 import pytest
+from typing import Final
 
 from loguru import logger
-
+from pm_tb_data._types import NORTH
 
 from seaice_ecdr.temporal_composite_daily import (
     iter_dates_near_date,
-    get_standard_initial_daily_ecdr_filename,
     temporally_composite_dataarray,
 )
+from seaice_ecdr.initial_daily_ecdr import get_idecdr_filepath
 
 
 # Set the default minimum log notification to Warning
@@ -88,14 +89,13 @@ def test_date_iterator():
 def test_access_to_standard_output_filename(tmpdir):
     """Verify that standard output file names can be generated."""
     date = dt.date(2021, 2, 19)
-    hemisphere = "north"
-    resolution = "12"
+    resolution: Final = "12"
 
-    sample_ide_filepath = get_standard_initial_daily_ecdr_filename(
-        date,
-        hemisphere,
-        resolution,
-        output_directory=Path(tmpdir),
+    sample_ide_filepath = get_idecdr_filepath(
+        date=date,
+        hemisphere=NORTH,
+        resolution=resolution,
+        cdr_data_dir=Path(tmpdir),
     )
     expected_filepath = Path(tmpdir) / "idecdr_NH_20210219_ausi_12km.nc"
 

--- a/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
+++ b/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
@@ -16,7 +16,7 @@ from seaice_ecdr.temporal_composite_daily import (
     iter_dates_near_date,
     temporally_composite_dataarray,
 )
-from seaice_ecdr.initial_daily_ecdr import get_idecdr_filepath
+from seaice_ecdr.initial_daily_ecdr import get_idecdr_filepath, get_idecdr_dir
 
 
 # Set the default minimum log notification to Warning
@@ -91,13 +91,16 @@ def test_access_to_standard_output_filename(tmpdir):
     date = dt.date(2021, 2, 19)
     resolution: Final = "12"
 
+    cdr_data_dir = Path(tmpdir)
     sample_ide_filepath = get_idecdr_filepath(
         date=date,
         hemisphere=NORTH,
         resolution=resolution,
-        cdr_data_dir=Path(tmpdir),
+        cdr_data_dir=cdr_data_dir,
     )
-    expected_filepath = Path(tmpdir) / "idecdr_NH_20210219_ausi_12km.nc"
+    expected_filepath = (
+        get_idecdr_dir(cdr_data_dir=cdr_data_dir) / "idecdr_NH_20210219_ausi_12km.nc"
+    )
 
     assert sample_ide_filepath == expected_filepath
 


### PR DESCRIPTION
Refactor handling of output paths into `cdr_data_dir`, which will contain subdirectories with outputs/inputs for various processing stages.

This reduces the amount of 'passing paths around' that needs to happen.