### PR TITLE
aggregate global attrs: sensor and platform based on contributing sat(s)

### DIFF
--- a/seaice_ecdr/_types.py
+++ b/seaice_ecdr/_types.py
@@ -11,5 +11,5 @@ SUPPORTED_SAT = Literal[
     "F13",  # SSMI F13
     "F11",  # SSMI F11
     "F08",  # SSMI F08
-    "n07",  # Nimus SMMR
+    "n07",  # Nimbus-7 SMMR
 ]

--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -15,7 +15,7 @@ from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.complete_daily_ecdr import get_ecdr_filepath
 from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
 from seaice_ecdr.nc_attrs import get_global_attrs
-from seaice_ecdr.util import standard_daily_aggregate_filename
+from seaice_ecdr.util import sat_from_filename, standard_daily_aggregate_filename
 
 
 # TODO: very similar to `monthly._get_daily_complete_filepaths_for_month`. DRY
@@ -83,6 +83,7 @@ def get_daily_ds_for_year(
         temporality="daily",
         aggregate=True,
         source=", ".join([fp.name for fp in daily_filepaths]),
+        sats=[sat_from_filename(fp.name) for fp in daily_filepaths],
     )
     ds.attrs.update(daily_aggregate_ds_global_attrs)
 

--- a/seaice_ecdr/monthly_aggregate.py
+++ b/seaice_ecdr/monthly_aggregate.py
@@ -13,7 +13,7 @@ from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
 from seaice_ecdr.monthly import get_monthly_dir
 from seaice_ecdr.nc_attrs import get_global_attrs
