### PR TITLE
Apply land mask to QA/flag fields

### DIFF
--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -13,7 +13,7 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: ee261755637274e93ade8e4b9fef780c5027e73884d9580b96852509abab43d7
+    linux-64: 0276c2f8457ee44191c28a132328b31e3a07ff4e2702dba1d6a6bf875fdc14fa
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -61,19 +61,19 @@ package:
   category: main
   optional: false
 - name: aiobotocore
-  version: 2.7.0
+  version: 2.9.0
   manager: conda
   platform: linux-64
   dependencies:
     aiohttp: '>=3.7.4.post0,<4.0.0'
     aioitertools: '>=0.5.1,<1.0.0'
-    botocore: '>=1.31.16,<1.31.65'
+    botocore: '>=1.33.2,<1.33.14'
     python: '>=3.8'
     wrapt: '>=1.10.10,<2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.7.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: eb36e010b948b1e8e5b891ba52d7c9e1
-    sha256: b827f1f0666abd25bc01a14828379804692603f30e999ce0eac3b0d15858efb5
+    md5: 72f6cca1b44a5333ef97ecb5ae59dcb1
+    sha256: 755b88441d79966f3bae165a46fc43be522cf59a1aa8c8181ee1a4c42ebe6d9a
   category: main
   optional: false
 - name: aiofiles
@@ -89,24 +89,23 @@ package:
   category: main
   optional: false
 - name: aiohttp
-  version: 3.8.6
+  version: 3.9.1
   manager: conda
   platform: linux-64
   dependencies:
     aiosignal: '>=1.1.2'
-    async-timeout: <5.0,>=4.0.0a3
+    async-timeout: '>=4.0,<5.0'
     attrs: '>=17.3.0'
-    charset-normalizer: '>=2.0,<4.0'
     frozenlist: '>=1.1.1'
     libgcc-ng: '>=12'
     multidict: '>=4.5,<7.0'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     yarl: '>=1.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.8.6-py310h2372a71_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.9.1-py310h2372a71_0.conda
   hash:
-    md5: d265a71480afd9479c9333ba86375d04
-    sha256: e32892fd786dc4ba150701ffd0981c8e942fc77e52754f6f1c331392004bd6f1
+    md5: f367877549376e985a3df1dc430692ae
+    sha256: 6a3983f2ee81308ae0716790ae780f63915f47fcd6a1038d3c75a78fcb675f23
   category: main
   optional: false
 - name: aioitertools
@@ -427,32 +426,6 @@ package:
     sha256: 806ee5d9fb255f7c327c45347935611dfb2988ec47438772935617215233c487
   category: main
   optional: false
-- name: backports
-  version: '1.0'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
-  hash:
-    md5: 54ca2e08b3220c148a1d8329c2678e02
-    sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
-  category: main
-  optional: false
-- name: backports.functools_lru_cache
-  version: 1.6.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    backports: ''
-    python: '>=3.6'
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6b1b907661838a75d067a22f87996b2e
-    sha256: 7027bb689dd4ca4a08e3b25805de9d04239be6b31125993558f21f102a9d2700
-  category: main
-  optional: false
 - name: blosc
   version: 1.21.5
   manager: conda
@@ -471,7 +444,7 @@ package:
   category: main
   optional: false
 - name: bokeh
-  version: 3.3.1
+  version: 3.3.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -485,10 +458,10 @@ package:
     pyyaml: '>=3.10'
     tornado: '>=5.1'
     xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.3.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.3.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 682d698da77e896c5e986b334ce8f0a5
-    sha256: 19294302fd62ff2c9fbdcd69bdbdf1266beb63eff54128dd81d1a1749f1c1969
+    md5: c02a7e79365121bd3bcc25f1b65f48a9
+    sha256: 71c36a77422e58d66d1e1c126b09481ad05f7e80b1a86860496de566ed990e0e
   category: main
   optional: false
 - name: boost-cpp
@@ -510,7 +483,7 @@ package:
   category: main
   optional: false
 - name: botocore
-  version: 1.31.64
+  version: 1.33.13
   manager: conda
   platform: linux-64
   dependencies:
@@ -518,10 +491,10 @@ package:
     python: '>=3.7'
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,<1.27'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.31.64-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.33.13-pyhd8ed1ab_0.conda
   hash:
-    md5: b208e9509d3a523b914fa21cd46e4ae2
-    sha256: f73692d2c9d4c38796d07b92b509dd9a14b036c83f520672c608d9d79eb440ba
+    md5: d2566fd9134b6f8b8e69a07e9a1fa17e
+    sha256: 498d08274880ef279e9a6dd68f66b384d71321d92301fa60330712f9edceab0c
   category: main
   optional: false
 - name: bounded-pool-executor
@@ -610,15 +583,15 @@ package:
   category: main
   optional: false
 - name: c-ares
-  version: 1.22.1
+  version: 1.24.0
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.22.1-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.24.0-hd590300_0.conda
   hash:
-    md5: 8430bd266c7b2cfbda403f7585d5ee86
-    sha256: d41cf87938ba66de538b91afed3ece9b4cf5ed082a7d1c1add46b70f482f34b9
+    md5: f5842b88e9cbfa177abfaeacd457a45d
+    sha256: b68b0611d1c9d0222b56d5fe3d634e7a26979c3aef30f5f48b1593e7249e8f7a
   category: main
   optional: false
 - name: ca-certificates
@@ -946,7 +919,7 @@ package:
   category: main
   optional: false
 - name: coverage
-  version: 7.3.2
+  version: 7.3.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -954,10 +927,10 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     tomli: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.3.2-py310h2372a71_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.3.3-py310h2372a71_0.conda
   hash:
-    md5: 33c03cd5711885c920ddff676fb84f98
-    sha256: f9c07ee8807188c39bd415dd8ce39ac7a90c41cb0cc741e9af429e1f886930c6
+    md5: c07e83a9bd8f5053b42be842b9871df9
+    sha256: be401f8a99aaa4ebe30a78228fb2b4dbdcae22f1023beb31514d01e1c2c4811c
   category: main
   optional: false
 - name: crashtest
@@ -973,7 +946,7 @@ package:
   category: main
   optional: false
 - name: cryptography
-  version: 41.0.5
+  version: 41.0.7
   manager: conda
   platform: linux-64
   dependencies:
@@ -982,10 +955,10 @@ package:
     openssl: '>=3.1.4,<4.0a0'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-41.0.5-py310h75e40e8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-41.0.7-py310hb8475ec_1.conda
   hash:
