### PR TITLE
Remove scale factor and offset from nc encoding

### DIFF
--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -5,7 +5,6 @@ import copy
 import datetime as dt
 import sys
 import traceback
-from collections import defaultdict
 from functools import cache
 from pathlib import Path
 from typing import Iterable, cast, get_args
@@ -328,26 +327,11 @@ def write_cde_netcdf(
         if excluded_field in cde_ds.variables.keys():
             cde_ds = cde_ds.drop_vars(excluded_field)
 
-    nc_encoding: dict = defaultdict(dict)
+    nc_encoding = {}
     for varname in cde_ds.variables.keys():
         varname = cast(str, varname)
         if varname not in uncompressed_fields:
             nc_encoding[varname] = {"zlib": True}
-
-        # Move scale_factor and add_offset into nc encoding. Without doing this,
-        # the resulting NC file hsa data that, when read, are not scaled
-        # properly (e.g., 255 is 2.55)
-        if "scale_factor" in cde_ds[varname].attrs.keys():
-            logger.info(f"adding scale factor to {varname}")
-            nc_encoding[varname] = {
-                **nc_encoding[varname],
-                "scale_factor": cde_ds[varname].attrs.pop("scale_factor"),
-            }
-        if "add_offset" in cde_ds[varname].attrs.keys():
-            nc_encoding[varname] = {
-                **nc_encoding[varname],
-                "add_offset": cde_ds[varname].attrs.pop("add_offset"),
-            }
 
     cde_ds.to_netcdf(
         output_filepath,


### PR DESCRIPTION
This was accidentally added in the merge of 88a1249 