-from seaice_ecdr.util import standard_monthly_aggregate_filename
+from seaice_ecdr.util import sat_from_filename, standard_monthly_aggregate_filename
 
 
 def _get_monthly_complete_filepaths(
@@ -65,6 +65,7 @@ def get_monthly_aggregate_ds(
         temporality="monthly",
         aggregate=True,
         source=", ".join([fp.name for fp in monthly_filepaths]),
+        sats=[sat_from_filename(fp.name) for fp in monthly_filepaths],
     )
     agg_ds.attrs.update(monthly_aggregate_ds_global_attrs)
 

--- a/seaice_ecdr/nc_attrs.py
+++ b/seaice_ecdr/nc_attrs.py
@@ -135,16 +135,51 @@ PLATFORMS_FOR_SATS: dict[SUPPORTED_SAT, str] = dict(
 )
 
 
+def _unique_sats(sats: list[SUPPORTED_SAT]) -> list[SUPPORTED_SAT]:
+    """Return the unique set of satellites.
+
+    Order is preserved.
+    """
+    # `set` is unordered. This gets the unique list of `sats`.
+    unique_sats = list(dict.fromkeys(sats))
+
+    return unique_sats
+
+
 def get_platforms_for_sats(sats: list[SUPPORTED_SAT]) -> list[str]:
     """Get the unique set of platforms for the given list of sats.
 
     Assumes `sats` is ordered from oldest->newest.
     """
     # `set` is unordered. This gets the unique list of `sats`.
-    unique_sats = list(dict.fromkeys(sats))
+    unique_sats = _unique_sats(sats)
     platforms_for_sat = [PLATFORMS_FOR_SATS[sat] for sat in unique_sats]
 
     return platforms_for_sat
+
+
+# Here’s what the GCMD sensor name should be based on sensor short name:
+SENSORS_FOR_SATS: dict[SUPPORTED_SAT, str] = dict(
+    am2="AMSR2 > Advanced Microwave Scanning Radiometer 2",
+    ame="AMSR-E > Advanced Microwave Scanning Radiometer-EOS",
+    F17="SSMIS > Special Sensor Microwave Imager/Sounder",
+    # TODO: de-dup SSM/I text?
+    F13="SSM/I > Special Sensor Microwave/Imager",
+    F11="SSM/I > Special Sensor Microwave/Imager",
+    F08="SSM/I > Special Sensor Microwave/Imager",
+    n07="SMMR > Scanning Multichannel Microwave Radiometer",
+)
+
+
+def get_sensors_for_sats(sats: list[SUPPORTED_SAT]) -> list[str]:
+    """Get the unique set of sensors for the given list of sats.
+
+    Assumes `sats` is ordered from oldest->newest.
+    """
+    unique_sats = _unique_sats(sats)
+    sensors_for_sat = [SENSORS_FOR_SATS[sat] for sat in unique_sats]
+
+    return sensors_for_sat
 
 
 def get_global_attrs(
@@ -173,13 +208,7 @@ def get_global_attrs(
     # TODO: support different resolutions, platforms, and sensors!
     resolution: Final = "12.5"
     platform = ", ".join(get_platforms_for_sats(sats))
-    # Here’s what the GCMD sensor name should be based on sensor short name:
-    # AMRS2: “AMSR2 > Advanced Microwave Scanning Radiometer 2”
-    # AMRS-E: “AMSR-E > Advanced Microwave Scanning Radiometer-EOS”
-    # SSMIS: “SSMIS > Special Sensor Microwave Imager/Sounder”
-    # SSM/I: “SSM/I > Special Sensor Microwave/Imager”
-    # SMMR: “SMMR > Scanning Multichannel Microwave Radiometer”
-    sensor: Final = "AMSR2 > Advanced Microwave Scanning Radiometer 2"
+    sensor = ", ".join(get_sensors_for_sats(sats))
 
     time_coverage_attrs = _get_time_coverage_attrs(
         temporality=temporality,

--- a/seaice_ecdr/nc_attrs.py
+++ b/seaice_ecdr/nc_attrs.py
@@ -124,13 +124,6 @@ def _get_time_coverage_attrs(
 
 
 # Here’s what the GCMD platform long name should be based on sensor/platform short name:
-# AMRS2: “GCOM-W1 > Global Change Observation Mission 1st-Water”
-# AMRS-E: " Aqua > Earth Observing System, Aqua”
-# SSMIS on F17: “DMSP 5D-3/F17 > Defense Meteorological Satellite Program-F17”
-# SSM/I on F13: “DMSP 5D-2/F13 > Defense Meteorological Satellite Program-F13”
-# SSM/I on F11: “DMSP 5D-2/F11 > Defense Meteorological Satellite Program-F11”
-# SSM/I on F8: “DMSP 5D-2/F8 > Defense Meteorological Satellite Program-F8”
-# SMMR: “Nimbus-7”
 PLATFORMS_FOR_SATS: dict[SUPPORTED_SAT, str] = dict(
     am2="GCOM-W1 > Global Change Observation Mission 1st-Water",
     ame="Aqua > Earth Observing System, Aqua",

--- a/seaice_ecdr/set_daily_ncattrs.py
+++ b/seaice_ecdr/set_daily_ncattrs.py
@@ -327,6 +327,8 @@ def finalize_cdecdr_ds(
         # TODO: support alternative source datasets. Will be AU_SI12 for AMSR2,
         # AE_SI12 for AMSR-E, and NSIDC-0001 for SSMIS, SSM/I, and SMMR
         source="Generated from AU_SI12",
+        # TODO: set sat from source
+        sats=["am2"],
     )
     ds.attrs.update(new_global_attrs)
 

--- a/seaice_ecdr/tests/unit/test_monthly.py
+++ b/seaice_ecdr/tests/unit/test_monthly.py
@@ -479,8 +479,8 @@ def test_monthly_ds(monkeypatch, tmpdir):
 def test__sat_for_month():
     assert "am2" == _sat_for_month(sats=["am2", "am2", "am2", "am2"])
 
-    assert "am2" == _sat_for_month(sats=["f17", "f17", "am2", "am2"])
+    assert "am2" == _sat_for_month(sats=["F17", "F17", "am2", "am2"])
 
-    assert "f17" == _sat_for_month(sats=["f16", "f16", "f16", "f17"])
+    assert "F17" == _sat_for_month(sats=["F13", "F13", "F13", "F17"])
 
-    assert "am2" == _sat_for_month(sats=["f16", "f17", "am2"])
+    assert "am2" == _sat_for_month(sats=["F13", "F17", "am2"])

--- a/seaice_ecdr/tests/unit/test_nc_attrs.py
+++ b/seaice_ecdr/tests/unit/test_nc_attrs.py
@@ -5,6 +5,7 @@ import xarray as xr
 from seaice_ecdr.nc_attrs import (
     _get_software_version_id,
     _get_time_coverage_attrs,
+    get_platforms_for_sats,
 )
 
 
@@ -121,3 +122,24 @@ def test__get_software_version_id():
     # git@github.com:nsidc/seaice_ecdr.git@10fdd316452d0d69fbcf4e7915b66c227298b0ec
     assert "github" in software_ver_id
     assert "@" in software_ver_id
+
+
+def test_get_platforms_for_sat():
+    expected = [
+        "DMSP 5D-2/F13 > Defense Meteorological Satellite Program-F13",
+        "DMSP 5D-3/F17 > Defense Meteorological Satellite Program-F17",
+        "GCOM-W1 > Global Change Observation Mission 1st-Water",
+    ]
+
+    actual = get_platforms_for_sats(
+        [
+            "F13",
+            "F17",
+            "F17",
+            "am2",
+            "am2",
+            "am2",
+        ]
+    )
+
+    assert expected == actual

--- a/seaice_ecdr/tests/unit/test_nc_attrs.py
+++ b/seaice_ecdr/tests/unit/test_nc_attrs.py
@@ -6,6 +6,7 @@ from seaice_ecdr.nc_attrs import (
     _get_software_version_id,
     _get_time_coverage_attrs,
     get_platforms_for_sats,
+    get_sensors_for_sats,
 )
 
 
@@ -132,6 +133,27 @@ def test_get_platforms_for_sat():
     ]
 
     actual = get_platforms_for_sats(
+        [
+            "F13",
+            "F17",
+            "F17",
+            "am2",
+            "am2",
+            "am2",
+        ]
+    )
+
+    assert expected == actual
+
+
+def test_get_sensors_for_sats():
+    expected = [
+        "SSM/I > Special Sensor Microwave/Imager",
+        "SSMIS > Special Sensor Microwave Imager/Sounder",
+        "AMSR2 > Advanced Microwave Scanning Radiometer 2",
+    ]
+
+    actual = get_sensors_for_sats(
         [
             "F13",
             "F17",

--- a/seaice_ecdr/tests/unit/test_util.py
+++ b/seaice_ecdr/tests/unit/test_util.py
@@ -1,8 +1,10 @@
 import datetime as dt
+from typing import Final
 
 from pm_tb_data._types import NORTH, SOUTH
 
 from seaice_ecdr.util import (
+    sat_from_filename,
     standard_daily_aggregate_filename,
     standard_daily_filename,
     standard_monthly_aggregate_filename,
@@ -84,3 +86,29 @@ def test_monthly_aggregate_filename():
     )
 
     assert actual == expected
+
+
+def test_daily_sat_from_filename():
+    expected_sat: Final = "am2"
+    fn = standard_daily_filename(
+        hemisphere=NORTH, resolution="12.5", sat=expected_sat, date=dt.date(2021, 1, 1)
+    )
+
+    actual_sat = sat_from_filename(fn)
+
+    assert expected_sat == actual_sat
+
+
+def test_monthly_sat_from_filename():
+    expected_sat: Final = "F17"
+    fn = standard_monthly_filename(
+        hemisphere=SOUTH,
+        resolution="12.5",
+        sat=expected_sat,
+        year=2021,
+        month=1,
+    )
+
+    actual_sat = sat_from_filename(fn)
+
+    assert expected_sat == actual_sat

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -1,4 +1,6 @@
 import datetime as dt
+import re
+from typing import cast, get_args
 
 from pm_tb_data._types import Hemisphere
 
@@ -77,3 +79,22 @@ def standard_monthly_aggregate_filename(
     fn = f"sic_ps{hemisphere[0]}{resolution}_{date_str}_{ECDR_PRODUCT_VERSION}.nc"
 
     return fn
+
+
+# This regex works for both daily and monthly filenames.
+STANDARD_FN_REGEX = re.compile(r"sic_ps.*_.*_(?P<sat>.*)_.*.nc")
+
+
+def sat_from_filename(filename: str) -> SUPPORTED_SAT:
+    match = STANDARD_FN_REGEX.match(filename)
+
+    if not match:
+        raise RuntimeError(f"Failed to parse satellite from {filename}")
+
+    sat = match.group("sat")
+
+    # Ensure the sat is expected.
+    assert sat in get_args(SUPPORTED_SAT)
+    sat = cast(SUPPORTED_SAT, sat)
+
+    return sat


### PR DESCRIPTION
Aggregate netcdf files indicate all of the sensors and platforms contributing to the file based on the soruce filenames.

This works, but we might want to consider extracting this information from individual files' sensor and platform global attrs, instead of parsing the filenames. 