-    md5: 33f090627d17c47493b88a5f7d2834e8
-    sha256: b81a6dd15052379775c43997a48f4a85db5c0448a80a75ba74c3af78cf33c0da
+    md5: 8a84d96d106767c08d6154ed5c8aae2c
+    sha256: 493feafc2492e841d361affb0bba2e29ab41d73b8db2d58c5abdfd4ccf1d29ad
   category: main
   optional: false
 - name: curl
@@ -1101,15 +1074,15 @@ package:
   category: main
   optional: false
 - name: distlib
-  version: 0.3.7
+  version: 0.3.8
   manager: conda
   platform: linux-64
   dependencies:
     python: 2.7|>=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
   hash:
-    md5: 12d8aae6994f342618443a8f05c652a0
-    sha256: 13c887cb4a29e1e853a118cfc0e42b72a7e1d1c50c66c0974885d37f0db30619
+    md5: db16c66b759a64dc5183d69cc3745a52
+    sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
   category: main
   optional: false
 - name: distributed
@@ -1179,15 +1152,15 @@ package:
   category: main
   optional: false
 - name: exceptiongroup
-  version: 1.1.3
+  version: 1.2.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: e6518222753f519e911e83136d2158d9
-    sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
+    md5: f6c211fee3c98229652b60a9a42ef363
+    sha256: cf83dcaf9006015c8ccab3fc6770f478464a66a8769e1763ca5d7dff09d11d08
   category: main
   optional: false
 - name: executing
@@ -1306,10 +1279,10 @@ package:
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
   hash:
-    md5: 19410c3df09dfb12d1206132a1d357c5
-    sha256: 470d5db54102bd51dbb0c5990324a2f4a0bc976faa493b22193338adb9882e2e
+    md5: 6185f640c43843e5ad6fd1c5372c3f80
+    sha256: 056c85b482d58faab5fd4670b6c1f5df0986314cca3bc831d458b22e4ef2c792
   category: main
   optional: false
 - name: fontconfig
@@ -1356,7 +1329,7 @@ package:
   category: main
   optional: false
 - name: fonttools
-  version: 4.45.0
+  version: 4.47.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -1366,10 +1339,10 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     unicodedata2: '>=14.0.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.45.0-py310h2372a71_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.47.0-py310h2372a71_0.conda
   hash:
-    md5: 5fc930c58bcc545e5f3773b3434a3fcd
-    sha256: c74cba927c28c84aeae944dd7177a86ca858ef60f37936eb50a336c423f648bb
+    md5: 27df6604157a2a9e782cbe720f752cf5
+    sha256: 468904105e134301032749de8bf613a5cbc61d4de51bce25524716b6386885a4
   category: main
   optional: false
 - name: freetype
@@ -1411,42 +1384,42 @@ package:
   category: main
   optional: false
 - name: frozenlist
-  version: 1.4.0
+  version: 1.4.1
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.0-py310h2372a71_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.1-py310h2372a71_0.conda
   hash:
-    md5: c7b2865e86782925a872c8598b760c08
-    sha256: cd1e59ceac047d9f692bb7cc2a6a6e2356a7d3db660b076b4afb19d35db2fd02
+    md5: f20cd4d9c1f4a8377d0818c819918bbb
+    sha256: 496d0ae05e81be0bd8e046bc48a3346f867caaad65041aa14ee2f3717af70db6
   category: main
   optional: false
 - name: fsspec
-  version: 2023.10.0
+  version: 2023.12.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.10.0-pyhca7485f_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.12.2-pyhca7485f_0.conda
   hash:
-    md5: 5b86cf1ceaaa9be2ec4627377e538db1
-    sha256: 1bbdfadb93cc768252fd207dca406cde928f9a81ff985ea1760b6539c55923e6
+    md5: bf40f2a8835b78b1f91083d306b493d2
+    sha256: 9269a5464698e0fde1f9c78544552817370c26df86e2a5a7518544b6a55ae8ee
   category: main
   optional: false
 - name: ftfy
-  version: 6.1.1
+  version: 6.1.3
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7,<4.0'
     wcwidth: '>=0.2.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/ftfy-6.1.1-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/ftfy-6.1.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 8112acb97be37967accbbe75436b62d7
-    sha256: 76f22f9bea6d52f10dc13c262c0940773f015802ee90a5e3c70c467d3ecd5806
+    md5: b7938352ffb646bbdd85696699ebe2d3
+    sha256: 6dd45563e9f32b24edb3dabe91efb996db61890e28899e02a3a7fab603795bdc
   category: main
   optional: false
 - name: gdal
@@ -1846,28 +1819,28 @@ package:
   category: main
   optional: false
 - name: identify
-  version: 2.5.32
+  version: 2.5.33
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
     ukkonen: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.32-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.33-pyhd8ed1ab_0.conda
   hash:
-    md5: 3ef8e9bab1bfaf900bb0a5db8c0c742c
-    sha256: 0783aa58f43d1c113a2ec300a29ba3313184056f9893671c75037fbadaf9e546
+    md5: 93c8f8ceb83827d88deeba796f07fba7
+    sha256: ce2a64c18221af96226be23278d81f22ff9f64b3c047d8865590f6718915303f
   category: main
   optional: false
 - name: idna
-  version: '3.4'
+  version: '3.6'
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
   hash:
-    md5: 34272b248891bddccc64479f9a7fffed
-    sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
+    md5: 1a76f09108576397c41c0b0c5bd84134
+    sha256: 6ee4c986d69ce61e60a20b2459b6f2027baeba153f0a64995fd3cb47c2cc7e07
   category: main
   optional: false
 - name: imagemagick
@@ -1913,28 +1886,28 @@ package:
   category: main
   optional: false
 - name: importlib-metadata
-  version: 6.8.0
+  version: 7.0.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
     zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.0-pyha770c72_0.conda
   hash:
-    md5: 4e9f59a060c3be52bc4ddc46ee9b6946
-    sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
+    md5: a941237cd06538837b25cd245fcd25d8
+    sha256: 9731e82a00d36b182dc515e31723e711ac82890bb1ca86c6a17a4b471135564f
   category: main
   optional: false
 - name: importlib_metadata
-  version: 6.8.0
+  version: 7.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    importlib-metadata: '>=6.8.0,<6.8.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+    importlib-metadata: '>=7.0.0,<7.0.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.0.0-hd8ed1ab_0.conda
   hash:
-    md5: b279b07ce18058034e5b3606ba103a8b
-    sha256: b96e01dc42d547d6d9ceb1c5b52a5232cc04e40153534350f702c3e0418a6b3f
+    md5: 12aff14f84c337be5e5636bf612f4140
+    sha256: b9e8ed41df6c55222e3777f422e77a22a6a19ff779b2e65aa8dfdea792c1f7de
   category: main
   optional: false
 - name: iniconfig
