### PR TITLE
Add unit tests to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,4 +50,4 @@ jobs:
 
       # Unit tests
       - name: "Run typecheck and tests"
-        run: "PYTHONPATH=/home/runner/work/seaice_ecdr/seaice_ecdr/pm_icecon/:/home/runner/work/seaice_ecdr/seaice_ecdr/pm_tb_data/ invoke test.ci"
+        run: "PYTHONPATH=/home/runner/work/seaice_ecdr/seaice_ecdr/seaice_ecdr/:/home/runner/work/seaice_ecdr/seaice_ecdr/pm_icecon/:/home/runner/work/seaice_ecdr/seaice_ecdr/pm_tb_data/ invoke test.ci"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,4 +50,4 @@ jobs:
 
       # Unit tests
       - name: "Run typecheck and tests"
-        run: "PYTHONPATH=/home/runner/work/seaice_ecdr/seaice_ecdr/seaice_ecdr/:/home/runner/work/seaice_ecdr/seaice_ecdr/pm_icecon/:/home/runner/work/seaice_ecdr/seaice_ecdr/pm_tb_data/ invoke test.ci"
+        run: "PYTHONPATH=/home/runner/work/seaice_ecdr/seaice_ecdr/:/home/runner/work/seaice_ecdr/seaice_ecdr/pm_icecon/:/home/runner/work/seaice_ecdr/seaice_ecdr/pm_tb_data/ invoke test.ci"

--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -296,7 +296,6 @@ def calc_qa_of_cdr_seaice_conc_monthly(
     )
 
     qa_of_cdr_seaice_conc_monthly.encoding = dict(
-        _FillValue=0,
         dtype=np.uint8,
         zlib=True,
     )

--- a/seaice_ecdr/tests/unit/test_monthly.py
+++ b/seaice_ecdr/tests/unit/test_monthly.py
@@ -292,7 +292,7 @@ def test_calc_qa_of_cdr_seaice_conc_monthly():
             + QA_OF_CDR_SEAICE_CONC_MONTHLY_BITMASKS[
                 "average_concentration_exceeds_0.30"
             ],
-            255,
+            0,
         ]
     )
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -16,6 +16,15 @@ def typecheck(ctx):
 
 
 @task()
+def unit(ctx):
+    """Run unit tests."""
+    print_and_run(
+        f"pytest -s {PROJECT_DIR}/seaice_ecdr/tests/unit",
+        pty=True,
+    )
+
+
+@task()
 def integration(ctx):
     """Run integration tests."""
     print_and_run(
@@ -48,6 +57,7 @@ def pytest(ctx):
 @task(
     pre=[
         typecheck,
+        unit,
     ],
 )
 def ci(ctx):


### PR DESCRIPTION
CI now runs unit tests. This PR also resolves two tests that were failing.

The first was related to the fill value for monthly QA fields. I went ahead and removed the `_FillValue` attribute per @sc0tts post on slack. Cells where no QA conditions are met now have a value of 0 instead of `np.nan`.

The other test was a holdover from using 255 as a flag value in the QA field. Fixed by replacing that value with the new value of 0.