### PR TITLE
Use grid id module

### DIFF
--- a/scripts/surface_geo_masks/create_surface_geo_mask.py
+++ b/scripts/surface_geo_masks/create_surface_geo_mask.py
@@ -25,8 +25,8 @@ GEO_INFO_FILE = {
     "pss12.5": "/projects/DATASETS/nsidc0771_polarstereo_anc_grid_info/NSIDC0771_LatLon_PS_S12.5km_v1.0.nc",
 }
 SURFGEOMASK_FILE = {
-    "psn12.5": get_surfacegeomask_filepath("psn12.5.nc"),
-    "pss12.5": get_surfacegeomask_filepath("pss12.5.nc"),
+    "psn12.5": get_surfacegeomask_filepath("psn12.5"),
+    "pss12.5": get_surfacegeomask_filepath("pss12.5"),
 }
 
 SURFTYPE_BIN_FILE = {
@@ -34,14 +34,14 @@ SURFTYPE_BIN_FILE = {
     "pss12.5": "/share/apps/amsr2-cdr/cdrv5_ancillary/landmask_pss12.5.dat",
 }
 
-# Note: SENSOR_LIST includes non-0051, eg amsr2
+# Note: SENSOR_LIST includes non-0051, eg am2
 SENSOR_LIST = [
     "smmr",
     "f08",
     "f11",
     "f13",
     "f17",
-    "amsr2",
+    "am2",
 ]
 
 NSIDC0051_SOURCES = ("smmr", "f08", "f11", "f13", "f17")
@@ -66,8 +66,8 @@ def have_polehole_inputs(input_type):
     """Verify that the expected input files exist."""
     if input_type in NSIDC0051_SOURCES:
         return os.path.isfile(SAMPLE_0051_DAILY_NH_NCFN[input_type])
-    elif input_type == "amsr2":
-        # This is the function for the AMSR2 mask
+    elif input_type == "am2":
+        # This is the function for the AM2 mask
         return psn_125_near_pole_hole_mask is not None
 
     raise RuntimeWarning(f"could not check polehole input for: {input_type}")
@@ -113,7 +113,7 @@ def get_geoarray_coord(gridid, coord_name):
 
 def get_polehole_mask(gridid, sensor):
     """Return the polemask for this sensor."""
-    if sensor == "amsr2":
+    if sensor == "am2":
         polemask_data = psn_125_near_pole_hole_mask()
     elif sensor in NSIDC0051_SOURCES:
         ds0051 = xr.load_dataset(

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -268,7 +268,11 @@ def complete_daily_ecdr_dataset_for_au_si_tbs(
     )
 
     # Add the surface-type field
-    cde_ds["surface_type"] = get_surfacetype_da(date, hemisphere, resolution)
+    cde_ds["surface_type"] = get_surfacetype_da(
+        date=date,
+        hemisphere=hemisphere,
+        resolution=resolution,
+    )
 
     # TODO: Need to ensure that the cdr_seaice_conc field does not have values
     #       where seaice cannot occur, eg over land or lakes

--- a/seaice_ecdr/grid_id.py
+++ b/seaice_ecdr/grid_id.py
@@ -1,0 +1,19 @@
+from typing import Literal, cast, get_args
+
+from pm_tb_data._types import Hemisphere
+
+from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
+
+GRID_ID = Literal["psn12.5", "pss12.5"]
+
+
+def get_grid_id(
+    *, hemisphere: Hemisphere, resolution: ECDR_SUPPORTED_RESOLUTIONS
+) -> GRID_ID:
+    grid_id = f"ps{hemisphere[0]}{resolution}"
+    if grid_id not in get_args(GRID_ID):
+        raise RuntimeError(f"Could not determine grid for {hemisphere=} {resolution=}")
+
+    grid_id = cast(GRID_ID, grid_id)
+
+    return grid_id

--- a/seaice_ecdr/gridid_to_xr_dataarray.py
+++ b/seaice_ecdr/gridid_to_xr_dataarray.py
@@ -1,9 +1,9 @@
-"""Generate xarray data set from a gridid.
+"""Generate xarray data set from a grid_id.
 
-gridid_to_xr_dataset
+grid_id_to_xr_dataset
 
 Return an xarray dataset with appropriate geolocation variables for
-a given NSIDC gridid
+a given NSIDC grid_id
 """
 
 
@@ -14,8 +14,10 @@ import numpy as np
 import xarray as xr
 from loguru import logger
 
+from seaice_ecdr.grid_id import GRID_ID
 
-def get_dataset_for_gridid(gridid, grid_date, return_dataset=True):
+
+def get_dataset_for_grid_id(grid_id: GRID_ID, grid_date, return_dataset=True):
     """Return xarray dataset.
 
     with appropriate geolocation dataarrays:
@@ -27,7 +29,7 @@ def get_dataset_for_gridid(gridid, grid_date, return_dataset=True):
     Because none of these need compression, no 'encoding' dictionary is
     returned
 
-    valid gridids are:
+    valid grid_ids are:
         psn3.125 psn6.25 psn12.5 psn25
         pss3.125 pss6.25 pss12.5 pss25
         e2n3.125 e2n6.25 e2n12.5 e2n25
@@ -37,18 +39,18 @@ def get_dataset_for_gridid(gridid, grid_date, return_dataset=True):
     """
     if return_dataset:
         logger.info(
-            f"Creating georeferenced dataset on {gridid} grid for {grid_date}"
+            f"Creating georeferenced dataset on {grid_id} grid for {grid_date}"
         )  # noqa
     crs_attrs: Dict[str, Union[str, float]] = {}
 
     # CRS for polar stereo grids
-    if gridid[:2] == "ps":
+    if grid_id[:2] == "ps":
         crs_attrs["grid_mapping_name"] = "polar_stereographic"
         crs_attrs["false_easting"] = 0.0
         crs_attrs["false_northing"] = 0.0
         crs_attrs["semi_major_axis"] = 6378273.0
         crs_attrs["inverse_flattening"] = 298.279411123064
-        if "psn" in gridid:
+        if "psn" in grid_id:
             # Note: two attrs will need resolution-based updates:
             #  long_name
             #  GeoTransform
@@ -69,7 +71,7 @@ def get_dataset_for_gridid(gridid, grid_date, return_dataset=True):
                 "crs_wkt"
             ] = 'PROJCS["NSIDC Sea Ice Polar Stereographic North",GEOGCS["Unspecified datum based upon the Hughes 1980 ellipsoid",DATUM["Not_specified_based_on_Hughes_1980_ellipsoid"’,SPHEROID["Hughes 1980",6378273,298.279411123061,AUTHORITY["EPSG","7058"]],AUTHORITY["EPSG","6054"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4054"]],PROJECTION["Polar_Stereographic"],PARAMETER["latitude_of_origin",70],PARAMETER["central_meridian",-45],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","3411"]]'  # noqa
             crs_attrs["GeoTransform"] = "{xleft} {res_m} 0 {ytop} 0 -{res_m}"
-        if "pss" in gridid:
+        if "pss" in grid_id:
             # Note: two attrs will need resolution-based updates:
             #  long_name
             #  GeoTransform
@@ -91,7 +93,7 @@ def get_dataset_for_gridid(gridid, grid_date, return_dataset=True):
             ] = 'PROJCS["NSIDC Sea Ice Polar Stereographic South",GEOGCS["Unspecified datum based upon the Hughes 1980 ellipsoid",DATUM["Not_specified_based_on_Hughes_1980_ellipsoid",SPHEROID["Hughes 1980",6378273,298.279411123061,AUTHORITY["EPSG","7058"]],AUTHORITY["EPSG","6054"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4054"]],PROJECTION["Polar_Stereographic"],PARAMETER["latitude_of_origin",-70],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","3412"]]'  # noqa
             crs_attrs["GeoTransform"] = "{xleft} {res_m} 0 {ytop} 0 -{res_m}"
 
-    elif gridid[:3] == "e2t":
+    elif grid_id[:3] == "e2t":
         xleft = -17367530.44
         xright = 17367530.44
         ytop = 6756820.2
@@ -115,7 +117,7 @@ def get_dataset_for_gridid(gridid, grid_date, return_dataset=True):
             "GeoTransform"
         ] = "-17367530.44 {res_tkm} 0 6756820.2 0 -{res_tkm}"  # noqa
 
-    elif gridid[:2] == "e2":
+    elif grid_id[:2] == "e2":
         xleft = -9000000.0
         xright = 9000000.0
         ytop = 9000000.0
@@ -128,7 +130,7 @@ def get_dataset_for_gridid(gridid, grid_date, return_dataset=True):
         crs_attrs["inverse_flattening"] = 298.257223563
         crs_attrs["GeoTransform"] = "-9000000 {res_m} 0 9000000 0 -{res_m}"
 
-        if gridid[:3] == "e2n":
+        if grid_id[:3] == "e2n":
             crs_attrs["long_name"] = "NSIDC_EASE2_N{res_km}km"
             crs_attrs["latitude_of_projection_origin"] = 90.0
             crs_attrs[
@@ -138,7 +140,7 @@ def get_dataset_for_gridid(gridid, grid_date, return_dataset=True):
             crs_attrs[
                 "crs_wkt"
             ] = 'PROJCS["unnamed",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9108"]],AUTHORITY["EPSG","4326"]],PROJECTION["Lambert_Azimuthal_Equal_Area"],PARAMETER["latitude_of_center",90],PARAMETER["longitude_of_center",0],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["Meter",1],AUTHORITY["epsg","6931"]]atitude_of_center",90],PARAMETER["longitude_of_center",0],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["Meter",1],AUTHORITY["epsg","6931"]]'  # noqa
-        elif gridid[:3] == "e2s":
+        elif grid_id[:3] == "e2s":
             crs_attrs["long_name"] = "NSIDC_EASE2_S{res_km}km"
             crs_attrs["latitude_of_projection_origin"] = -90.0
             crs_attrs[
@@ -149,12 +151,12 @@ def get_dataset_for_gridid(gridid, grid_date, return_dataset=True):
                 "crs_wkt"
             ] = 'PROJCS["unnamed",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9108"]],AUTHORITY["EPSG","4326"]],PROJECTION["Lambert_Azimuthal_Equal_Area"],PARAMETER["latitude_of_center",-90],PARAMETER["longitude_of_center",0],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["Meter",1],AUTHORITY["epsg","6932"]]'  # noqa
         else:
-            raise ValueError(f"Could not determine EASE2 hemisphere: {gridid}")
+            raise ValueError(f"Could not determine EASE2 hemisphere: {grid_id}")
 
-    res_km = gridid[3:]
+    res_km = grid_id[3:]
     res_m = int(float(res_km) * 1000)
     crs_attrs["long_name"] = crs_attrs["long_name"].format(res_km=res_km)  # type: ignore[union-attr]  # noqa
-    if gridid[:3] == "e2t":
+    if grid_id[:3] == "e2t":
         res_m = 1.0010104 * res_m  # type: ignore[assignment]
         res_tkm = 1.0010104 * float(res_km)
         crs_attrs["GeoTransform"] = crs_attrs["GeoTransform"].format(  # type: ignore[union-attr]  # noqa
@@ -243,7 +245,7 @@ def get_dataset_for_gridid(gridid, grid_date, return_dataset=True):
                 "x": x_da,
             },
             attrs={
-                "description": f"Geolocation for gridid {gridid}",
+                "description": f"Geolocation for grid_id {grid_id}",
             },
         )
 
@@ -257,14 +259,15 @@ def get_dataset_for_gridid(gridid, grid_date, return_dataset=True):
         }
 
 
+# TODO: do we need this `__main__` logic? If so, document it.
 if __name__ == "__main__":
     import sys
 
     try:
-        gridid = sys.argv[1]
+        grid_id = sys.argv[1]
     except IndexError:
-        gridid = "psn25"
-        print(f"Using default gridid: {gridid}")
+        grid_id = "psn25"
+        print(f"Using default grid_id: {grid_id}")
 
     try:
         grid_date = dt.datetime.strptime(sys.argv[2], "%Y%m%d").date()
@@ -277,7 +280,7 @@ if __name__ == "__main__":
     else:
         add_random_field = False
 
-    ds = get_dataset_for_gridid(gridid, grid_date)
+    ds = get_dataset_for_grid_id(grid_id, grid_date)  # type: ignore[arg-type]
 
     if add_random_field:
         # Generate an appropriate time value
@@ -335,7 +338,7 @@ if __name__ == "__main__":
         ds.attrs["comment"] = "This version has a sample data field"
 
     try:
-        ofn = f"geolocation_{gridid}.nc"
+        ofn = f"geolocation_{grid_id}.nc"
         ds.to_netcdf(ofn, unlimited_dims=["time"])
         print(f"Wrote: {ofn}")
     except AttributeError:

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -29,13 +29,14 @@ from pm_icecon.land_spillover import apply_nt2_land_spillover
 from pm_icecon.nt._types import NasateamGradientRatioThresholds
 from pm_icecon.nt.tiepoints import NasateamTiePoints
 from pm_icecon.util import date_range
-from pm_tb_data._types import NORTH, SOUTH, Hemisphere
+from pm_tb_data._types import Hemisphere
 from pm_tb_data.fetch.au_si import AU_SI_RESOLUTIONS, get_au_si_tbs
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.cli.util import datetime_to_date
 from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
-from seaice_ecdr.gridid_to_xr_dataarray import get_dataset_for_gridid
+from seaice_ecdr.grid_id import get_grid_id
+from seaice_ecdr.gridid_to_xr_dataarray import get_dataset_for_grid_id
 from seaice_ecdr.land_spillover import load_or_create_land90_conc, read_adj123_file
 from seaice_ecdr.masks import psn_125_near_pole_hole_mask
 from seaice_ecdr.util import standard_daily_filename
@@ -190,12 +191,12 @@ def _setup_ecdr_ds(
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
 ) -> xr.Dataset:
     # Initialize geo-referenced xarray Dataset
-    grid_id = _get_grid_id(
+    grid_id = get_grid_id(
         hemisphere=hemisphere,
         resolution=resolution,
     )
 
-    ecdr_ide_ds = get_dataset_for_gridid(grid_id, date)
+    ecdr_ide_ds = get_dataset_for_grid_id(grid_id, date)
 
     # Set initial global attributes
 
@@ -238,22 +239,6 @@ def _setup_ecdr_ds(
         )
 
     return ecdr_ide_ds
-
-
-def _get_grid_id(
-    *, hemisphere: Hemisphere, resolution: ECDR_SUPPORTED_RESOLUTIONS
-) -> str:
-    # Set the gridid
-    if hemisphere == NORTH and resolution == "12.5":
-        gridid = "psn12.5"
-    elif hemisphere == SOUTH and resolution == "12.5":
-        gridid = "pss12.5"
-    else:
-        raise RuntimeError(
-            f"Could not determine gridid from:\n" f"{hemisphere} and {resolution}"
-        )
-
-    return gridid
 
 
 def _au_si_res_str(*, resolution: ECDR_SUPPORTED_RESOLUTIONS) -> AU_SI_RESOLUTIONS:
@@ -673,13 +658,13 @@ def compute_initial_daily_ecdr_dataset(
         if tb_h19.shape == (896, 608):
             # NH
             l90c = load_or_create_land90_conc(
-                gridid="psn12.5",
+                grid_id="psn12.5",
                 xdim=608,
                 ydim=896,
                 overwrite=False,
             )
             adj123 = read_adj123_file(
-                gridid="psn12.5",
+                grid_id="psn12.5",
                 xdim=608,
                 ydim=896,
             )
@@ -691,13 +676,13 @@ def compute_initial_daily_ecdr_dataset(
         elif tb_h19.shape == (664, 632):
             # SH
             l90c = load_or_create_land90_conc(
-                gridid="pss12.5",
+                grid_id="pss12.5",
                 xdim=632,
                 ydim=664,
                 overwrite=False,
             )
             adj123 = read_adj123_file(
-                gridid="pss12.5",
+                grid_id="pss12.5",
                 xdim=632,
                 ydim=664,
             )

--- a/seaice_ecdr/land_spillover.py
+++ b/seaice_ecdr/land_spillover.py
@@ -11,14 +11,14 @@ from pm_icecon.land_spillover import create_land90
 
 
 def read_adj123_file(
-    gridid: str = "psn12.5",
+    grid_id: str = "psn12.5",
     xdim: int = 608,
     ydim: int = 896,
     anc_dir: str = "/share/apps/amsr2-cdr/nasateam2_ancillary",
-    adj123_fn_template: str = "{anc_dir}/coastal_adj_diag123_{gridid}.dat",
+    adj123_fn_template: str = "{anc_dir}/coastal_adj_diag123_{grid_id}.dat",
 ):
     """Read the diagonal adjacency 123 file."""
-    coast_adj_fn = adj123_fn_template.format(anc_dir=anc_dir, gridid=gridid)
+    coast_adj_fn = adj123_fn_template.format(anc_dir=anc_dir, grid_id=grid_id)
     assert os.path.isfile(coast_adj_fn)
     adj123 = np.fromfile(coast_adj_fn, dtype=np.uint8).reshape(ydim, xdim)
 
@@ -26,13 +26,13 @@ def read_adj123_file(
 
 
 def create_land90_conc_file(
-    gridid: str = "psn12.5",
+    grid_id: str = "psn12.5",
     xdim: int = 608,
     ydim: int = 896,
     anc_dir: str = "/share/apps/amsr2-cdr/nasateam2_ancillary",
-    adj123_fn_template: str = "{anc_dir}/coastal_adj_diag123_{gridid}.dat",
+    adj123_fn_template: str = "{anc_dir}/coastal_adj_diag123_{grid_id}.dat",
     write_l90c_file: bool = True,
-    l90c_fn_template: str = "{anc_dir}/land90_conc_{gridid}.dat",
+    l90c_fn_template: str = "{anc_dir}/land90_conc_{grid_id}.dat",
 ):
     """Create the land90-conc file.
 
@@ -44,11 +44,11 @@ def create_land90_conc_file(
     concentration of 90%.  The average of the 49 grid cells in the 7x7 array
     yields the `land90` concentration value.
     """
-    adj123 = read_adj123_file(gridid, xdim, ydim, anc_dir, adj123_fn_template)
+    adj123 = read_adj123_file(grid_id, xdim, ydim, anc_dir, adj123_fn_template)
     land90 = create_land90(adj123=adj123)
 
     if write_l90c_file:
-        l90c_fn = l90c_fn_template.format(anc_dir=anc_dir, gridid=gridid)
+        l90c_fn = l90c_fn_template.format(anc_dir=anc_dir, grid_id=grid_id)
         land90.tofile(l90c_fn)
         print(f"Wrote: {l90c_fn}\n  {land90.dtype}  {land90.shape}")
 
@@ -56,18 +56,18 @@ def create_land90_conc_file(
 
 
 def load_or_create_land90_conc(
-    gridid: str = "psn12.5",
+    grid_id: str = "psn12.5",
     xdim: int = 608,
     ydim: int = 896,
     anc_dir: str = "/share/apps/amsr2-cdr/nasateam2_ancillary",
-    l90c_fn_template: str = "{anc_dir}/land90_conc_{gridid}.dat",
+    l90c_fn_template: str = "{anc_dir}/land90_conc_{grid_id}.dat",
     overwrite: bool = False,
 ):
     # Attempt to load the land90_conc field, and if fail, create it
-    l90c_fn = l90c_fn_template.format(anc_dir=anc_dir, gridid=gridid)
+    l90c_fn = l90c_fn_template.format(anc_dir=anc_dir, grid_id=grid_id)
     if overwrite or not os.path.isfile(l90c_fn):
         data = create_land90_conc_file(
-            gridid, xdim, ydim, anc_dir=anc_dir, l90c_fn_template=l90c_fn_template
+            grid_id, xdim, ydim, anc_dir=anc_dir, l90c_fn_template=l90c_fn_template
         )
     else:
         data = np.fromfile(l90c_fn, dtype=np.float32).reshape(ydim, xdim)

--- a/seaice_ecdr/tests/unit/test_grid_id.py
+++ b/seaice_ecdr/tests/unit/test_grid_id.py
@@ -1,0 +1,8 @@
+from pm_tb_data._types import NORTH, SOUTH
+
+from seaice_ecdr.grid_id import get_grid_id
+
+
+def test_get_grid_id():
+    assert "psn12.5" == get_grid_id(hemisphere=NORTH, resolution="12.5")
+    assert "pss12.5" == get_grid_id(hemisphere=SOUTH, resolution="12.5")

--- a/seaice_ecdr/use_surface_geo_mask.py
+++ b/seaice_ecdr/use_surface_geo_mask.py
@@ -13,7 +13,7 @@ import pandas as pd
 import xarray as xr
 from pm_tb_data._types import Hemisphere
 
-from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
+from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS, SUPPORTED_SAT
 from seaice_ecdr.constants import CDR_ANCILLARY_DIR
 
 
@@ -31,14 +31,13 @@ def get_surfgeo_ds(gridid):
 
 def _get_sat_by_date(
     date: dt.date,
-) -> str:
-    """Return the sensor used for this date."""
+) -> SUPPORTED_SAT:
+    """Return the satellite used for this date."""
     # TODO: these date ranges belong in a config location
     if date >= dt.date(2012, 7, 2) and date <= dt.date(2030, 12, 31):
-        # TODO: this should be `am2` to be consistent with `SUPPORTED_SAT`.
-        return "amsr2"
+        return "am2"
     else:
-        raise RuntimeError(f"Could not determine sensor for date: {date}")
+        raise RuntimeError(f"Could not determine sat for date: {date}")
 
 
 def get_surfacetype_da(

--- a/seaice_ecdr/use_surface_geo_mask.py
+++ b/seaice_ecdr/use_surface_geo_mask.py
@@ -15,6 +15,7 @@ from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS, SUPPORTED_SAT
 from seaice_ecdr.constants import CDR_ANCILLARY_DIR
+from seaice_ecdr.grid_id import GRID_ID, get_grid_id
 
 
 def get_surfacegeomask_filepath(grid_id: str) -> Path:
@@ -24,9 +25,9 @@ def get_surfacegeomask_filepath(grid_id: str) -> Path:
 
 
 @cache
-def get_surfgeo_ds(gridid):
+def get_surfgeo_ds(grid_id: GRID_ID) -> xr.Dataset:
     """Return xr Dataset of ancillary surface/geolocation for this grid."""
-    return xr.load_dataset(get_surfacegeomask_filepath(gridid))
+    return xr.load_dataset(get_surfacegeomask_filepath(grid_id))
 
 
 def _get_sat_by_date(
@@ -47,17 +48,11 @@ def get_surfacetype_da(
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
 ) -> xr.DataArray:
     """Return a dataarray with surface type information for this date."""
-    if hemisphere == "north" and resolution == "12.5":
-        surfgeo_ds = get_surfgeo_ds("psn12.5")
-    elif hemisphere == "south" and resolution == "12.5":
-        surfgeo_ds = get_surfgeo_ds("pss12.5")
-    else:
-        raise RuntimeError(
-            f"""
-        Could not determine grid for:
-            hemisphere: {hemisphere}
-            resolution: {resolution} ({type(resolution)})"""
-        )
+    grid_id = get_grid_id(
+        hemisphere=hemisphere,
+        resolution=resolution,
+    )
+    surfgeo_ds = get_surfgeo_ds(grid_id)
 
     xvar = surfgeo_ds.variables["x"]
     yvar = surfgeo_ds.variables["y"]

--- a/seaice_ecdr/use_surface_geo_mask.py
+++ b/seaice_ecdr/use_surface_geo_mask.py
@@ -41,6 +41,7 @@ def _get_sat_by_date(
 
 
 def get_surfacetype_da(
+    *,
     date: dt.date,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,


### PR DESCRIPTION
More consistent handling of Grid IDs.

Thinking more about this, longer term, we might want to move the logic for handling grid IDs to `pm_tb_data`. Each dataset returned by that could provide such a `grid_id`, which maps to a particular grid/CRS.

Also, this PR includes some commits I meant to have on #52 . My mistake. Thought this would make it a little easier to review the changes to how grid ids are handled.