@@ -1977,27 +1950,27 @@ package:
   category: main
   optional: false
 - name: ipython
-  version: 8.17.2
+  version: 8.18.1
   manager: conda
   platform: linux-64
   dependencies:
-    __linux: ''
+    __unix: ''
     decorator: ''
     exceptiongroup: ''
     jedi: '>=0.16'
     matplotlib-inline: ''
     pexpect: '>4.3'
     pickleshare: ''
-    prompt_toolkit: '>=3.0.30,<3.1.0,!=3.0.37'
+    prompt-toolkit: '>=3.0.41,<3.1.0'
     pygments: '>=2.4.0'
     python: '>=3.9'
     stack_data: ''
     traitlets: '>=5'
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.17.2-pyh41d4057_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.18.1-pyh707e725_3.conda
   hash:
-    md5: f39d0b60e268fe547f1367edbab457d4
-    sha256: 31322d58f412787f5beeb01db4d16f10f8ae4e0cc2ec99fafef1e690374fe298
+    md5: 15c6f45a45f7ac27f6d60b0b084f6761
+    sha256: d98d615ac8ad71de698afbc50e8269570d4b89706821c4ff3058a4ceec69bd9b
   category: main
   optional: false
 - name: jack
@@ -2323,11 +2296,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libopenblas: '>=0.3.24,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-19_linux64_openblas.conda
+    libopenblas: '>=0.3.25,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-20_linux64_openblas.conda
   hash:
-    md5: 420f4e9be59d0dc9133a0f43f7bab3f3
-    sha256: b1311b9414559c5760b08a32e0382ca27fa302c967968aa6f78e042519f728ce
+    md5: 2b7bb4f7562c8cf334fc2e20c2d28abc
+    sha256: 8a0ee1de693a9b3da4a11b95ec81b40dd434bd01fa1f5f38f8268cd2146bf8f0
   category: main
   optional: false
 - name: libbrotlicommon
@@ -2387,10 +2360,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-19_linux64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-20_linux64_openblas.conda
   hash:
-    md5: d12374af44575413fbbd4a217d46ea33
-    sha256: 84fddccaf58f42b07af7fb42512bd617efcb072f17bdef27f4c1884dbd33c86a
+    md5: 36d486d72ab64ffea932329a1d3729a3
+    sha256: 0e34fb0f82262f02fcb279ab4a1db8d50875dc98e3019452f8f387e6bf3c0247
   category: main
   optional: false
 - name: libclang
@@ -2402,11 +2375,10 @@ package:
     libgcc-ng: '>=12'
     libllvm15: '>=15.0.7,<15.1.0a0'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_h7634d5b_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_hb11cfb5_4.conda
   hash:
-    md5: 0922208521c0463e690bbaebba7eb551
-    sha256: c2b0c8dd675e30d86bad410679f258820bc36723fbadffc13c2f60249be91815
+    md5: c90f4cbb57839c98fef8f830e4b9972f
+    sha256: 0b80441f222a91074d0e5edb0fbc3b1ce16ca2cdf6ab899721afdcc3a3ff6302
   category: main
   optional: false
 - name: libclang13
@@ -2417,11 +2389,10 @@ package:
     libgcc-ng: '>=12'
     libllvm15: '>=15.0.7,<15.1.0a0'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_h9986a30_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_ha2b6cf4_4.conda
   hash:
-    md5: 1720df000b48e31842500323cb7be18c
-    sha256: df1221a9a05b9bb3bd9b43c08a7e2fe57a0e15a0010ef26065f7ed7666083f45
+    md5: 898e0dd993afbed0d871b60c2eb33b83
+    sha256: e1d34d415160b69a401dc0662bf1b5378655193ed1364bf7dd14f055e76e4b60
   category: main
   optional: false
 - name: libcrc32c
@@ -2513,11 +2484,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
   hash:
-    md5: 6f8720dff19e17ce5d48cfe7f3d2f0a3
-    sha256: 8c9635aa0ea28922877dc96358f9547f6a55fc7e2eb75a556b05f1725496baf9
+    md5: 172bf1cd1ff8629f2b1179945ed45055
+    sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
   category: main
   optional: false
 - name: libevent
@@ -2586,16 +2557,16 @@ package:
   category: main
   optional: false
 - name: libgcrypt
-  version: 1.10.2
+  version: 1.10.3
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libgpg-error: '>=1.47,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.2-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.3-hd590300_0.conda
   hash:
-    md5: 3d7d5e5cebf8af5aadb040732860f1b6
-    sha256: 21053a00af8e648d58bafc856167dc2c35a9e927a6aff3030d50e01b113265a3
+    md5: 32d16ad533c59bb0a3c5ffaf16110829
+    sha256: d1bd47faa29fec7288c7b212198432b07f890d3d6f646078da93b059c2e9daff
   category: main
   optional: false
 - name: libgd
@@ -2786,11 +2757,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=10.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
   hash:
-    md5: b62b52da46c39ee2bc3c162ac7f1804d
-    sha256: 6a81ebac9f1aacdf2b4f945c87ad62b972f0f69c8e0981d68e111739e6720fd7
+    md5: d66573916ffcf376178462f1b61c941e
+    sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
   category: main
   optional: false
 - name: libkml
@@ -2815,10 +2786,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-19_linux64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-20_linux64_openblas.conda
   hash:
-    md5: 9f100edf65436e3eabc2a51fc00b2c37
-    sha256: 58f402aae605ebd0932e1cbbf855cd49dcdfa2fcb6aab790a4f6068ec5937878
+    md5: 6fabc51f5e647d09cc010c40061557e0
+    sha256: ad7745b8d0f2ccb9c3ba7aaa7167d62fc9f02e45eb67172ae5f0dfb5a3b1a2cc
   category: main
   optional: false
 - name: libllvm15
@@ -2913,17 +2884,17 @@ package:
   category: main
   optional: false
 - name: libopenblas
-  version: 0.3.24
+  version: 0.3.25
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libgfortran-ng: ''
     libgfortran5: '>=12.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.25-pthreads_h413a1c8_0.conda
   hash:
-    md5: 6e4ef6ca28655124dcde9bd500e44c32
-    sha256: c8e080ae4d57506238023e98869928ae93564e6407ef5b0c4d3a337e8c2b7662
+    md5: d172b34a443b95f86089e8229ddc9a17
+    sha256: 628564517895ee1b09cf72c817548bd80ef1acce6a8214a8520d9f7b44c4cfaf
   category: main
   optional: false
 - name: libopus
