### PR TITLE
Implement standard filenames for CDR V5

### DIFF
--- a/seaice_ecdr/_types.py
+++ b/seaice_ecdr/_types.py
@@ -1,0 +1,3 @@
+from typing import Literal
+
+ECDR_SUPPORTED_RESOLUTIONS = Literal["12.5", "25"]

--- a/seaice_ecdr/compare/visualize.py
+++ b/seaice_ecdr/compare/visualize.py
@@ -7,7 +7,7 @@ visualization code.
 """
 import datetime as dt
 from pathlib import Path
-from typing import get_args
+from typing import cast, get_args
 
 import cartopy.crs as ccrs
 import numpy as np
@@ -23,6 +23,7 @@ from pm_icecon.tests.regression import test_nt
 from pm_tb_data._types import NORTH, SOUTH, Hemisphere
 from pm_tb_data.fetch import au_si
 
+from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.compare.ref_data import get_au_si_bt_conc, get_cdr, get_sea_ice_index
 from seaice_ecdr.initial_daily_ecdr import initial_daily_ecdr_dataset_for_au_si_tbs
 
@@ -421,9 +422,16 @@ def compare_cdr(
 ):
     cdr_ds = get_cdr(date=date, hemisphere=hemisphere, resolution=resolution)
 
+    seaice_ecdr_resolution = {
+        "12": "12.5",
+        "25": "25",
+    }[resolution]
+    seaice_ecdr_resolution = cast(ECDR_SUPPORTED_RESOLUTIONS, seaice_ecdr_resolution)
     our_cdr_ds = _flip(
         initial_daily_ecdr_dataset_for_au_si_tbs(
-            date=date, hemisphere=hemisphere, resolution=resolution
+            date=date,
+            hemisphere=hemisphere,
+            resolution=seaice_ecdr_resolution,
         )
     )
 

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 # This is the version string for the ECDR product.
-ECDR_PRODUCT_VERSION = "v5"
+ECDR_PRODUCT_VERSION = "v05r00"
 
 # NSIDC infrastructure-specific paths:
 NSIDC_NFS_SHARE_DIR = Path("/share/apps/amsr2-cdr")

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -5,12 +5,12 @@ from typing import get_args
 
 import click
 from pm_tb_data._types import Hemisphere
-from pm_tb_data.fetch.au_si import AU_SI_RESOLUTIONS
 from pm_tb_data.fetch.lance_amsr2 import (
     access_local_lance_data,
     download_latest_lance_files,
 )
 
+from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.cli.util import datetime_to_date
 from seaice_ecdr.constants import LANCE_NRT_DATA_DIR, NRT_BASE_OUTPUT_DIR
 from seaice_ecdr.initial_daily_ecdr import (
@@ -24,7 +24,7 @@ def compute_nrt_initial_daily_ecdr_dataset(
     *,
     date: dt.date,
     hemisphere: Hemisphere,
-    resolution: AU_SI_RESOLUTIONS,
+    resolution: ECDR_SUPPORTED_RESOLUTIONS,
     lance_amsr2_input_dir: Path,
 ):
     """Create an initial daily ECDR NetCDF using NRT LANCE AMSR2 data."""
@@ -116,7 +116,7 @@ def download_latest_nrt_data(*, output_dir: Path, overwrite: bool) -> None:
     "-r",
     "--resolution",
     required=True,
-    type=click.Choice(get_args(AU_SI_RESOLUTIONS)),
+    type=click.Choice(get_args(ECDR_SUPPORTED_RESOLUTIONS)),
 )
 @click.option(
     "--lance-amsr2-input-dir",
@@ -138,7 +138,7 @@ def nrt_initial_daily_ecdr(
     date: dt.date,
     hemisphere: Hemisphere,
     ecdr_data_dir: Path,
-    resolution: AU_SI_RESOLUTIONS,
+    resolution: ECDR_SUPPORTED_RESOLUTIONS,
     lance_amsr2_input_dir: Path,
 ):
     """Create an initial daily ECDR NetCDF using NRT LANCE AMSR2 data.

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -557,13 +557,6 @@ def create_tiecdr_for_date_range(
                 file_label="tiecdr",
                 ecdr_data_dir=ecdr_data_dir,
             )
-            err_filename = standard_output_filename(
-                hemisphere=hemisphere,
-                date=date,
-                sat="u2",
-                algorithm="tiecdr",
-                resolution=f"{resolution}km",
-            )
             err_filename = err_filepath.name + ".error"
             logger.info(f"Writing error info to {err_filename}")
             with open(err_filepath.parent / err_filename, "w") as f:

--- a/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
+++ b/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
@@ -29,7 +29,7 @@ def sample_idecdr_dataset_nh():
 
     test_date = dt.datetime(2021, 4, 5).date()
     test_hemisphere = NORTH
