### PR TITLE
Add global attrs to monthly files

### DIFF
--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -552,14 +552,7 @@ def make_monthly_ds(
 
     # Set global attributes
     monthly_ds_global_attrs = get_global_attrs(
-        # TODO: These should be the start and then end of the month, not of the data. So,
-        # 0:00:00 of 1st of month, and 23:59:59.9999 (or whatever) or last day of month.
-        time_coverage_start=dt.datetime(
-            daily_ds_for_month.year, daily_ds_for_month.month, 1, 0, 0, 0
-        ),
-        time_coverage_end=dt.datetime(
-            daily_ds_for_month.year, daily_ds_for_month.month, 1, 23, 59, 59
-        ),
+        time=monthly_ds.time,
         temporality="monthly",
         aggregate=False,
         source=", ".join([fp.item().name for fp in daily_ds_for_month.filepaths]),

--- a/seaice_ecdr/nc_attrs.py
+++ b/seaice_ecdr/nc_attrs.py
@@ -1,26 +1,30 @@
 import datetime as dt
 from collections import OrderedDict
-from typing import Any, Literal
+from typing import Any, Final
 
-from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.constants import ECDR_PRODUCT_VERSION
 
 # Datetime string format for date-related attributes.
 DATE_STR_FMT = "%Y-%m-%dT%H:%M:%SZ"
 
 
-# Input data source ID.
-SourceDatasetId = Literal["AU_SI12", "AE_SI12", "NSIDC-0001"]
-
-
 def get_global_attrs(
     *,
     time_coverage_start: dt.datetime,
     time_coverage_end: dt.datetime,
-    resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    # `dataset_id` will be AU_SI12 for AMSR2, AE_SI12 for AMSR-E, and NSIDC-0001 for
+) -> dict[str, Any]:
+    """Return a dictionary containing the global attributes for a standard ECDR NetCDF file.
+
+    Note the `date_created` field is populated with the current UTC datetime. It is
+    assumed the result of this function will be used to set the attributes of an
+    xr.Dataset that will be promptly written to disk as a NetCDF file.
+    """
+
+    # TODO: support different resolutions, dataset_ids, platforms, and sensors!
+    resolution: Final = "12.5"
+    # `source_dataset_id` will be AU_SI12 for AMSR2, AE_SI12 for AMSR-E, and NSIDC-0001 for
     # SSMIS, SSM/I, and SMMR
-    source_dataset_id: SourceDatasetId,
+    source_dataset_id: Final = "AU_SI12"
     # Here’s what the GCMD platform long name should be based on sensor/platform short name:
     # AMRS2: “GCOM-W1 > Global Change Observation Mission 1st-Water”
     # AMRS-E: " Aqua > Earth Observing System, Aqua”
@@ -29,21 +33,14 @@ def get_global_attrs(
     # SSM/I on F11: “DMSP 5D-2/F11 > Defense Meteorological Satellite Program-F11”
     # SSM/I on F8: “DMSP 5D-2/F8 > Defense Meteorological Satellite Program-F8”
     # SMMR: “Nimbus-7”
-    platform: str,
+    platform: Final = "GCOM-W1 > Global Change Observation Mission 1st-Water"
     # Here’s what the GCMD sensor name should be based on sensor short name:
     # AMRS2: “AMSR2 > Advanced Microwave Scanning Radiometer 2”
     # AMRS-E: “AMSR-E > Advanced Microwave Scanning Radiometer-EOS”
     # SSMIS: “SSMIS > Special Sensor Microwave Imager/Sounder”
     # SSM/I: “SSM/I > Special Sensor Microwave/Imager”
     # SMMR: “SMMR > Scanning Multichannel Microwave Radiometer”
-    sensor: str,
-) -> dict[str, Any]:
-    """Return a dictionary containing the global attributes for a standard ECDR NetCDF file.
-
-    Note the `date_created` field is populated with the current UTC datetime. It is
-    assumed the result of this function will be used to set the attributes of an
-    xr.Dataset that will be promptly written to disk as a NetCDF file.
-    """
+    sensor: Final = "AMSR2 > Advanced Microwave Scanning Radiometer 2"
 
     new_global_attrs = OrderedDict(
         # We expect conventions to be the first item in the global attributes.

--- a/seaice_ecdr/nc_attrs.py
+++ b/seaice_ecdr/nc_attrs.py
@@ -87,7 +87,7 @@ def get_global_attrs(
     # `source` attribute. Currently passed through unchanged.
     # For daily files, this will be AU_SI12 for AMSR2,
     # AE_SI12 for AMSR-E, and NSIDC-0001 for SSMIS, SSM/I, and SMMR.
-    # For monthly and aggregate files, `source` is a space-separated string
+    # For monthly and aggregate files, `source` is a comman-space-separated string
     # of source filenames.
     source: str,
 ) -> dict[str, Any]:

--- a/seaice_ecdr/nc_attrs.py
+++ b/seaice_ecdr/nc_attrs.py
@@ -1,0 +1,38 @@
+def get_global_attrs() -> dict[str, str]:
+    new_global_attrs = {
+        "title": (
+            "NOAA-NSIDC Climate Data Record of Passive Microwave"
+            "Sea Ice Concentration Version 5"
+        ),
+        "Conventions": "CF-1.10, ACDD-1.3",
+        "program": "NOAA Climate Data Record Program",
+        "cdr_variable": "cdr_seaice_conc",
+        "software_version_id": "tbd",
+        "metadata_link": "tbd",
+        "product_version": "v05r00",
+        "spatial_resolution": "25km",
+        "standard_name_vocabulary": "CF Standard Name Table (v16, 11 October 2010)",
+        "id": "tbd",
+        "naming_authority": "org.doi.dx",
+        "license": "No constraints on data access or use",
+        "summary": (
+            "<tbd> This data set provides a passive microwave sea ice concentration"
+            "climate data record (CDR)...."
+        ),
+        "keywords": "EARTH SCIENCE > CRYOSPHERE > SEA ICE > SEA ICE CONCENTRATION, Continent > North America > Canada > Hudson Bay, Geographic Region > Arctic, Geographic Region > Polar, Geographic Region > Northern Hemisphere, Ocean > Arctic Ocean, Ocean > Arctic Ocean > Barents Sea, Ocean > Arctic Ocean > Beaufort Sea, Ocean > Arctic Ocean > Chukchi Sea, CONTINENT > NORTH AMERICA > CANADA > HUDSON BAY, Ocean > Atlantic Ocean > North Atlantic Ocean > Davis Straight, OCEAN > ATLANTIC OCEAN > NORTH ATLANTIC OCEAN > GULF OF ST LAWRENCE, Ocean > Atlantic Ocean > North Atlantic Ocean > North Sea, Ocean > Atlantic Ocean > North Atlantic Ocean > Norwegian Sea, OCEAN > ATLANTIC OCEAN > NORTH ATLANTIC OCEAN > SVALBARD AND JAN MAYEN, Ocean > Pacific Ocean, Ocean > Pacific Ocean > North Pacific Ocean > Bering Sea, Ocean > Pacific Ocean > North Pacific Ocean > Sea Of Okhotsk",
+        "keywords_vocabulary": "NASA Global Change Master Directory (GCMD) Keywords, Version 7.0.0",
+        "cdm_data_type": "Grid",
+        "project": "NOAA/NSIDC passive microwave sea ice concentration climate data record",
+        "creator_url": "http://nsidc.org/",
+        "creator_email": "nsidc@nsidc.org",
+        "institution": "NSIDC > National Snow and Ice Data Center",
+        "processing_level": "NOAA Level 3",
+        "contributor_name": "tbd",
+        "contributor_role": "tbd",
+        "acknowledgment": "tbd",
+        "source": "tbd",
+        "platform": "tbd",
+        "sensor": "tbd",
+    }
+
+    return new_global_attrs

--- a/seaice_ecdr/nc_attrs.py
+++ b/seaice_ecdr/nc_attrs.py
@@ -98,7 +98,7 @@ def get_global_attrs(
     xr.Dataset that will be promptly written to disk as a NetCDF file.
     """
 
-    # TODO: support different resolutions, dataset_ids, platforms, and sensors!
+    # TODO: support different resolutions, platforms, and sensors!
     resolution: Final = "12.5"
     # Here’s what the GCMD platform long name should be based on sensor/platform short name:
     # AMRS2: “GCOM-W1 > Global Change Observation Mission 1st-Water”

--- a/seaice_ecdr/nc_attrs.py
+++ b/seaice_ecdr/nc_attrs.py
@@ -1,38 +1,100 @@
-def get_global_attrs() -> dict[str, str]:
-    new_global_attrs = {
-        "title": (
+import datetime as dt
+from collections import OrderedDict
+from typing import Any
+
+from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
+from seaice_ecdr.constants import ECDR_PRODUCT_VERSION
+
+# Datetime string format for date-related attributes.
+DATE_STR_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def get_global_attrs(
+    *,
+    time_coverage_start: dt.datetime,
+    time_coverage_end: dt.datetime,
+    resolution: ECDR_SUPPORTED_RESOLUTIONS,
+    # `dataset_id` will be AU_SI12 for AMSR2, AE_SI12 for AMSR-E, and NSIDC-0001 for
+    # SSMIS, SSM/I, and SMMR
+    dataset_id: str,
+    # Here’s what the GCMD platform long name should be based on sensor/platform short name:
+    # AMRS2: “GCOM-W1 > Global Change Observation Mission 1st-Water”
+    # AMRS-E: " Aqua > Earth Observing System, Aqua”
+    # SSMIS on F17: “DMSP 5D-3/F17 > Defense Meteorological Satellite Program-F17”
+    # SSM/I on F13: “DMSP 5D-2/F13 > Defense Meteorological Satellite Program-F13”
+    # SSM/I on F11: “DMSP 5D-2/F11 > Defense Meteorological Satellite Program-F11”
+    # SSM/I on F8: “DMSP 5D-2/F8 > Defense Meteorological Satellite Program-F8”
+    # SMMR: “Nimbus-7”
+    platform: str,
+    # Here’s what the GCMD sensor name should be based on sensor short name:
+    # AMRS2: “AMSR2 > Advanced Microwave Scanning Radiometer 2”
+    # AMRS-E: “AMSR-E > Advanced Microwave Scanning Radiometer-EOS”
+    # SSMIS: “SSMIS > Special Sensor Microwave Imager/Sounder”
+    # SSM/I: “SSM/I > Special Sensor Microwave/Imager”
+    # SMMR: “SMMR > Scanning Multichannel Microwave Radiometer”
+    sensor: str,
+) -> dict[str, Any]:
+    """Return a dictionary containing the global attributes for a standard ECDR NetCDF file.
+
+    Note the `date_created` field is populated with the current UTC datetime. It is
+    assumed the result of this function will be used to set the attributes of an
+    xr.Dataset that will be promptly written to disk as a NetCDF file.
+    """
+
+    new_global_attrs = OrderedDict(
+        # We expect conventions to be the first item in the global attributes.
+        conventions="CF-1.10, ACDD-1.3",
+        # Use the current UTC time to set the `date_created` attribute.
+        date_created=dt.datetime.utcnow().strftime(DATE_STR_FMT),
+        time_coverage_start=time_coverage_start.strftime(DATE_STR_FMT),
+        time_coverage_end=time_coverage_end.strftime(DATE_STR_FMT),
+        # TODO: time coverage duration & resolution
+        # For individual daily files this is P1D, for an aggregated file this is
+        # P1Y if it’s a full year. It looks like if it’s a partial year in V4 we
+        # do P1Y as well. Should we change that to be PXXD where XX is the
+        # number of days until we get a full year? For the monthly aggregate, v4
+        # doesn’t have this attribute at all. We should have it. It could say
+        # P45Y3M when we have a partial year. Let’s discuss.
+        time_coverage_duration="TODO",
+        # For monthly file this is P1M. For daily, "P1D"
+        time_coverage_resolution="TODO",
+        title=(
             "NOAA-NSIDC Climate Data Record of Passive Microwave"
-            "Sea Ice Concentration Version 5"
+            " Sea Ice Concentration Version 5"
         ),
-        "Conventions": "CF-1.10, ACDD-1.3",
-        "program": "NOAA Climate Data Record Program",
-        "cdr_variable": "cdr_seaice_conc",
-        "software_version_id": "tbd",
-        "metadata_link": "tbd",
-        "product_version": "v05r00",
-        "spatial_resolution": "25km",
-        "standard_name_vocabulary": "CF Standard Name Table (v16, 11 October 2010)",
-        "id": "tbd",
-        "naming_authority": "org.doi.dx",
-        "license": "No constraints on data access or use",
-        "summary": (
-            "<tbd> This data set provides a passive microwave sea ice concentration"
-            "climate data record (CDR)...."
-        ),
-        "keywords": "EARTH SCIENCE > CRYOSPHERE > SEA ICE > SEA ICE CONCENTRATION, Continent > North America > Canada > Hudson Bay, Geographic Region > Arctic, Geographic Region > Polar, Geographic Region > Northern Hemisphere, Ocean > Arctic Ocean, Ocean > Arctic Ocean > Barents Sea, Ocean > Arctic Ocean > Beaufort Sea, Ocean > Arctic Ocean > Chukchi Sea, CONTINENT > NORTH AMERICA > CANADA > HUDSON BAY, Ocean > Atlantic Ocean > North Atlantic Ocean > Davis Straight, OCEAN > ATLANTIC OCEAN > NORTH ATLANTIC OCEAN > GULF OF ST LAWRENCE, Ocean > Atlantic Ocean > North Atlantic Ocean > North Sea, Ocean > Atlantic Ocean > North Atlantic Ocean > Norwegian Sea, OCEAN > ATLANTIC OCEAN > NORTH ATLANTIC OCEAN > SVALBARD AND JAN MAYEN, Ocean > Pacific Ocean, Ocean > Pacific Ocean > North Pacific Ocean > Bering Sea, Ocean > Pacific Ocean > North Pacific Ocean > Sea Of Okhotsk",
-        "keywords_vocabulary": "NASA Global Change Master Directory (GCMD) Keywords, Version 7.0.0",
-        "cdm_data_type": "Grid",
-        "project": "NOAA/NSIDC passive microwave sea ice concentration climate data record",
-        "creator_url": "http://nsidc.org/",
-        "creator_email": "nsidc@nsidc.org",
-        "institution": "NSIDC > National Snow and Ice Data Center",
-        "processing_level": "NOAA Level 3",
-        "contributor_name": "tbd",
-        "contributor_role": "tbd",
-        "acknowledgment": "tbd",
-        "source": "tbd",
-        "platform": "tbd",
-        "sensor": "tbd",
-    }
+        program="NOAA Climate Data Record Program",
+        # TODO: populate!!
+        software_version_id="TODO",
+        metadata_link="https://nsidc.org/data/g02202/versions/5/",
+        product_version=ECDR_PRODUCT_VERSION,
+        spatial_resolution=f"{resolution}km",
+        standard_name_vocabulary="CF Standard Name Table (v83, 17 October 2023)",
+        id="https://doi.org/10.7265/rjzb-pf78",
+        naming_authority="org.doi.dx",
+        license="No constraints on data access or use",
+        summary="This data set provides a passive microwave sea ice concentration climate data record (CDR) based on gridded brightness temperatures from the Advanced Microwave Scanning Radiometer 2 (AMSR2) onboard the GCOM-W1 satellite, the Advanced Microwave Scanning Radiometer for EOS (AMSR-E) onboard the Aqua satellite, the Special Sensor Microwave Imager (SSM/I) and the Special Sensor Microwave Imager/Sounder (SSMIS) that are part of the Defense Meteorological Satellite Program (DMSP) series of passive microwave radiometers, and the Nimbus-7 Scanning Multichannel Microwave Radiometer (SMMR). The sea ice concentration CDR is an estimate of sea ice concentration that is produced by combining concentration estimates from two algorithms developed at the NASA Goddard Space Flight Center (GSFC): the NASA Team algorithm and the Bootstrap algorithm. The individual algorithms are used to process and combine brightness temperature data at NSIDC. This product is designed to provide a consistent time series of sea ice concentrations (the fraction, or percentage, of ocean area covered by sea ice) from November 1978 to the present which spans the coverage of several passive microwave instruments. The data are gridded on the NSIDC polar stereographic grid with 12.5 x 12.5 km grid cells, and are available in NetCDF file format. Each file contains a variable with the CDR concentration values as well as variables that hold the raw NASA Team and Bootstrap processed concentrations for reference; Variables containing standard deviation, quality flags, and projection information are also included.",
+        keywords="EARTH SCIENCE > CRYOSPHERE > SEA ICE > SEA ICE CONCENTRATION, Continent > North America > Canada > Hudson Bay, Geographic Region > Arctic, Geographic Region > Polar, Geographic Region > Northern Hemisphere, Ocean > Arctic Ocean, Ocean > Arctic Ocean > Barents Sea, Ocean > Arctic Ocean > Beaufort Sea, Ocean > Arctic Ocean > Chukchi Sea, CONTINENT > NORTH AMERICA > CANADA > HUDSON BAY, Ocean > Atlantic Ocean > North Atlantic Ocean > Davis Straight, OCEAN > ATLANTIC OCEAN > NORTH ATLANTIC OCEAN > GULF OF ST LAWRENCE, Ocean > Atlantic Ocean > North Atlantic Ocean > North Sea, Ocean > Atlantic Ocean > North Atlantic Ocean > Norwegian Sea, OCEAN > ATLANTIC OCEAN > NORTH ATLANTIC OCEAN > SVALBARD AND JAN MAYEN, Ocean > Pacific Ocean, Ocean > Pacific Ocean > North Pacific Ocean > Bering Sea, Ocean > Pacific Ocean > North Pacific Ocean > Sea Of Okhotsk",
+        keywords_vocabulary="NASA Global Change Master Directory (GCMD) Keywords, Version 17.1",
+        cdm_data_type="Grid",
+        project="NOAA/NSIDC passive microwave sea ice concentration climate data record",
+        creator_url="http://nsidc.org/",
+        creator_email="nsidc@nsidc.org",
+        institution="NSIDC > National Snow and Ice Data Center",
+        processing_level="NOAA Level 3",
+        contributor_name="Walter N. Meier, Florence Fetterer, Ann Windnagel, J. Scott Stewart, Trey Stafford",
+        contributor_role="principal investigator, author, author, software developer, software developer",
+        acknowledgment="This project was supported in part by a grant from the NOAA Climate Data Record Program. The NASA Team and Bootstrap sea ice concentration algorithms were developed by Donald J. Cavalieri, Josefino C. Comiso, Claire L. Parkinson, and others at the NASA Goddard Space Flight Center in Greenbelt, MD.",
+        source=f"Generated from {dataset_id}",
+        platform=platform,
+        sensor=sensor,
+        # TODO: ideally, these would get dynamically set from the input data's
+        # grid definition...
+        geospatial_lat_min=31.35,
+        geospatial_lat_max=90.0,
+        geospatial_lat_units="degrees_north",
+        geospatial_lon_min=-180.0,
+        geospatial_lon_max=180.0,
+        geospatial_lon_units="degrees_east",
+    )
 
     return new_global_attrs

--- a/seaice_ecdr/nc_attrs.py
+++ b/seaice_ecdr/nc_attrs.py
@@ -1,12 +1,16 @@
 import datetime as dt
 from collections import OrderedDict
-from typing import Any
+from typing import Any, Literal
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.constants import ECDR_PRODUCT_VERSION
 
 # Datetime string format for date-related attributes.
 DATE_STR_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+# Input data source ID.
+SourceDatasetId = Literal["AU_SI12", "AE_SI12", "NSIDC-0001"]
 
 
 def get_global_attrs(
@@ -16,7 +20,7 @@ def get_global_attrs(
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     # `dataset_id` will be AU_SI12 for AMSR2, AE_SI12 for AMSR-E, and NSIDC-0001 for
     # SSMIS, SSM/I, and SMMR
-    dataset_id: str,
+    source_dataset_id: SourceDatasetId,
     # Here’s what the GCMD platform long name should be based on sensor/platform short name:
     # AMRS2: “GCOM-W1 > Global Change Observation Mission 1st-Water”
     # AMRS-E: " Aqua > Earth Observing System, Aqua”
@@ -84,7 +88,7 @@ def get_global_attrs(
         contributor_name="Walter N. Meier, Florence Fetterer, Ann Windnagel, J. Scott Stewart, Trey Stafford",
         contributor_role="principal investigator, author, author, software developer, software developer",
         acknowledgment="This project was supported in part by a grant from the NOAA Climate Data Record Program. The NASA Team and Bootstrap sea ice concentration algorithms were developed by Donald J. Cavalieri, Josefino C. Comiso, Claire L. Parkinson, and others at the NASA Goddard Space Flight Center in Greenbelt, MD.",
-        source=f"Generated from {dataset_id}",
+        source=f"Generated from {source_dataset_id}",
         platform=platform,
         sensor=sensor,
         # TODO: ideally, these would get dynamically set from the input data's

--- a/seaice_ecdr/nc_attrs.py
+++ b/seaice_ecdr/nc_attrs.py
@@ -17,7 +17,8 @@ Temporality = Literal["daily", "monthly"]
 def _get_software_version_id():
     """Return string representing this software's version.
 
-    Takes the form <git_repo>@<git_hash>
+    Takes the form <git_repo>@<git_hash>. E.g.,:
+    "git@github.com:nsidc/seaice_ecdr.git@10fdd316452d0d69fbcf4e7915b66c227298b0ec"
     """
     software_git_hash_result = subprocess.run(
         ["git", "rev-parse", "HEAD"], capture_output=True

--- a/seaice_ecdr/nc_attrs.py
+++ b/seaice_ecdr/nc_attrs.py
@@ -132,7 +132,6 @@ def get_global_attrs(
             " Sea Ice Concentration Version 5"
         ),
         program="NOAA Climate Data Record Program",
-        # TODO: populate!!
         software_version_id=_get_software_version_id(),
         metadata_link="https://nsidc.org/data/g02202/versions/5/",
         product_version=ECDR_PRODUCT_VERSION,

--- a/seaice_ecdr/nc_attrs.py
+++ b/seaice_ecdr/nc_attrs.py
@@ -84,6 +84,12 @@ def get_global_attrs(
     temporality: Temporality,
     # Is this an aggregate file, or not?
     aggregate: bool,
+    # `source` attribute. Currently passed through unchanged.
+    # For daily files, this will be AU_SI12 for AMSR2,
+    # AE_SI12 for AMSR-E, and NSIDC-0001 for SSMIS, SSM/I, and SMMR.
+    # For monthly and aggregate files, `source` is a space-separated string
+    # of source filenames.
+    source: str,
 ) -> dict[str, Any]:
     """Return a dictionary containing the global attributes for a standard ECDR NetCDF file.
 
@@ -94,9 +100,6 @@ def get_global_attrs(
 
     # TODO: support different resolutions, dataset_ids, platforms, and sensors!
     resolution: Final = "12.5"
-    # `source_dataset_id` will be AU_SI12 for AMSR2, AE_SI12 for AMSR-E, and NSIDC-0001 for
-    # SSMIS, SSM/I, and SMMR
-    source_dataset_id: Final = "AU_SI12"
     # Here’s what the GCMD platform long name should be based on sensor/platform short name:
     # AMRS2: “GCOM-W1 > Global Change Observation Mission 1st-Water”
     # AMRS-E: " Aqua > Earth Observing System, Aqua”
@@ -152,7 +155,7 @@ def get_global_attrs(
         contributor_name="Walter N. Meier, Florence Fetterer, Ann Windnagel, J. Scott Stewart, Trey Stafford",
         contributor_role="principal investigator, author, author, software developer, software developer",
         acknowledgment="This project was supported in part by a grant from the NOAA Climate Data Record Program. The NASA Team and Bootstrap sea ice concentration algorithms were developed by Donald J. Cavalieri, Josefino C. Comiso, Claire L. Parkinson, and others at the NASA Goddard Space Flight Center in Greenbelt, MD.",
-        source=f"Generated from {source_dataset_id}",
+        source=source,
         platform=platform,
         sensor=sensor,
         # TODO: ideally, these would get dynamically set from the input data's

--- a/seaice_ecdr/set_daily_ncattrs.py
+++ b/seaice_ecdr/set_daily_ncattrs.py
@@ -355,11 +355,6 @@ def finalize_cdecdr_ds(
         time_coverage_end=dt.datetime(
             ds_date.year, ds_date.month, ds_date.day, 23, 59, 59
         ),
-        # TODO: support different resolutions, dataset_ids, platforms, and sensors!
-        resolution="12.5",
-        source_dataset_id="AU_SI12",
-        platform="GCOM-W1 > Global Change Observation Mission 1st-Water",
-        sensor="AMSR2 > Advanced Microwave Scanning Radiometer 2",
     )
     ds.attrs.update(new_global_attrs)
 

--- a/seaice_ecdr/set_daily_ncattrs.py
+++ b/seaice_ecdr/set_daily_ncattrs.py
@@ -1,8 +1,11 @@
 """Set the netCDF variables and attributes for ecdr data files."""
+import datetime as dt
 
 import numpy as np
+import pandas as pd
 import xarray as xr
-from nc_attrs import get_global_attrs
+
+from seaice_ecdr.nc_attrs import get_global_attrs
 
 CDECDR_FIELDS_TO_DROP = [
     "h18_day_si",
@@ -344,7 +347,20 @@ def finalize_cdecdr_ds(
     )
 
     # Finally, address global attributes
-    new_global_attrs = get_global_attrs()
+    ds_date: dt.date = pd.Timestamp(ds_in.time.values[0]).date()
+    new_global_attrs = get_global_attrs(
+        time_coverage_start=dt.datetime(
+            ds_date.year, ds_date.month, ds_date.day, 0, 0, 0
+        ),
+        time_coverage_end=dt.datetime(
+            ds_date.year, ds_date.month, ds_date.day, 23, 59, 59
+        ),
+        # TODO: support different resolutions, dataset_ids, platforms, and sensors!
+        resolution="12.5",
+        dataset_id="AU_SI12",
+        platform="GCOM-W1 > Global Change Observation Mission 1st-Water",
+        sensor="AMSR2 > Advanced Microwave Scanning Radiometer 2",
+    )
     ds.attrs.update(new_global_attrs)
 
     return ds

--- a/seaice_ecdr/set_daily_ncattrs.py
+++ b/seaice_ecdr/set_daily_ncattrs.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import xarray as xr
+from nc_attrs import get_global_attrs
 
 CDECDR_FIELDS_TO_DROP = [
     "h18_day_si",
@@ -25,46 +26,6 @@ CDECDR_FIELDS_TO_RENAME = {
     "temporal_flag": "temporal_interpolation_flag",
     # 'stdev_of_seaice_conc': 'stdev_of_cdr_seaice_conc',  # this should be in tiecdr
 }
-
-
-def get_global_attrs() -> dict[str, str]:
-    new_global_attrs = {
-        "title": (
-            "NOAA-NSIDC Climate Data Record of Passive Microwave"
-            "Sea Ice Concentration Version 5"
-        ),
-        "Conventions": "CF-1.10, ACDD-1.3",
-        "program": "NOAA Climate Data Record Program",
-        "cdr_variable": "cdr_seaice_conc",
-        "software_version_id": "tbd",
-        "metadata_link": "tbd",
-        "product_version": "v05r00",
-        "spatial_resolution": "25km",
-        "standard_name_vocabulary": "CF Standard Name Table (v16, 11 October 2010)",
-        "id": "tbd",
-        "naming_authority": "org.doi.dx",
-        "license": "No constraints on data access or use",
-        "summary": (
-            "<tbd> This data set provides a passive microwave sea ice concentration"
-            "climate data record (CDR)...."
-        ),
-        "keywords": "EARTH SCIENCE > CRYOSPHERE > SEA ICE > SEA ICE CONCENTRATION, Continent > North America > Canada > Hudson Bay, Geographic Region > Arctic, Geographic Region > Polar, Geographic Region > Northern Hemisphere, Ocean > Arctic Ocean, Ocean > Arctic Ocean > Barents Sea, Ocean > Arctic Ocean > Beaufort Sea, Ocean > Arctic Ocean > Chukchi Sea, CONTINENT > NORTH AMERICA > CANADA > HUDSON BAY, Ocean > Atlantic Ocean > North Atlantic Ocean > Davis Straight, OCEAN > ATLANTIC OCEAN > NORTH ATLANTIC OCEAN > GULF OF ST LAWRENCE, Ocean > Atlantic Ocean > North Atlantic Ocean > North Sea, Ocean > Atlantic Ocean > North Atlantic Ocean > Norwegian Sea, OCEAN > ATLANTIC OCEAN > NORTH ATLANTIC OCEAN > SVALBARD AND JAN MAYEN, Ocean > Pacific Ocean, Ocean > Pacific Ocean > North Pacific Ocean > Bering Sea, Ocean > Pacific Ocean > North Pacific Ocean > Sea Of Okhotsk",
-        "keywords_vocabulary": "NASA Global Change Master Directory (GCMD) Keywords, Version 7.0.0",
-        "cdm_data_type": "Grid",
-        "project": "NOAA/NSIDC passive microwave sea ice concentration climate data record",
-        "creator_url": "http://nsidc.org/",
-        "creator_email": "nsidc@nsidc.org",
-        "institution": "NSIDC > National Snow and Ice Data Center",
-        "processing_level": "NOAA Level 3",
-        "contributor_name": "tbd",
-        "contributor_role": "tbd",
-        "acknowledgment": "tbd",
-        "source": "tbd",
-        "platform": "tbd",
-        "sensor": "tbd",
-    }
-
-    return new_global_attrs
 
 
 def finalize_cdecdr_ds(

--- a/seaice_ecdr/set_daily_ncattrs.py
+++ b/seaice_ecdr/set_daily_ncattrs.py
@@ -355,6 +355,8 @@ def finalize_cdecdr_ds(
         time_coverage_end=dt.datetime(
             ds_date.year, ds_date.month, ds_date.day, 23, 59, 59
         ),
+        temporality="daily",
+        aggregate=False,
     )
     ds.attrs.update(new_global_attrs)
 

--- a/seaice_ecdr/set_daily_ncattrs.py
+++ b/seaice_ecdr/set_daily_ncattrs.py
@@ -357,6 +357,9 @@ def finalize_cdecdr_ds(
         ),
         temporality="daily",
         aggregate=False,
+        # TODO: support alternative source datasets. Will be AU_SI12 for AMSR2,
+        # AE_SI12 for AMSR-E, and NSIDC-0001 for SSMIS, SSM/I, and SMMR
+        source="Generated from AU_SI12",
     )
     ds.attrs.update(new_global_attrs)
 

--- a/seaice_ecdr/set_daily_ncattrs.py
+++ b/seaice_ecdr/set_daily_ncattrs.py
@@ -1,8 +1,6 @@
 """Set the netCDF variables and attributes for ecdr data files."""
-import datetime as dt
 
 import numpy as np
-import pandas as pd
 import xarray as xr
 
 from seaice_ecdr.nc_attrs import get_global_attrs
@@ -347,14 +345,8 @@ def finalize_cdecdr_ds(
     )
 
     # Finally, address global attributes
-    ds_date: dt.date = pd.Timestamp(ds_in.time.values[0]).date()
     new_global_attrs = get_global_attrs(
-        time_coverage_start=dt.datetime(
-            ds_date.year, ds_date.month, ds_date.day, 0, 0, 0
-        ),
-        time_coverage_end=dt.datetime(
-            ds_date.year, ds_date.month, ds_date.day, 23, 59, 59
-        ),
+        time=ds.time,
         temporality="daily",
         aggregate=False,
         # TODO: support alternative source datasets. Will be AU_SI12 for AMSR2,

--- a/seaice_ecdr/set_daily_ncattrs.py
+++ b/seaice_ecdr/set_daily_ncattrs.py
@@ -357,7 +357,7 @@ def finalize_cdecdr_ds(
         ),
         # TODO: support different resolutions, dataset_ids, platforms, and sensors!
         resolution="12.5",
-        dataset_id="AU_SI12",
+        source_dataset_id="AU_SI12",
         platform="GCOM-W1 > Global Change Observation Mission 1st-Water",
         sensor="AMSR2 > Advanced Microwave Scanning Radiometer 2",
     )

--- a/seaice_ecdr/tests/unit/test_nc_attrs.py
+++ b/seaice_ecdr/tests/unit/test_nc_attrs.py
@@ -8,7 +8,8 @@ from seaice_ecdr.nc_attrs import (
 )
 
 
-def test__get_time_coverage_attrs():
+def test__get_time_coverage_attrs_daily():
+    # Typical daily complete file
     expected_daily = {
         "time_coverage_start": "2022-03-01T00:00:00Z",
         "time_coverage_end": "2022-03-01T23:59:59Z",
@@ -24,6 +25,9 @@ def test__get_time_coverage_attrs():
     )
     assert expected_daily == actual_daily
 
+
+def test__get_time_coverage_attrs_daily_aggregate():
+    # Daily aggregate for a full year
     expected_daily_aggregate = {
         "time_coverage_start": "2022-01-01T00:00:00Z",
         "time_coverage_end": "2022-12-31T23:59:59Z",
@@ -39,6 +43,9 @@ def test__get_time_coverage_attrs():
     )
     assert expected_daily_aggregate == actual_daily_aggregate
 
+
+def test__get_time_coverage_attrs_daily_aggregate_partial_year():
+    # Daily aggregate for a partial year
     expected_daily_partial_aggregate = {
         "time_coverage_start": "2022-01-01T00:00:00Z",
         "time_coverage_end": "2022-02-01T23:59:59Z",
@@ -54,6 +61,7 @@ def test__get_time_coverage_attrs():
     )
     assert expected_daily_partial_aggregate == actual_daily_partial_aggregate
 
+    # Daily aggregate for a partial year at the beginning of the record
     expected_daily_partial_aggregate_eoy = {
         "time_coverage_start": "1978-10-01T00:00:00Z",
         "time_coverage_end": "1978-12-31T23:59:59Z",
@@ -69,6 +77,9 @@ def test__get_time_coverage_attrs():
     )
     assert expected_daily_partial_aggregate_eoy == actual_daily_partial_aggregate_eoy
 
+
+def test__get_time_coverage_attrs_monthly():
+    # Typical monthly file
     expected_monthly = {
         "time_coverage_start": "2022-03-01T00:00:00Z",
         "time_coverage_end": "2022-03-31T23:59:59Z",
@@ -84,6 +95,9 @@ def test__get_time_coverage_attrs():
     )
     assert expected_monthly == actual_monthly
 
+
+def test__get_time_coverage_attrs_monthly_aggregate():
+    # Monthly aggregate file
     expected_monthly_aggregate = {
         "time_coverage_start": "2022-01-01T00:00:00Z",
         "time_coverage_end": "2022-05-31T23:59:59Z",

--- a/seaice_ecdr/tests/unit/test_nc_attrs.py
+++ b/seaice_ecdr/tests/unit/test_nc_attrs.py
@@ -48,5 +48,7 @@ def test__get_time_coverage_duration_resolution():
 def test__get_software_version_id():
     software_ver_id = _get_software_version_id()
 
+    # The softawre version id should look something like:
+    # git@github.com:nsidc/seaice_ecdr.git@10fdd316452d0d69fbcf4e7915b66c227298b0ec
     assert "github" in software_ver_id
     assert "@" in software_ver_id

--- a/seaice_ecdr/tests/unit/test_nc_attrs.py
+++ b/seaice_ecdr/tests/unit/test_nc_attrs.py
@@ -1,4 +1,7 @@
-from seaice_ecdr.nc_attrs import _get_time_coverage_duration_resolution
+from seaice_ecdr.nc_attrs import (
+    _get_software_version_id,
+    _get_time_coverage_duration_resolution,
+)
 
 
 def test__get_time_coverage_duration_resolution():
@@ -40,3 +43,10 @@ def test__get_time_coverage_duration_resolution():
         aggregate=True,
     )
     assert expected_monthly_aggregate == actual_monthly_aggregate
+
+
+def test__get_software_version_id():
+    software_ver_id = _get_software_version_id()
+
+    assert "github" in software_ver_id
+    assert "@" in software_ver_id

--- a/seaice_ecdr/tests/unit/test_nc_attrs.py
+++ b/seaice_ecdr/tests/unit/test_nc_attrs.py
@@ -1,0 +1,42 @@
+from seaice_ecdr.nc_attrs import _get_time_coverage_duration_resolution
+
+
+def test__get_time_coverage_duration_resolution():
+    expected_daily = {
+        "time_coverage_duration": "P1D",
+        "time_coverage_resolution": "P1D",
+    }
+    actual_daily = _get_time_coverage_duration_resolution(
+        temporality="daily",
+        aggregate=False,
+    )
+    assert expected_daily == actual_daily
+
+    expected_daily_aggregate = {
+        "time_coverage_duration": "P1Y",
+        "time_coverage_resolution": "P1D",
+    }
+    actual_daily_aggregate = _get_time_coverage_duration_resolution(
+        temporality="daily",
+        aggregate=True,
+    )
+    assert expected_daily_aggregate == actual_daily_aggregate
+
+    expected_monthly = {
+        "time_coverage_duration": "P1M",
+        "time_coverage_resolution": "P1M",
+    }
+    actual_monthly = _get_time_coverage_duration_resolution(
+        temporality="monthly",
+        aggregate=False,
+    )
+    assert expected_monthly == actual_monthly
+
+    expected_monthly_aggregate = {
+        "time_coverage_resolution": "P1M",
+    }
+    actual_monthly_aggregate = _get_time_coverage_duration_resolution(
+        temporality="monthly",
+        aggregate=True,
+    )
+    assert expected_monthly_aggregate == actual_monthly_aggregate

--- a/seaice_ecdr/tests/unit/test_nc_attrs.py
+++ b/seaice_ecdr/tests/unit/test_nc_attrs.py
@@ -1,44 +1,99 @@
+import numpy as np
+import pandas as pd
+import xarray as xr
+
 from seaice_ecdr.nc_attrs import (
     _get_software_version_id,
-    _get_time_coverage_duration_resolution,
+    _get_time_coverage_attrs,
 )
 
 
-def test__get_time_coverage_duration_resolution():
+def test__get_time_coverage_attrs():
     expected_daily = {
+        "time_coverage_start": "2022-03-01T00:00:00Z",
+        "time_coverage_end": "2022-03-01T23:59:59Z",
         "time_coverage_duration": "P1D",
         "time_coverage_resolution": "P1D",
     }
-    actual_daily = _get_time_coverage_duration_resolution(
+    actual_daily = _get_time_coverage_attrs(
+        time=xr.DataArray(
+            pd.date_range(start="2022-03-01", end="2022-03-01", freq="D")
+        ),
         temporality="daily",
         aggregate=False,
     )
     assert expected_daily == actual_daily
 
     expected_daily_aggregate = {
+        "time_coverage_start": "2022-01-01T00:00:00Z",
+        "time_coverage_end": "2022-12-31T23:59:59Z",
         "time_coverage_duration": "P1Y",
         "time_coverage_resolution": "P1D",
     }
-    actual_daily_aggregate = _get_time_coverage_duration_resolution(
+    actual_daily_aggregate = _get_time_coverage_attrs(
+        time=xr.DataArray(
+            pd.date_range(start="2022-01-01", end="2022-12-31", freq="D")
+        ),
         temporality="daily",
         aggregate=True,
     )
     assert expected_daily_aggregate == actual_daily_aggregate
 
+    expected_daily_partial_aggregate = {
+        "time_coverage_start": "2022-01-01T00:00:00Z",
+        "time_coverage_end": "2022-02-01T23:59:59Z",
+        "time_coverage_duration": "P32D",
+        "time_coverage_resolution": "P1D",
+    }
+    actual_daily_partial_aggregate = _get_time_coverage_attrs(
+        time=xr.DataArray(
+            pd.date_range(start="2022-01-01", end="2022-02-01", freq="D")
+        ),
+        temporality="daily",
+        aggregate=True,
+    )
+    assert expected_daily_partial_aggregate == actual_daily_partial_aggregate
+
+    expected_daily_partial_aggregate_eoy = {
+        "time_coverage_start": "1978-10-01T00:00:00Z",
+        "time_coverage_end": "1978-12-31T23:59:59Z",
+        "time_coverage_duration": "P92D",
+        "time_coverage_resolution": "P1D",
+    }
+    actual_daily_partial_aggregate_eoy = _get_time_coverage_attrs(
+        time=xr.DataArray(
+            pd.date_range(start="1978-10-01", end="1978-12-31", freq="D")
+        ),
+        temporality="daily",
+        aggregate=True,
+    )
+    assert expected_daily_partial_aggregate_eoy == actual_daily_partial_aggregate_eoy
+
     expected_monthly = {
+        "time_coverage_start": "2022-03-01T00:00:00Z",
+        "time_coverage_end": "2022-03-31T23:59:59Z",
         "time_coverage_duration": "P1M",
         "time_coverage_resolution": "P1M",
     }
-    actual_monthly = _get_time_coverage_duration_resolution(
+    actual_monthly = _get_time_coverage_attrs(
+        time=xr.DataArray(
+            pd.date_range(start="2022-03-01", end="2022-03-01", freq="D")
+        ),
         temporality="monthly",
         aggregate=False,
     )
     assert expected_monthly == actual_monthly
 
     expected_monthly_aggregate = {
+        "time_coverage_start": "2022-01-01T00:00:00Z",
+        "time_coverage_end": "2022-05-31T23:59:59Z",
+        "time_coverage_duration": "P5M",
         "time_coverage_resolution": "P1M",
     }
-    actual_monthly_aggregate = _get_time_coverage_duration_resolution(
+    actual_monthly_aggregate = _get_time_coverage_attrs(
+        time=xr.DataArray(
+            [np.datetime64(f"2022-{month:02}-01") for month in range(1, 5 + 1)]
+        ),
         temporality="monthly",
         aggregate=True,
     )


### PR DESCRIPTION
This PR adds a function to create a dictionary of standard global attributes for daily and monthly netcdf files. Although we aren't producing aggregate files yet, this code has support for those too.

Still some TODOs here (e.g., to support different source datasets/platforms).