@@ -2959,7 +2930,7 @@ package:
     krb5: '>=1.20.1,<1.21.0a0'
     libgcc-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.0.8,<4.0a0'
+    openssl: '>=3.0.8,<3.2.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libpq-15.2-hb675445_0.conda
   hash:
     md5: 4654b17eccaba55b8581d6b9c77f53cc
@@ -3055,16 +3026,16 @@ package:
   category: main
   optional: false
 - name: libsqlite
-  version: 3.44.0
+  version: 3.44.2
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.0-h2797004_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.2-h2797004_0.conda
   hash:
-    md5: b58e6816d137f3aabf77d341dd5d732b
-    sha256: 74ef5dcb900c38bec53140036e5e2a9cc7ffcd806da479ea2305f962a358a259
+    md5: 3b6a9f225c3dbe0d24f4fedd4625c5bf
+    sha256: ee2c4d724a3ed60d5b458864d66122fb84c6ce1df62f735f90d8db17b66cd88a
   category: main
   optional: false
 - name: libssh2
@@ -3510,7 +3481,7 @@ package:
   category: main
   optional: false
 - name: msgpack-python
-  version: 1.0.6
+  version: 1.0.7
   manager: conda
   platform: linux-64
   dependencies:
@@ -3518,10 +3489,10 @@ package:
     libstdcxx-ng: '>=12'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.0.6-py310hd41b1e2_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.0.7-py310hd41b1e2_0.conda
   hash:
-    md5: 03255e1437f31f25ad95bb45c8b398bb
-    sha256: cf37ee99132533005db95b611377d99f3cf4cb6feed494806d53aa7101768cd4
+    md5: dc5263dcaa1347e5a456ead3537be27d
+    sha256: a5c7612029e3871b0af0bd69e8ee1545d3deb93b5bec29cf1bf72522375fda31
   category: main
   optional: false
 - name: multidict
@@ -3694,20 +3665,20 @@ package:
   category: main
   optional: false
 - name: nss
-  version: '3.94'
+  version: '3.96'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
-    libsqlite: '>=3.43.0,<4.0a0'
+    libsqlite: '>=3.44.2,<4.0a0'
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
     nspr: '>=4.35,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.94-h1d7d5a4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.96-h1d7d5a4_0.conda
   hash:
-    md5: 7caef74bbfa730e014b20f0852068509
-    sha256: c9b7910fc554c6550905b9150f4c8230e973ca63f41b42f2c18a49e8aa458e78
+    md5: 1c8f8b8eb041ecd54053fc4b6ad57957
+    sha256: 9f73d55f42085d7bca59c675fea57dae2a21f3d62530e47b3d89db89ca444767
   category: main
   optional: false
 - name: numpy
@@ -3864,18 +3835,17 @@ package:
   category: main
   optional: false
 - name: patsy
-  version: 0.5.3
+  version: 0.5.4
   manager: conda
   platform: linux-64
   dependencies:
     numpy: '>=1.4.0'
     python: '>=3.6'
-    scipy: ''
     six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/patsy-0.5.3-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/patsy-0.5.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 50ef6b29b1fb0768ca82c5aeb4fb2d96
-    sha256: 9d232f9cda05ce1833a7e5b16db4486ddfb71318635047fb64de119d364e0259
+    md5: 1184267eddebb57e47f8e1419c225595
+    sha256: 74ad247503ef182c34bc847fd8a34124c573091012c78688ab1b0bde99af48ea
   category: main
   optional: false
 - name: pcre2
@@ -3919,15 +3889,15 @@ package:
   category: main
   optional: false
 - name: phonenumbers
-  version: 8.13.25
+  version: 8.13.27
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/phonenumbers-8.13.25-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/phonenumbers-8.13.27-pyhd8ed1ab_0.conda
   hash:
-    md5: 0e1d825517d17cc52cc00062ed3cbdf6
-    sha256: 6358d843358c89fcb09b5617767e643024367fc6e257d2bf54fb32d1de7291de
+    md5: da7a5416b87ce81c67fd11ea7b6a0416
+    sha256: 88fe81bca4ed2c6c9aa99807c92709c389eef53ec52ac14cbc89ceec4e3fe702
   category: main
   optional: false
 - name: pickleshare
@@ -4003,16 +3973,15 @@ package:
   category: main
   optional: false
 - name: platformdirs
-  version: 3.11.0
+  version: 4.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 8f567c0a74aa44cf732f15773b4083b0
-    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
+    md5: 45a5065664da0d1dfa8f8cd2eaf05ab9
+    sha256: 9e4ff17ce802159ed31344eb913eaa877688226765b77947b102b42255a53853
   category: main
   optional: false
 - name: plotly
@@ -4132,20 +4101,20 @@ package:
   category: main
   optional: false
 - name: pre-commit
-  version: 3.5.0
+  version: 3.6.0
   manager: conda
   platform: linux-64
   dependencies:
     cfgv: '>=2.0.0'
     identify: '>=1.0.0'
     nodeenv: '>=0.11.1'
-    python: '>=3.8'
+    python: '>=3.9'
     pyyaml: '>=5.1'
     virtualenv: '>=20.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.5.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.6.0-pyha770c72_0.conda
   hash:
-    md5: 964e3d762e427661c59263435a14c492
-    sha256: 51a4a17334a15ec92805cd075776563ff93b3b6c20732c4cb607c98a761ae02f
+    md5: 473a7cfca197da0a10cff3f6dded7d4b
+    sha256: 7d1f4b4a2eb4946b5808769642c5f643788c3a9e090f1c02a6c63f8794fb3d54
   category: main
   optional: false
 - name: proj
@@ -4166,42 +4135,30 @@ package:
   category: main
   optional: false
 - name: prompt-toolkit
-  version: 3.0.41
+  version: 3.0.42
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
     wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.41-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.42-pyha770c72_0.conda
   hash:
-    md5: f511a993aa4336bef9dd874ee3403e67
-    sha256: e26a5554883a0eada3641b6d861d8cb4895e2c7fcc17a587de07b8b1ecbfff0f
-  category: main
-  optional: false
-- name: prompt_toolkit
-  version: 3.0.41
-  manager: conda
-  platform: linux-64
-  dependencies:
-    prompt-toolkit: '>=3.0.41,<3.0.42.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.41-hd8ed1ab_0.conda
-  hash:
-    md5: b1387bd091fa0420557f801a78587678
-    sha256: dd2fea25930d258159441ad4a45e5d3274f0d2f1dea92fe25b44b48c486aa969
+    md5: 0bf64bf10eee21f46ac83c161917fa86
+    sha256: 58525b2a9305fb154b2b0d43a48b9a6495441b80e4fbea44f2a34a597d2cef16
   category: main
   optional: false
 - name: psutil
