### PR TITLE
Rename ancillary dir

### DIFF
--- a/scripts/gather_ancillary_fields.py
+++ b/scripts/gather_ancillary_fields.py
@@ -24,9 +24,9 @@ from pm_icecon.land_spillover import create_land90
 from pm_icecon.nt.params.amsr2 import get_amsr2_params
 from pm_tb_data._types import NORTH, SOUTH, Hemisphere
 
+from seaice_ecdr.ancillary import get_ancillary_filepath
 from seaice_ecdr.constants import NSIDC_NFS_SHARE_DIR
 from seaice_ecdr.grid_id import get_grid_id
-from seaice_ecdr.masks import get_ancillary_filepath
 
 # originally from `pm_icecon`
 BOOTSTRAP_MASKS_DIR = NSIDC_NFS_SHARE_DIR / "bootstrap_masks"

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -24,4 +24,4 @@ NRT_BASE_OUTPUT_DIR = BASE_OUTPUT_DIR / "nrt"
 LANCE_NRT_DATA_DIR = NSIDC_NFS_SHARE_DIR / "lance_amsr2_nrt_data"
 
 # Location of surface mask & geo-information files.
-CDR_ANCILLARY_DIR = NSIDC_NFS_SHARE_DIR / "cdrv5_ancillary"
+CDR_ANCILLARY_DIR = NSIDC_NFS_SHARE_DIR / f"ecdr_{ECDR_PRODUCT_VERSION}_ancillary"

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -9,7 +9,7 @@ NSIDC_NFS_SHARE_DIR = Path("/share/apps/amsr2-cdr")
 # TODO: dev-specific directories for the outputs!
 
 # Outputs from the `seaice_ecdr` go to these locations.
-BASE_OUTPUT_DIR = NSIDC_NFS_SHARE_DIR / f"ecdr_{ECDR_PRODUCT_VERSION}_outputs"
+BASE_OUTPUT_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_outputs"
 
 # Daily initial/intermiedate output for 'standard' (not NRT) ECDR processing
 # (e.g, using input data from AU_SI12)
@@ -24,4 +24,4 @@ NRT_BASE_OUTPUT_DIR = BASE_OUTPUT_DIR / "nrt"
 LANCE_NRT_DATA_DIR = NSIDC_NFS_SHARE_DIR / "lance_amsr2_nrt_data"
 
 # Location of surface mask & geo-information files.
-CDR_ANCILLARY_DIR = NSIDC_NFS_SHARE_DIR / f"ecdr_{ECDR_PRODUCT_VERSION}_ancillary"
+CDR_ANCILLARY_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_ancillary"


### PR DESCRIPTION
Make the ancillary dir name consistent w/ the base output dir (include the entire version string).