-    test_resolution: Final = "12"
+    test_resolution: Final = "12.5"
 
     ide_conc_ds = compute_idecdr_ds(
         date=test_date,
@@ -46,7 +46,7 @@ def sample_idecdr_dataset_sh():
 
     test_date = dt.datetime(2021, 4, 5).date()
     test_hemisphere = NORTH
-    test_resolution: Final = "12"
+    test_resolution: Final = "12.5"
 
     ide_conc_ds = compute_idecdr_ds(
         date=test_date,
@@ -122,7 +122,7 @@ def test_cli_idecdr_ncfile_creation(tmpdir):
     tmpdir_path = Path(tmpdir)
     test_date = dt.datetime(2021, 4, 5).date()
     test_hemisphere = NORTH
-    test_resolution: Final = "12"
+    test_resolution: Final = "12.5"
     make_idecdr_netcdf(
         date=test_date,
         hemisphere=test_hemisphere,
@@ -150,7 +150,7 @@ def test_can_drop_fields_from_idecdr_netcdf(
     tmpdir_path = Path(tmpdir)
     test_date = dt.datetime(2021, 4, 5).date()
     test_hemisphere = NORTH
-    test_resolution: Final = "12"
+    test_resolution: Final = "12.5"
     make_idecdr_netcdf(
         date=test_date,
         hemisphere=test_hemisphere,

--- a/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
+++ b/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
@@ -33,7 +33,7 @@ except ValueError:
 
 date = dt.date(2021, 2, 19)
 hemisphere = NORTH
-resolution: Final = "12"
+resolution: Final = "12.5"
 
 
 def test_create_ide_file(tmpdir):

--- a/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
+++ b/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
@@ -14,7 +14,7 @@ def test_no_melt_onset_for_southern_hemisphere(tmpdir):
         melt_onset_field = cdecdr.create_melt_onset_field(
             date=date,
             hemisphere=SOUTH,
-            resolution="12",
+            resolution="12.5",
             ecdr_data_dir=Path(tmpdir),
         )
         assert melt_onset_field is None
@@ -29,7 +29,7 @@ def test_melt_onset_field_outside_melt_season(tmpdir):
         melt_onset_field = cdecdr.create_melt_onset_field(
             date=date,
             hemisphere=hemisphere,
-            resolution="12",
+            resolution="12.5",
             ecdr_data_dir=Path(tmpdir),
             no_melt_flag=no_melt_flag,
         )

--- a/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
+++ b/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
@@ -12,6 +12,7 @@ import xarray as xr
 from loguru import logger
 from pm_tb_data._types import NORTH
 
+from seaice_ecdr.constants import ECDR_PRODUCT_VERSION
 from seaice_ecdr.initial_daily_ecdr import get_idecdr_dir, get_idecdr_filepath
 from seaice_ecdr.temporal_composite_daily import (
     iter_dates_near_date,
@@ -88,7 +89,7 @@ def test_date_iterator():
 def test_access_to_standard_output_filename(tmpdir):
     """Verify that standard output file names can be generated."""
     date = dt.date(2021, 2, 19)
-    resolution: Final = "12"
+    resolution: Final = "12.5"
 
     ecdr_data_dir = Path(tmpdir)
     sample_ide_filepath = get_idecdr_filepath(
@@ -98,7 +99,8 @@ def test_access_to_standard_output_filename(tmpdir):
         ecdr_data_dir=ecdr_data_dir,
     )
     expected_filepath = (
-        get_idecdr_dir(ecdr_data_dir=ecdr_data_dir) / "idecdr_NH_20210219_ausi_12km.nc"
+        get_idecdr_dir(ecdr_data_dir=ecdr_data_dir)
+        / f"idecdr_sic_psn12.5_20210219_ausi_{ECDR_PRODUCT_VERSION}.nc"
     )
 
     assert sample_ide_filepath == expected_filepath

--- a/seaice_ecdr/tests/unit/test_util.py
+++ b/seaice_ecdr/tests/unit/test_util.py
@@ -25,6 +25,20 @@ def test_daily_filename_south():
     assert actual == expected
 
 
+def test_daily_aggregate_filename():
+    expected = "sic_psn12.5_20210101-20211231_amsr2_v05r00.nc"
+
+    actual = standard_daily_filename(
+        hemisphere=NORTH,
+        resolution="12.5",
+        sat="amsr2",
+        date=dt.date(2021, 1, 1),
+        end_date=dt.date(2021, 12, 31),
+    )
+
+    assert actual == expected
+
+
 def test_monthly_filename_north():
     expected = "sic_psn12.5_202101_amsr2_v05r00.nc"
 

--- a/seaice_ecdr/tests/unit/test_util.py
+++ b/seaice_ecdr/tests/unit/test_util.py
@@ -65,3 +65,19 @@ def test_monthly_filename_south():
     )
 
     assert actual == expected
+
+
+def test_monthly_aggregate_filename():
+    expected = "sic_pss12.5_202101-202112_amsr2_v05r00.nc"
+
+    actual = standard_monthly_filename(
+        hemisphere=SOUTH,
+        resolution="12.5",
+        sat="amsr2",
+        year=2021,
+        month=1,
+        end_year=2021,
+        end_month=12,
+    )
+
+    assert actual == expected

--- a/seaice_ecdr/tests/unit/test_util.py
+++ b/seaice_ecdr/tests/unit/test_util.py
@@ -1,0 +1,25 @@
+import datetime as dt
+
+from pm_tb_data._types import NORTH, SOUTH
+
+from seaice_ecdr.util import standard_daily_filename
+
+
+def test_daily_filename_north():
+    expected = "sic_psn12.5_20210101_amsr2_v05r00.nc"
+
+    actual = standard_daily_filename(
+        hemisphere=NORTH, resolution="12.5", sat="amsr2", date=dt.date(2021, 1, 1)
+    )
+
+    assert actual == expected
+
+
+def test_daily_filename_south():
+    expected = "sic_pss12.5_20210101_amsr2_v05r00.nc"
+
+    actual = standard_daily_filename(
+        hemisphere=SOUTH, resolution="12.5", sat="amsr2", date=dt.date(2021, 1, 1)
+    )
+
+    assert actual == expected

--- a/seaice_ecdr/tests/unit/test_util.py
+++ b/seaice_ecdr/tests/unit/test_util.py
@@ -2,7 +2,7 @@ import datetime as dt
 
 from pm_tb_data._types import NORTH, SOUTH
 
-from seaice_ecdr.util import standard_daily_filename
+from seaice_ecdr.util import standard_daily_filename, standard_monthly_filename
 
 
 def test_daily_filename_north():
@@ -20,6 +20,34 @@ def test_daily_filename_south():
 
     actual = standard_daily_filename(
         hemisphere=SOUTH, resolution="12.5", sat="amsr2", date=dt.date(2021, 1, 1)
+    )
+
+    assert actual == expected
+
+
+def test_monthly_filename_north():
+    expected = "sic_psn12.5_202101_amsr2_v05r00.nc"
+
+    actual = standard_monthly_filename(
+        hemisphere=NORTH,
+        resolution="12.5",
+        sat="amsr2",
+        year=2021,
+        month=1,
+    )
+
+    assert actual == expected
+
+
+def test_monthly_filename_south():
+    expected = "sic_pss12.5_202101_amsr2_v05r00.nc"
+
+    actual = standard_monthly_filename(
+        hemisphere=SOUTH,
+        resolution="12.5",
+        sat="amsr2",
+        year=2021,
+        month=1,
     )
 
     assert actual == expected

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -11,13 +11,25 @@ def standard_daily_filename(
     resolution: str,
     sat: str,
     date: dt.date,
+    end_date: dt.date | None = None,
 ) -> str:
     """Return standard daily NetCDF filename.
 
+    Provides aggregate filename if an `end_date` is given, treating `date` as
+    the start date.
+
     North Daily files: sic_psn12.5_YYYYMMDD_sat_v05r00.nc
     South Daily files: sic_pss12.5_YYYYMMDD_sat_v05r00.nc
+
+    North Daily aggregate files: sic_psn12.5_YYYYMMDD-YYYYMMDD_sat_v05r00.nc
+    South Daily aggregate files: sic_pss12.5_YYYYMMDD-YYYYMMDD_sat_v05r00.nc
     """
-    fn = f"sic_ps{hemisphere[0]}{resolution}_{date:%Y%m%d}_{sat}_{ECDR_PRODUCT_VERSION}.nc"
+    if end_date is not None:
+        date_str = f"{date:%Y%m%d}-{end_date:%Y%m%d}"
+    else:
+        date_str = f"{date:%Y%m%d}"
+
+    fn = f"sic_ps{hemisphere[0]}{resolution}_{date_str}_{sat}_{ECDR_PRODUCT_VERSION}.nc"
 
     return fn
 

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -41,12 +41,25 @@ def standard_monthly_filename(
     sat: str,
     year: int,
     month: int,
+    end_year: int | None = None,
+    end_month: int | None = None,
 ) -> str:
     """Return standard monthly NetCDF filename.
 
+    Provides aggregate filename if an `end_year` and `end_month` are given,
+    treating `year` and `month` as the start year and month.
+
     North Monthly files: sic_psn12.5_YYYYMM_sat_v05r00.nc
     South Monthly files: sic_pss12.5_YYYYMM_sat_v05r00.nc
+
+    North Monthly aggregate files: sic_psn12.5_YYYYMM-YYYYMM_sat_v05r00.nc
+    South Monthly aggregate files: sic_pss12.5_YYYYMM-YYYYMM_sat_v05r00.nc
     """
-    fn = f"sic_ps{hemisphere[0]}{resolution}_{year}{month:02}_{sat}_{ECDR_PRODUCT_VERSION}.nc"
+    if end_year is not None and end_month is not None:
+        date_str = f"{year}{month:02}-{end_year}{end_month:02}"
+    else:
+        date_str = f"{year}{month:02}"
+
+    fn = f"sic_ps{hemisphere[0]}{resolution}_{date_str}_{sat}_{ECDR_PRODUCT_VERSION}.nc"
 
     return fn

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -1,0 +1,18 @@
+import datetime as dt
+
+from pm_tb_data._types import Hemisphere
+
+from seaice_ecdr.constants import ECDR_PRODUCT_VERSION
+
+
+def standard_daily_filename(
+    *, hemisphere: Hemisphere, resolution: str, sat: str, date: dt.date
+) -> str:
+    """Return standard daily NetCDF filename.
+
+    North Daily files: sic_psn12.5_YYYYMMDD_sat_v05r00.nc
+    South Daily files: sic_pss12.5_YYYYMMDD_sat_v05r00.nc
+    """
+    fn = f"sic_ps{hemisphere[0]}{resolution}_{date:%Y%m%d}_{sat}_{ECDR_PRODUCT_VERSION}.nc"
+
+    return fn

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -6,7 +6,11 @@ from seaice_ecdr.constants import ECDR_PRODUCT_VERSION
 
 
 def standard_daily_filename(
-    *, hemisphere: Hemisphere, resolution: str, sat: str, date: dt.date
+    *,
+    hemisphere: Hemisphere,
+    resolution: str,
+    sat: str,
+    date: dt.date,
 ) -> str:
     """Return standard daily NetCDF filename.
 
@@ -14,5 +18,23 @@ def standard_daily_filename(
     South Daily files: sic_pss12.5_YYYYMMDD_sat_v05r00.nc
     """
     fn = f"sic_ps{hemisphere[0]}{resolution}_{date:%Y%m%d}_{sat}_{ECDR_PRODUCT_VERSION}.nc"
+
+    return fn
+
+
+def standard_monthly_filename(
+    *,
+    hemisphere: Hemisphere,
+    resolution: str,
+    sat: str,
+    year: int,
+    month: int,
+) -> str:
+    """Return standard monthly NetCDF filename.
+
+    North Monthly files: sic_psn12.5_YYYYMM_sat_v05r00.nc
+    South Monthly files: sic_pss12.5_YYYYMM_sat_v05r00.nc
+    """
+    fn = f"sic_ps{hemisphere[0]}{resolution}_{year}{month:02}_{sat}_{ECDR_PRODUCT_VERSION}.nc"
 
     return fn


### PR DESCRIPTION
Adds functions for generating daily and monthly standard filenames.

Utilizes these functions when creating various intermediate outputs.

E.g.,
```
$ ./scripts/cli.sh  cdecdr --date 2022-03-02 --hemisphere north --resolution 12.5
<output clipped for brevity>
$ tree /share/apps/amsr2-cdr/ecdr_v05r00_outputs/
/share/apps/amsr2-cdr/ecdr_v05r00_outputs/
└── standard
    ├── complete_daily
    │   ├── cdecdr_sic_psn12.5km_20220301_ausi_v05r00.nc
    │   └── cdecdr_sic_psn12.5km_20220302_ausi_v05r00.nc
    ├── initial_daily
    │   ├── idecdr_sic_psn12.5_20220224_ausi_v05r00.nc
    │   ├── idecdr_sic_psn12.5_20220225_ausi_v05r00.nc
    │   ├── idecdr_sic_psn12.5_20220226_ausi_v05r00.nc
    │   ├── idecdr_sic_psn12.5_20220227_ausi_v05r00.nc
    │   ├── idecdr_sic_psn12.5_20220228_ausi_v05r00.nc
    │   ├── idecdr_sic_psn12.5_20220301_ausi_v05r00.nc
    │   ├── idecdr_sic_psn12.5_20220302_ausi_v05r00.nc
    │   ├── idecdr_sic_psn12.5_20220303_ausi_v05r00.nc
    │   ├── idecdr_sic_psn12.5_20220304_ausi_v05r00.nc
    │   ├── idecdr_sic_psn12.5_20220305_ausi_v05r00.nc
    │   ├── idecdr_sic_psn12.5_20220306_ausi_v05r00.nc
    │   └── idecdr_sic_psn12.5_20220307_ausi_v05r00.nc
    └── temporal_interp
        ├── tiecdr_sic_psn12.5_20220301_ausi_v05r00.nc
        └── tiecdr_sic_psn12.5_20220302_ausi_v05r00.nc

4 directories, 16 files
```