-  version: 5.9.5
+  version: 5.9.7
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py310h2372a71_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.7-py310h2372a71_0.conda
   hash:
-    md5: cb25177acf28cc35cfa6c1ac1c679e22
-    sha256: db8a99bc41c1b0405c8e9daa92b9d4e7711f9717aff7fd3feeba407ca2a91aa2
+    md5: eb1f8f278d0b00c7b6d5c01a5b06609f
+    sha256: 82d01c09f10cdc0b9333c9478a05bfd55f9cf7b5a1db079938b46920fedd9f7b
   category: main
   optional: false
 - name: pthread-stubs
@@ -4352,15 +4309,15 @@ package:
   category: main
   optional: false
 - name: pygments
-  version: 2.17.1
+  version: 2.17.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 5bb8a4f4162594af97cee1434d39f500
-    sha256: 406ed28a4c8cd6be56e7e1b2dabd283e834f234d057522228adb72b1885b87c7
+    md5: 140a7f159396547e9799aa98f9f0742e
+    sha256: af5f8867450dc292f98ea387d4d8945fc574284677c8f60eaa9846ede7387257
   category: main
   optional: false
 - name: pylev
@@ -4497,6 +4454,19 @@ package:
     sha256: f07d3b44cabbed7843de654c4a6990a08475ce3b708bb735c7da9842614586f2
   category: main
   optional: false
+- name: pytest-order
+  version: 1.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    pytest: '>=3.7'
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-order-1.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: d66820a0d1d10f6731b101d36dc38ad9
+    sha256: 8d4f0c70f66dfeb4f857e2b92b30713b7b6b475b748dcb2b47ef7d0f18346752
+  category: main
+  optional: false
 - name: python
   version: 3.10.13
   manager: conda
@@ -4571,16 +4541,16 @@ package:
   category: main
   optional: false
 - name: python-fsutil
-  version: 0.11.0
+  version: 0.13.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.5'
     requests: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fsutil-0.11.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-fsutil-0.13.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 52d13eb9da0c35391bfb03e159847a20
-    sha256: 13159d879030b76e31debd3e3c05d2ec32d127ee712816532a40982e0be456f3
+    md5: a922141183076c1646b56431f01c73dd
+    sha256: 6ff1ca8ee853cec48ab1895c23b898c5bc6af4dbf5b12fd9e30abd99b66ed640
   category: main
   optional: false
 - name: python-kaleido
@@ -4808,17 +4778,17 @@ package:
   category: main
   optional: false
 - name: rich-click
-  version: 1.7.1
+  version: 1.7.2
   manager: conda
   platform: linux-64
   dependencies:
     click: '>=7,<9'
     python: '>=3.7'
     rich: '>=10'
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-click-1.7.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-click-1.7.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 2795aab9e8b40af88c799fb2355194f9
-    sha256: e783d0f6bdc851e1a1fdba1fb1ab045462e03f8a9a3aaf9b7a63ecb4a9478341
+    md5: fe1eae76a71246959cefd09b5b00869b
+    sha256: 4bfddbc5716a09bfea1c3345b1eed0ddb36d0e55f357afb60ca3e73c9231cc68
   category: main
   optional: false
 - name: ruamel.yaml
@@ -4865,18 +4835,18 @@ package:
   category: main
   optional: false
 - name: s3fs
-  version: 2023.10.0
+  version: 2023.12.2
   manager: conda
   platform: linux-64
   dependencies:
-    aiobotocore: '>=2.7.0,<2.7.1'
+    aiobotocore: '>=2.5.4,<3.0.0'
     aiohttp: ''
-    fsspec: 2023.10.0
+    fsspec: 2023.12.2
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2023.10.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2023.12.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 557aa3617c92aa511841887db279dc51
-    sha256: 2f190cf0c550d4ba400af6b62afefa47a01ff5b57ece67354d38037a304f0acb
+    md5: e6de0e35f836bef08cbcfeb50337d2a4
+    sha256: d3bdcc9eb8c61a383a1199d62f9c20c124fbcf46289600bfe3dfbdd7f813d7d3
   category: main
   optional: false
 - name: scipy
@@ -5059,19 +5029,19 @@ package:
   category: main
   optional: false
 - name: sqlite
-  version: 3.44.0
+  version: 3.44.2
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libsqlite: 3.44.0
+    libsqlite: 3.44.2
     libzlib: '>=1.2.13,<1.3.0a0'
     ncurses: '>=6.4,<7.0a0'
     readline: '>=8.2,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.44.0-h2c6b66d_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.44.2-h2c6b66d_0.conda
   hash:
-    md5: df56c636df4a98990462d66ac7be2330
-    sha256: ae7031a471868c7057cc16eded7bb58fa3723d9c1650c9d3eb8de1ff65d89dbb
+    md5: 4f2892c672829693fd978d065db4e8be
+    sha256: bae479520fe770fe11996b4c240923ed097f851fbd2401d55540e551c9dbbef7
   category: main
   optional: false
 - name: stack_data
@@ -5109,15 +5079,15 @@ package:
   category: main
   optional: false
 - name: tblib
-  version: 2.0.0
+  version: 3.0.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tblib-2.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: f5580336fe091d46f9a2ea97da044550
-    sha256: 25557d772df1572e48e4c678d5825ace6411d7b6773f2d7ad4e06111bce12031
+    md5: 04eedddeb68ad39871c8127dd1c21f4f
+    sha256: 2e2c255b6f24a6d75b9938cb184520e27db697db2c24f04e18342443ae847c0a
   category: main
   optional: false
 - name: text-unidecode
@@ -5253,39 +5223,39 @@ package:
   category: main
   optional: false
 - name: traitlets
-  version: 5.13.0
+  version: 5.14.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 8a9953c15e1e5a7c1baddbbf4511a567
-    sha256: 7ac67960ba2e8c16818043cc65ac6190fa4fd95f5b24357df58e4f73d5e60a10
+    md5: 886f4a84ddb49b943b1697ac314e85b3
+    sha256: c32412029033264140926be474d327d7fd57c0d11db9b1745396b3d4db78a799
   category: main
   optional: false
 - name: typing-extensions
-  version: 4.8.0
+  version: 4.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    typing_extensions: 4.8.0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+    typing_extensions: 4.9.0
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.9.0-hd8ed1ab_0.conda
   hash:
-    md5: 384462e63262a527bda564fa2d9126c0
-    sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
+    md5: c16524c1b7227dc80b36b4fa6f77cc86
+    sha256: d795c1eb1db4ea147f01ece74e5a504d7c2e8d5ee8c11ec987884967dd938f9c
   category: main
   optional: false
 - name: typing_extensions
-  version: 4.8.0
+  version: 4.9.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.9.0-pyha770c72_0.conda
   hash:
-    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
-    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
+    md5: a92a6440c3fe7052d63244f3aba2a4a7
+    sha256: f3c5be8673bfd905c4665efcb27fa50192f24f84fa8eff2f19cba5d09753d905
   category: main
   optional: false
 - name: tzcode
@@ -5397,31 +5367,30 @@ package:
   category: main
   optional: false
 - name: virtualenv
-  version: 20.24.6
+  version: 20.25.0
   manager: conda
   platform: linux-64
   dependencies:
     distlib: <1,>=0.3.7
     filelock: <4,>=3.12.2
-    platformdirs: <4,>=3.9.1
+    platformdirs: <5,>=3.9.1
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.24.6-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.25.0-pyhd8ed1ab_0.conda
   hash:
-    md5: fb1fc875719e217ed799a7aae11d3be4
-    sha256: 09492f89a22dc17d9b32f2a791deee93d06e99fb312c3d47430fe35343b7fbde
+    md5: c119653cba436d8183c27bf6d190e587
+    sha256: 50827c3721a9dbf973b568709d4381add2a6552fa562f26a385c5edc16a534af
   category: main
   optional: false
 - name: wcwidth
-  version: 0.2.10
+  version: 0.2.12
   manager: conda
   platform: linux-64
   dependencies:
-    backports.functools_lru_cache: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.10-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.12-pyhd8ed1ab_0.conda
   hash:
-    md5: 48978e4e99db7d1ee0d277f6dee20684
-    sha256: e988673c05416073d0e776bac223b6c79fb5cc1207291c6c6f9e238624a135c0
+    md5: bf4a1d1a97ca27b0b65bacd9e238b484
+    sha256: ca757d0fc2dbd422af9d3238a8b4b630a6e11df3707a447bd89540656770d1d7
   category: main
   optional: false
 - name: webencodings
@@ -5451,7 +5420,7 @@ package:
   category: main
   optional: false
 - name: xarray
-  version: 2023.11.0
+  version: 2023.12.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5459,10 +5428,10 @@ package:
     packaging: '>=21.3'
     pandas: '>=1.4'
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.11.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2023.12.0-pyhd8ed1ab_0.conda
   hash:
-    md5: f445b20bac3db8f604a48592087b2d8f
-    sha256: 71a2000fd5f5065e8c9a184c3f9262b27c4a5eeb5366a6d7e4d267d28e9f07d9
+    md5: e9b31d3ab1b0dd5fd8c24419f6560b90
+    sha256: ab89b70aa3d31a9cacf0e91a7c7a6f8cc45d866d71cdcee1219561cff0e8a9a5
   category: main
   optional: false
 - name: xcb-util
@@ -5791,7 +5760,7 @@ package:
   category: main
   optional: false
 - name: yarl
-  version: 1.9.2
+  version: 1.9.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -5800,10 +5769,10 @@ package:
     multidict: '>=4.0'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.9.2-py310h2372a71_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.9.3-py310h2372a71_0.conda
   hash:
-    md5: 30ae8a8f248b4e7cd2622cff41cb05a7
-    sha256: 0a9aeb8cf885ef6dd0a737693823a4e4d27b2ee724fa3af317d8ccd925fa4258
+    md5: 10246f66639d9ca55e790410f0dbb465
+    sha256: 159e9e292f841477dd1e4c897c055d364472720c79b16fa329faee1e7b878564
   category: main
   optional: false
 - name: zict

--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,7 @@ dependencies:
   - pytest-cov ~=4.1.0
   - mypy ==1.7.0
   - pyfakefs ~=5.2.4
+  - pytest-order ~=1.0.1
 
   # other utilities
   - bump-my-version ~=0.10.0

--- a/scripts/gather_ancillary_fields.py
+++ b/scripts/gather_ancillary_fields.py
@@ -24,9 +24,9 @@ from pm_icecon.land_spillover import create_land90
 from pm_icecon.nt.params.amsr2 import get_amsr2_params
 from pm_tb_data._types import NORTH, SOUTH, Hemisphere
 
+from seaice_ecdr.ancillary import get_ancillary_filepath
 from seaice_ecdr.constants import NSIDC_NFS_SHARE_DIR
 from seaice_ecdr.grid_id import get_grid_id
-from seaice_ecdr.masks import get_ancillary_filepath
 
 # originally from `pm_icecon`
 BOOTSTRAP_MASKS_DIR = NSIDC_NFS_SHARE_DIR / "bootstrap_masks"

