### PR TITLE
Standardize supported satellite strs

### DIFF
--- a/seaice_ecdr/_types.py
+++ b/seaice_ecdr/_types.py
@@ -1,3 +1,15 @@
 from typing import Literal
 
+# In kilometers.
 ECDR_SUPPORTED_RESOLUTIONS = Literal["12.5", "25"]
+
+# Supported sats
+SUPPORTED_SAT = Literal[
+    "am2",  # AMSR2
+    "ame",  # AMSRE
+    "F17",  # SSMIS F17
+    "F13",  # SSMI F13
+    "F11",  # SSMI F11
+    "F08",  # SSMI F08
+    "n07",  # Nimus SMMR
+]

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -51,7 +51,7 @@ def get_ecdr_filepath(
     standard_fn = standard_daily_filename(
         hemisphere=hemisphere,
         date=date,
-        sat="ausi",
+        sat="am2",
         resolution=resolution,
     )
     ecdr_filename = "cdecdr_" + standard_fn

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -950,7 +950,7 @@ def get_idecdr_filepath(
     standard_fn = standard_daily_filename(
         hemisphere=hemisphere,
         date=date,
-        sat="ausi",
+        sat="am2",
         resolution=resolution,
     )
     idecdr_fn = "idecdr_" + standard_fn

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -58,7 +58,7 @@ def get_tie_filepath(
     standard_fn = standard_daily_filename(
         hemisphere=hemisphere,
         date=date,
-        sat="ausi",
+        sat="am2",
         resolution=resolution,
     )
     # Add `tiecdr` to the beginning of the standard name to distinguish it as a

--- a/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
+++ b/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
@@ -100,7 +100,7 @@ def test_access_to_standard_output_filename(tmpdir):
     )
     expected_filepath = (
         get_idecdr_dir(ecdr_data_dir=ecdr_data_dir)
-        / f"idecdr_sic_psn12.5_20210219_ausi_{ECDR_PRODUCT_VERSION}.nc"
+        / f"idecdr_sic_psn12.5_20210219_am2_{ECDR_PRODUCT_VERSION}.nc"
     )
 
     assert sample_ide_filepath == expected_filepath

--- a/seaice_ecdr/tests/unit/test_util.py
+++ b/seaice_ecdr/tests/unit/test_util.py
@@ -6,32 +6,32 @@ from seaice_ecdr.util import standard_daily_filename, standard_monthly_filename
 
 
 def test_daily_filename_north():
-    expected = "sic_psn12.5_20210101_amsr2_v05r00.nc"
+    expected = "sic_psn12.5_20210101_am2_v05r00.nc"
 
     actual = standard_daily_filename(
-        hemisphere=NORTH, resolution="12.5", sat="amsr2", date=dt.date(2021, 1, 1)
+        hemisphere=NORTH, resolution="12.5", sat="am2", date=dt.date(2021, 1, 1)
     )
 
     assert actual == expected
 
 
 def test_daily_filename_south():
-    expected = "sic_pss12.5_20210101_amsr2_v05r00.nc"
+    expected = "sic_pss12.5_20210101_am2_v05r00.nc"
 
     actual = standard_daily_filename(
-        hemisphere=SOUTH, resolution="12.5", sat="amsr2", date=dt.date(2021, 1, 1)
+        hemisphere=SOUTH, resolution="12.5", sat="am2", date=dt.date(2021, 1, 1)
     )
 
     assert actual == expected
 
 
 def test_daily_aggregate_filename():
-    expected = "sic_psn12.5_20210101-20211231_amsr2_v05r00.nc"
+    expected = "sic_psn12.5_20210101-20211231_am2_v05r00.nc"
 
     actual = standard_daily_filename(
         hemisphere=NORTH,
         resolution="12.5",
-        sat="amsr2",
+        sat="am2",
         date=dt.date(2021, 1, 1),
         end_date=dt.date(2021, 12, 31),
     )
@@ -40,12 +40,12 @@ def test_daily_aggregate_filename():
 
 
 def test_monthly_filename_north():
-    expected = "sic_psn12.5_202101_amsr2_v05r00.nc"
+    expected = "sic_psn12.5_202101_am2_v05r00.nc"
 
     actual = standard_monthly_filename(
         hemisphere=NORTH,
         resolution="12.5",
-        sat="amsr2",
+        sat="am2",
         year=2021,
         month=1,
     )
@@ -54,12 +54,12 @@ def test_monthly_filename_north():
 
 
 def test_monthly_filename_south():
-    expected = "sic_pss12.5_202101_amsr2_v05r00.nc"
+    expected = "sic_pss12.5_202101_am2_v05r00.nc"
 
     actual = standard_monthly_filename(
         hemisphere=SOUTH,
         resolution="12.5",
-        sat="amsr2",
+        sat="am2",
         year=2021,
         month=1,
     )
@@ -68,12 +68,12 @@ def test_monthly_filename_south():
 
 
 def test_monthly_aggregate_filename():
-    expected = "sic_pss12.5_202101-202112_amsr2_v05r00.nc"
+    expected = "sic_pss12.5_202101-202112_am2_v05r00.nc"
 
     actual = standard_monthly_filename(
         hemisphere=SOUTH,
         resolution="12.5",
-        sat="amsr2",
+        sat="am2",
         year=2021,
         month=1,
         end_year=2021,

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -2,14 +2,15 @@ import datetime as dt
 
 from pm_tb_data._types import Hemisphere
 
+from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS, SUPPORTED_SAT
 from seaice_ecdr.constants import ECDR_PRODUCT_VERSION
 
 
 def standard_daily_filename(
     *,
     hemisphere: Hemisphere,
-    resolution: str,
-    sat: str,
+    resolution: ECDR_SUPPORTED_RESOLUTIONS,
+    sat: SUPPORTED_SAT,
     date: dt.date,
     end_date: dt.date | None = None,
 ) -> str:
@@ -37,8 +38,8 @@ def standard_daily_filename(
 def standard_monthly_filename(
     *,
     hemisphere: Hemisphere,
-    resolution: str,
-    sat: str,
+    resolution: ECDR_SUPPORTED_RESOLUTIONS,
+    sat: SUPPORTED_SAT,
     year: int,
     month: int,
     end_year: int | None = None,


### PR DESCRIPTION
Follow-up PR for #27 that standardizes the strings we use to identify different satellites supported by the ECDR code.