--- a/seaice_ecdr/ancillary.py
+++ b/seaice_ecdr/ancillary.py
@@ -195,6 +195,10 @@ def get_invalid_ice_mask(
 
     invalid_ice_mask = ancillary_ds.invalid_ice_mask.sel(month=month)
 
+    # The invalid ice mask is indexed by month in the ancillary dataset. Drop
+    # that coordinate.
+    invalid_ice_mask = invalid_ice_mask.drop_vars("month")
+
     return invalid_ice_mask
 
 

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -249,7 +249,6 @@ def complete_daily_ecdr_dataset_for_au_si_tbs(
     date: dt.date,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    interp_range: int = 5,
     ecdr_data_dir: Path,
 ) -> xr.Dataset:
     """Create xr dataset containing the complete daily enhanced CDR.
@@ -371,15 +370,12 @@ def make_cdecdr_netcdf(
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     ecdr_data_dir: Path,
-    interp_range: int = 5,
-    fill_the_pole_hole: bool = True,
-) -> None:
+) -> Path:
     logger.info(f"Creating cdecdr for {date=}, {hemisphere=}, {resolution=}")
     cde_ds = complete_daily_ecdr_dataset_for_au_si_tbs(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        interp_range=interp_range,
         ecdr_data_dir=ecdr_data_dir,
     )
 
@@ -397,6 +393,8 @@ def make_cdecdr_netcdf(
         output_filepath=output_path,
     )
     logger.info(f"Wrote complete daily ncfile: {written_cde_ncfile}")
+
+    return output_path
 
 
 def read_or_create_and_read_cdecdr_ds(

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -227,7 +227,7 @@ def create_melt_onset_field(
         hemisphere=hemisphere,
         resolution=resolution,
     )
-    is_melted_today[land_mask] = False
+    is_melted_today[0, land_mask.data] = False
 
     have_prior_melt_values = prior_melt_onset_field != no_melt_flag
     is_missing_prior = prior_melt_onset_field == no_melt_flag

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -18,6 +18,7 @@ from pm_tb_data._types import NORTH, SOUTH, Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import (
+    get_land_mask,
     get_surfacetype_da,
 )
 from seaice_ecdr.cli.util import datetime_to_date
@@ -221,6 +222,12 @@ def create_melt_onset_field(
         tb_h19=tb_h19,
         tb_h37=tb_h37,
     )
+    # Apply land mask
+    land_mask = get_land_mask(
+        hemisphere=hemisphere,
+        resolution=resolution,
+    )
+    is_melted_today[land_mask] = False
 
     have_prior_melt_values = prior_melt_onset_field != no_melt_flag
     is_missing_prior = prior_melt_onset_field == no_melt_flag

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -9,7 +9,7 @@ NSIDC_NFS_SHARE_DIR = Path("/share/apps/amsr2-cdr")
 # TODO: dev-specific directories for the outputs!
 
 # Outputs from the `seaice_ecdr` go to these locations.
-BASE_OUTPUT_DIR = NSIDC_NFS_SHARE_DIR / f"ecdr_{ECDR_PRODUCT_VERSION}_outputs"
+BASE_OUTPUT_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_outputs"
 
 # Daily initial/intermiedate output for 'standard' (not NRT) ECDR processing
 # (e.g, using input data from AU_SI12)
@@ -24,4 +24,4 @@ NRT_BASE_OUTPUT_DIR = BASE_OUTPUT_DIR / "nrt"
 LANCE_NRT_DATA_DIR = NSIDC_NFS_SHARE_DIR / "lance_amsr2_nrt_data"
 
 # Location of surface mask & geo-information files.
-CDR_ANCILLARY_DIR = NSIDC_NFS_SHARE_DIR / "cdrv5_ancillary"
+CDR_ANCILLARY_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_ancillary"

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -711,6 +711,8 @@ def compute_initial_daily_ecdr_dataset(
     #  32: Spatial interpolation applied
     #  64: *applied later* Temporal interpolation applied
     # 128: *applied later* Melt onset detected
+    # TODO: dynamically read the bitmask values from the source dataset
+    # (`flag_masks` & `flag_meanings`)
     qa_bitmask = np.zeros((ydim, xdim), dtype=np.uint8)
     qa_bitmask[ecdr_ide_ds["bt_weather_mask"].data[0, :, :]] += 1
     qa_bitmask[ecdr_ide_ds["nt_weather_mask"].data[0, :, :]] += 2

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -322,6 +322,8 @@ def compute_initial_daily_ecdr_dataset(
             != ecdr_ide_ds[si_varname].data[0, :, :]
         ) & (~np.isnan(ecdr_ide_ds[si_varname].data[0, :, :]))
         spatint_bitmask_arr[is_tb_si_diff] += TB_SPATINT_BITMASK_MAP[tbname]
+        land_mask = get_land_mask(hemisphere=hemisphere, resolution=resolution)
+        spatint_bitmask_arr[land_mask.data] = 0
 
     ecdr_ide_ds["spatial_interpolation_flag"] = (
         ("time", "y", "x"),
@@ -716,6 +718,8 @@ def compute_initial_daily_ecdr_dataset(
     qa_bitmask[invalid_tb_mask & ~ecdr_ide_ds["invalid_ice_mask"].data[0, :, :]] += 8
     qa_bitmask[ecdr_ide_ds["invalid_ice_mask"].data[0, :, :]] += 16
     qa_bitmask[ecdr_ide_ds["spatial_interpolation_flag"].data[0, :, :] != 0] += 32
+    qa_bitmask[land_mask] = 0
+
     ecdr_ide_ds["qa_of_cdr_seaice_conc"] = (
         ("time", "y", "x"),
         np.expand_dims(qa_bitmask, axis=0),

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -814,10 +814,7 @@ def write_ide_netcdf(
     )
 
     # Return the path if it exists
-    if output_filepath.exists():
-        return output_filepath
-    else:
-        return Path("")
+    return output_filepath
 
 
 @cache

--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -527,7 +527,7 @@ def make_monthly_ds(
     monthly_ds = _assign_time_to_monthly_ds(
         monthly_ds=monthly_ds,
         year=daily_ds_for_month.year,
-        month=int(daily_ds_for_month.month.values),
+        month=daily_ds_for_month.month,
     )
 
     monthly_ds["crs"] = daily_ds_for_month.crs.isel(time=0).drop_vars("time")

--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -527,7 +527,7 @@ def make_monthly_ds(
     monthly_ds = _assign_time_to_monthly_ds(
         monthly_ds=monthly_ds,
         year=daily_ds_for_month.year,
-        month=daily_ds_for_month.month,
+        month=int(daily_ds_for_month.month.values),
     )
 
     monthly_ds["crs"] = daily_ds_for_month.crs.isel(time=0).drop_vars("time")

--- a/seaice_ecdr/tests/integration/__init__.py
+++ b/seaice_ecdr/tests/integration/__init__.py
@@ -1,0 +1,23 @@
+from functools import cache
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+
+@cache
+def _get_cached_tmpdir():
+    tmpdir = TemporaryDirectory()
+
+    return tmpdir
+
+
+@pytest.fixture(scope="session")
+def ecdr_data_dir_test_path():
+    """Session-scoped fixture providing temporary dir representing ECDR data dir."""
+    tmpdir = _get_cached_tmpdir()
+    tmppath = Path(tmpdir.name)
+
+    yield tmppath
+
+    tmpdir.cleanup()

--- a/seaice_ecdr/tests/integration/test_complete_daily.py
+++ b/seaice_ecdr/tests/integration/test_complete_daily.py
@@ -1,0 +1,18 @@
+import datetime as dt
+
+from pm_tb_data._types import NORTH
+
+from seaice_ecdr.complete_daily_ecdr import make_cdecdr_netcdf
+from seaice_ecdr.tests.integration import ecdr_data_dir_test_path  # noqa
+
+
+def test_make_cdecdr_netcdf(ecdr_data_dir_test_path):  # noqa
+    for day in range(1, 5):
+        output_path = make_cdecdr_netcdf(
+            date=dt.date(2022, 3, day),
+            hemisphere=NORTH,
+            resolution="12.5",
+            ecdr_data_dir=ecdr_data_dir_test_path,
+        )
+
+        assert output_path.is_file()

--- a/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
+++ b/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
@@ -1,7 +1,6 @@
 """Tests for initial daily ECDR generation."""
 
 import datetime as dt
-import sys
 from pathlib import Path
 from typing import Final
 
@@ -10,14 +9,14 @@ import xarray as xr
 from loguru import logger
 from pm_tb_data._types import NORTH
 
-from seaice_ecdr.initial_daily_ecdr import get_idecdr_filepath, make_idecdr_netcdf
+from seaice_ecdr.initial_daily_ecdr import (
+    get_idecdr_filepath,
+    make_idecdr_netcdf,
+    write_ide_netcdf,
+)
 from seaice_ecdr.initial_daily_ecdr import (
     initial_daily_ecdr_dataset_for_au_si_tbs as compute_idecdr_ds,
 )
-
-# Set the default minimum log notification to Warning
-logger.remove(0)  # Removes previous logger info
-logger.add(sys.stderr, level="WARNING")
 
 cdr_conc_fieldname = "conc"
 
@@ -65,13 +64,21 @@ def test_seaice_idecdr_can_output_to_netcdf(
 
     # NH
     sample_output_filepath_nh = tmp_path / "sample_idecdr_nh.nc"
-    sample_idecdr_dataset_nh.to_netcdf(sample_output_filepath_nh)
-    assert sample_output_filepath_nh.is_file()
+    written_path = write_ide_netcdf(
+        ide_ds=sample_idecdr_dataset_nh,
+        output_filepath=sample_output_filepath_nh,
+    )
+    assert sample_output_filepath_nh == written_path
+    assert sample_output_filepath_nh.exists()
 
     # SH
     sample_output_filepath_sh = tmp_path / "sample_idecdr_sh.nc"
-    sample_idecdr_dataset_sh.to_netcdf(sample_output_filepath_sh)
-    assert sample_output_filepath_sh.is_file()
+    written_path = write_ide_netcdf(
+        ide_ds=sample_idecdr_dataset_sh,
+        output_filepath=sample_output_filepath_sh,
+    )
+    assert sample_output_filepath_sh == written_path
+    assert sample_output_filepath_sh.exists()
 
 
 def test_seaice_idecdr_is_Dataset(

--- a/seaice_ecdr/tests/integration/test_monthly.py
+++ b/seaice_ecdr/tests/integration/test_monthly.py
@@ -1,0 +1,31 @@
+import pytest
+import xarray as xr
+from pm_tb_data._types import NORTH
+
+from seaice_ecdr import monthly
+from seaice_ecdr.tests.integration import ecdr_data_dir_test_path  # noqa
+
+
+@pytest.mark.order(after="test_complete_daily.py::test_make_cdecdr_netcdf")
+def test_make_monthly_nc(ecdr_data_dir_test_path, monkeypatch):  # noqa
+    # usually we require at least 20 days of data for a valid month. This mock
+    # data is just 3 days in size, so we need to mock the
+    # "check_min_days_for_valid_month" function.
+    monkeypatch.setattr(
+        monthly, "check_min_days_for_valid_month", lambda *_args, **_kwargs: True
+    )
+
+    output_path = monthly.make_monthly_nc(
+        year=2022,
+        month=3,
+        hemisphere=NORTH,
+        resolution="12.5",
+        ecdr_data_dir=ecdr_data_dir_test_path,
+    )
+
+    assert output_path.is_file()
+
+    # Confirm that the netcdf file is readable and matches the dataset provided
+    # by `make_monthly_ds`
+    ds = xr.open_dataset(output_path)
+    assert ds is not None

--- a/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
+++ b/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
@@ -12,11 +12,7 @@ from typing import Final
 from loguru import logger
 from pm_tb_data._types import NORTH
 
-from seaice_ecdr.initial_daily_ecdr import (
-    get_idecdr_filepath,
-    initial_daily_ecdr_dataset_for_au_si_tbs,
-    write_ide_netcdf,
-)
+from seaice_ecdr.initial_daily_ecdr import get_idecdr_filepath
 from seaice_ecdr.temporal_composite_daily import (
     make_tiecdr_netcdf,
     read_or_create_and_read_idecdr_ds,
@@ -36,28 +32,9 @@ hemisphere = NORTH
 resolution: Final = "12.5"
 
 
-def test_create_ide_file(tmpdir):
-    """Verify that initial daily ecdr file can be created."""
-    sample_ide_filepath = get_idecdr_filepath(
-        date=date,
-        hemisphere=hemisphere,
-        resolution=resolution,
-        ecdr_data_dir=Path(tmpdir),
-    )
-
-    test_ide_ds = initial_daily_ecdr_dataset_for_au_si_tbs(
-        date=date, hemisphere=hemisphere, resolution=resolution
-    )
-    written_path = write_ide_netcdf(
-        ide_ds=test_ide_ds,
-        output_filepath=sample_ide_filepath,
-    )
-    assert sample_ide_filepath == written_path
-    assert sample_ide_filepath.exists()
-
-
 def test_read_or_create_and_read_idecdr_ds(tmpdir):
     """Verify that initial daily ecdr file can be created."""
+
     sample_ide_filepath = get_idecdr_filepath(
         date=date,
         hemisphere=hemisphere,

--- a/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
+++ b/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
@@ -116,6 +116,7 @@ def test_temporal_composite_max_interp_range_9():
             target_date=dt.date(2020, 1, 1),
             da=xr.DataArray(coords=(range(2), range(3), range(4))),
             interp_range=10,
+            land_mask=xr.DataArray([False, False, False]),
         )
 
 
@@ -152,10 +153,11 @@ def test_temporal_composite_da_oneday():
 
     # Note: the key is to test that if interp_range is zero,
     #       then the output will equal the input
-    temporal_composite, temporal_flags = temporally_composite_dataarray(
+    temporal_composite, _ = temporally_composite_dataarray(
         target_date=mock_date,
         da=initial_data_array,
         interp_range=0,
+        land_mask=xr.full_like(initial_data_array.isel(time=0), False, dtype=bool),
     )
 
     assert np.array_equal(temporal_composite, initial_data_array, equal_nan=True)
@@ -271,6 +273,7 @@ def test_temporal_composite_da_multiday():
         target_date=mock_date,
         da=input_data_array,
         interp_range=time_spread,
+        land_mask=xr.full_like(input_data_array.isel(time=0), False, dtype=bool),
     )
 
     assert np.array_equal(


### PR DESCRIPTION
Note that e.g., the spatial and temporal interpoloation flag values still have values of 0 over land, but that is expected. We don't use a fill/missing value for these fields because we want to ensure they remain as `byte`s when read by other programs.