### PR TITLE
Simplify platform start date overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,6 @@ module = [
   "setuptools.*",
   "netCDF4.*",
   "rasterio.*",
-  "seaice.*",
+  "yaml.*",
 ]
 ignore_missing_imports = true

--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -17,10 +17,6 @@ from seaice_ecdr.complete_daily_ecdr import get_ecdr_filepath
 from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
 from seaice_ecdr.nc_attrs import get_global_attrs
 from seaice_ecdr.nc_util import concatenate_nc_files
-from seaice_ecdr.platforms import (
-    PLATFORM_START_DATES_DEFAULT,
-    read_platform_start_dates_cfg,
-)
 from seaice_ecdr.util import sat_from_filename, standard_daily_aggregate_filename
 
 
@@ -32,7 +28,6 @@ def _get_daily_complete_filepaths_for_year(
     ecdr_data_dir: Path,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    platform_start_dates,
 ) -> list[Path]:
     data_list = []
     for period in pd.period_range(start=dt.date(year, 1, 1), end=dt.date(year, 12, 31)):
@@ -41,7 +36,6 @@ def _get_daily_complete_filepaths_for_year(
             hemisphere=hemisphere,
             resolution=resolution,
             ecdr_data_dir=ecdr_data_dir,
-            platform_start_dates=platform_start_dates,
         )
         if expected_fp.is_file():
             data_list.append(expected_fp)
@@ -115,14 +109,12 @@ def make_daily_aggregate_netcdf_for_year(
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     ecdr_data_dir: Path,
-    platform_start_dates,
 ) -> None:
     daily_filepaths = _get_daily_complete_filepaths_for_year(
         year=year,
         ecdr_data_dir=ecdr_data_dir,
         hemisphere=hemisphere,
         resolution=resolution,
-        platform_start_dates=platform_start_dates,
     )
 
     # Create a temporary dir to store a WIP netcdf file. We do this because
@@ -207,19 +199,6 @@ def make_daily_aggregate_netcdf_for_year(
     help="Year for which to create the monthly file.",
     default=None,
 )
-@click.option(
-    "--start-dates-cfg",
-    required=False,
-    type=click.Path(
-        exists=True,
-        file_okay=True,
-        dir_okay=False,
-        resolve_path=True,
-        path_type=Path,
-    ),
-    default=None,
-    help="If given, this is the name of a yaml file with platform_start_dates dict",
-)
 def cli(
     *,
     year: int,
@@ -227,15 +206,9 @@ def cli(
     ecdr_data_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     end_year: int | None,
-    start_dates_cfg: Path | None,
 ) -> None:
     if end_year is None:
         end_year = year
-
-    if start_dates_cfg is None:
-        platform_start_dates = PLATFORM_START_DATES_DEFAULT
-    else:
-        platform_start_dates = read_platform_start_dates_cfg(start_dates_cfg)
 
     for year_to_process in range(year, end_year + 1):
         make_daily_aggregate_netcdf_for_year(
@@ -243,5 +216,4 @@ def cli(
             hemisphere=hemisphere,
             resolution=resolution,
             ecdr_data_dir=ecdr_data_dir,
-            platform_start_dates=platform_start_dates,
         )

--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -40,10 +40,6 @@ from seaice_ecdr.ancillary import flag_value_for_meaning
 from seaice_ecdr.complete_daily_ecdr import get_ecdr_filepath
 from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
 from seaice_ecdr.nc_attrs import get_global_attrs
-from seaice_ecdr.platforms import (
-    PLATFORM_START_DATES_DEFAULT,
-    read_platform_start_dates_cfg,
-)
 from seaice_ecdr.util import sat_from_filename, standard_monthly_filename
 
 
@@ -74,7 +70,6 @@ def _get_daily_complete_filepaths_for_month(
     ecdr_data_dir: Path,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    platform_start_dates,
 ) -> list[Path]:
     """Return a list of paths to ECDR daily complete filepaths for the given year and month."""
     data_list = []
@@ -89,7 +84,6 @@ def _get_daily_complete_filepaths_for_month(
             hemisphere=hemisphere,
             resolution=resolution,
             ecdr_data_dir=ecdr_data_dir,
-            platform_start_dates=platform_start_dates,
         )
         if expected_fp.is_file():
             data_list.append(expected_fp)
@@ -127,7 +121,6 @@ def get_daily_ds_for_month(
     ecdr_data_dir: Path,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    platform_start_dates,
 ) -> xr.Dataset:
     """Create an xr.Dataset wtih ECDR complete daily data for a given year and month.
 
@@ -141,7 +134,6 @@ def get_daily_ds_for_month(
         ecdr_data_dir=ecdr_data_dir,
         hemisphere=hemisphere,
         resolution=resolution,
-        platform_start_dates=platform_start_dates,
     )
     # Read all of the complete daily data for the given year and month.
     ds = xr.open_mfdataset(data_list)
@@ -629,7 +621,6 @@ def make_monthly_nc(
     hemisphere: Hemisphere,
     ecdr_data_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    platform_start_dates,
 ) -> Path:
     daily_ds_for_month = get_daily_ds_for_month(
         year=year,
@@ -637,7 +628,6 @@ def make_monthly_nc(
         ecdr_data_dir=ecdr_data_dir,
         hemisphere=hemisphere,
         resolution=resolution,
-        platform_start_dates=platform_start_dates,
     )
 
     sat = daily_ds_for_month.sat
@@ -748,17 +738,11 @@ def cli(
     hemisphere: Hemisphere,
     ecdr_data_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    start_dates_cfg: Path | None,
 ):
     if end_year is None:
         end_year = year
     if end_month is None:
         end_month = month
-
-    if start_dates_cfg is None:
-        platform_start_dates = PLATFORM_START_DATES_DEFAULT
-    else:
-        platform_start_dates = read_platform_start_dates_cfg(start_dates_cfg)
 
     for period in pd.period_range(
         start=pd.Period(year=year, month=month, freq="M"),
@@ -771,5 +755,4 @@ def cli(
             ecdr_data_dir=ecdr_data_dir,
             hemisphere=hemisphere,
             resolution=resolution,
-            platform_start_dates=platform_start_dates,
         )

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -19,9 +19,7 @@ from seaice_ecdr.initial_daily_ecdr import (
     write_ide_netcdf,
 )
 from seaice_ecdr.platforms import (
-    PLATFORM_START_DATES_DEFAULT,
     get_platform_by_date,
-    read_platform_start_dates_cfg,
 )
 
 
@@ -31,7 +29,6 @@ def compute_nrt_initial_daily_ecdr_dataset(
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     lance_amsr2_input_dir: Path,
-    platform_start_dates,
 ):
     """Create an initial daily ECDR NetCDF using NRT LANCE AMSR2 data."""
     xr_tbs = access_local_lance_data(
@@ -45,7 +42,6 @@ def compute_nrt_initial_daily_ecdr_dataset(
         hemisphere=hemisphere,
         resolution=resolution,
         xr_tbs=xr_tbs,
-        platform_start_dates=platform_start_dates,
     )
 
     return nrt_initial_ecdr_ds
@@ -140,19 +136,6 @@ def download_latest_nrt_data(*, output_dir: Path, overwrite: bool) -> None:
     default=LANCE_NRT_DATA_DIR,
     help="Directory in which LANCE AMSR2 NRT files are located.",
 )
-@click.option(
-    "--start-dates-cfg",
-    required=False,
-    type=click.Path(
-        exists=True,
-        file_okay=True,
-        dir_okay=False,
-        resolve_path=True,
-        path_type=Path,
-    ),
-    default=None,
-    help="If given, this is the name of a yaml file with platform_start_dates dict",
-)
 def nrt_initial_daily_ecdr(
     *,
     date: dt.date,
@@ -160,26 +143,19 @@ def nrt_initial_daily_ecdr(
     ecdr_data_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     lance_amsr2_input_dir: Path,
-    start_dates_cfg: Path | None,
 ):
     """Create an initial daily ECDR NetCDF using NRT LANCE AMSR2 data.
 
     TODO: Consider renaming this: nrt_initial_daily_ecdr_netcdf()
     """
-    if start_dates_cfg is None:
-        platform_start_dates = PLATFORM_START_DATES_DEFAULT
-    else:
-        platform_start_dates = read_platform_start_dates_cfg(start_dates_cfg)
-
     nrt_initial_ecdr_ds = compute_nrt_initial_daily_ecdr_dataset(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
         lance_amsr2_input_dir=lance_amsr2_input_dir,
-        platform_start_dates=platform_start_dates,
     )
 
-    platform = get_platform_by_date(date, platform_start_dates)
+    platform = get_platform_by_date(date)
     output_path = get_idecdr_filepath(
         hemisphere=hemisphere,
         date=date,

--- a/seaice_ecdr/platforms.py
+++ b/seaice_ecdr/platforms.py
@@ -55,22 +55,7 @@ PLATFORM_AVAILABILITY: OrderedDict[SUPPORTED_SAT, dict] = OrderedDict(
 )
 
 
-"""
 PLATFORM_START_DATES: OrderedDict[dt.date, str] = OrderedDict(
-    {
-        dt.date(1978, 10, 25): "n07",
-        dt.date(1987, 7, 10): "F08",
-        dt.date(1991, 12, 3): "F11",
-        dt.date(1995, 10, 1): "F13",
-        dt.date(2008, 1, 1): "F17",
-        # dt.date(2002, 6, 1): 'ame',   # AMSR-E...
-        # dt.date(2011, 10, 4): 'F17',  # followed by f17 (again)
-        dt.date(2012, 7, 3): "am2",
-    }
-)
-"""
-
-PLATFORM_START_DATES_DEFAULT: OrderedDict[dt.date, str] = OrderedDict(
     {
         dt.date(1978, 10, 25): "n07",
         dt.date(1987, 7, 10): "F08",
@@ -134,7 +119,7 @@ def _platform_available_for_date(
 def _platform_start_dates_are_consistent(
     *,
     # platform_start_dates: OrderedDict = PLATFORM_START_DATES,
-    platform_start_dates: OrderedDict = PLATFORM_START_DATES_DEFAULT,
+    platform_start_dates: OrderedDict = PLATFORM_START_DATES,
     platform_availability: OrderedDict = PLATFORM_AVAILABILITY,
 ) -> bool:
     """Return whether the provided start date structure is valid."""
@@ -182,9 +167,8 @@ def _platform_start_dates_are_consistent(
 
 def get_platform_by_date(
     date: dt.date,
-    # platform_start_dates: OrderedDict = PLATFORM_START_DATES,
-    # platform_start_dates: OrderedDict = PLATFORM_START_DATES_DEFAULT,
-    platform_start_dates: OrderedDict,
+    *,
+    platform_start_dates: OrderedDict = PLATFORM_START_DATES,
     platform_availability: OrderedDict = PLATFORM_AVAILABILITY,
 ) -> str:
     """Return the platform for this date."""

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -28,9 +28,7 @@ from seaice_ecdr.initial_daily_ecdr import (
     make_idecdr_netcdf,
 )
 from seaice_ecdr.platforms import (
-    PLATFORM_START_DATES_DEFAULT,
     get_platform_by_date,
-    read_platform_start_dates_cfg,
 )
 from seaice_ecdr.util import standard_daily_filename
 
@@ -136,17 +134,15 @@ def get_tie_filepath(
     hemisphere,
     resolution,
     ecdr_data_dir: Path,
-    platform_start_dates,
 ) -> Path:
     """Return the complete daily tie file path."""
 
-    platform = get_platform_by_date(date, platform_start_dates)
+    platform = get_platform_by_date(date)
     sat = cast(SUPPORTED_SAT, platform)
 
     standard_fn = standard_daily_filename(
         hemisphere=hemisphere,
         date=date,
-        # sat="am2",
         sat=sat,
         resolution=resolution,
     )
@@ -341,7 +337,6 @@ def temporally_composite_dataarray(
 def read_or_create_and_read_idecdr_ds(
     *,
     date: dt.date,
-    platform_start_dates,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     ecdr_data_dir: Path,
@@ -350,7 +345,6 @@ def read_or_create_and_read_idecdr_ds(
     """Read an idecdr netCDF file, creating it if it doesn't exist."""
     platform = get_platform_by_date(
         date,
-        platform_start_dates=platform_start_dates,
     )
 
     ide_filepath = get_idecdr_filepath(
@@ -376,7 +370,6 @@ def read_or_create_and_read_idecdr_ds(
         ]
         make_idecdr_netcdf(
             date=date,
-            platform_start_dates=platform_start_dates,
             hemisphere=hemisphere,
             resolution=resolution,
             ecdr_data_dir=ecdr_data_dir,
@@ -526,7 +519,6 @@ def filter_field_via_bitmask(
 def temporally_interpolated_ecdr_dataset(
     *,
     date: dt.date,
-    platform_start_dates,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     interp_range: int = 5,
@@ -547,7 +539,6 @@ def temporally_interpolated_ecdr_dataset(
         hemisphere=hemisphere,
         resolution=resolution,
         ecdr_data_dir=ecdr_data_dir,
-        platform_start_dates=platform_start_dates,
     )
 
     # Copy ide_ds to a new xr tiecdr dataset
@@ -568,7 +559,6 @@ def temporally_interpolated_ecdr_dataset(
             "hemisphere": hemisphere,
             "resolution": resolution,
             "ecdr_data_dir": ecdr_data_dir,
-            "platform_start_dates": platform_start_dates,
         },
     )
 
@@ -629,7 +619,7 @@ def temporally_interpolated_ecdr_dataset(
     #       grid is having its pole hole filled!
     if fill_the_pole_hole and hemisphere == NORTH:
         cdr_conc_pre_polefill = cdr_conc.copy()
-        platform = get_platform_by_date(date, platform_start_dates)
+        platform = get_platform_by_date(date)
         near_pole_hole_mask = nh_polehole_mask(
             date=date, resolution=resolution, sat=platform
         )
@@ -690,7 +680,6 @@ def temporally_interpolated_ecdr_dataset(
             "hemisphere": hemisphere,
             "resolution": resolution,
             "ecdr_data_dir": ecdr_data_dir,
-            "platform_start_dates": platform_start_dates,
         },
     )
 
@@ -719,7 +708,6 @@ def temporally_interpolated_ecdr_dataset(
             "hemisphere": hemisphere,
             "resolution": resolution,
             "ecdr_data_dir": ecdr_data_dir,
-            "platform_start_dates": platform_start_dates,
         },
     )
 
@@ -738,7 +726,7 @@ def temporally_interpolated_ecdr_dataset(
 
         # Fill pole hole of BT
         bt_conc_pre_polefill = bt_conc_2d.copy()
-        platform = get_platform_by_date(date, platform_start_dates)
+        platform = get_platform_by_date(date)
         near_pole_hole_mask = nh_polehole_mask(
             date=date, resolution=resolution, sat=platform
         )
@@ -854,7 +842,6 @@ def temporally_interpolated_ecdr_dataset_for_au_si_tbs(
     interp_range: int = 5,
     ecdr_data_dir: Path,
     fill_the_pole_hole: bool = True,
-    platform_start_dates=PLATFORM_START_DATES,
 ) -> xr.Dataset:
     """Create xr dataset containing the second pass of daily enhanced CDR.
 
@@ -871,7 +858,6 @@ def temporally_interpolated_ecdr_dataset_for_au_si_tbs(
         hemisphere=hemisphere,
         resolution=resolution,
         ecdr_data_dir=ecdr_data_dir,
-        platform_start_dates=platform_start_dates,
     )
 
     # Copy ide_ds to a new xr tiecdr dataset
@@ -892,7 +878,6 @@ def temporally_interpolated_ecdr_dataset_for_au_si_tbs(
             "hemisphere": hemisphere,
             "resolution": resolution,
             "ecdr_data_dir": ecdr_data_dir,
-            "platform_start_dates": platform_start_dates,
         },
     )
 
@@ -953,7 +938,7 @@ def temporally_interpolated_ecdr_dataset_for_au_si_tbs(
     #       grid is having its pole hole filled!
     if fill_the_pole_hole and hemisphere == NORTH:
         cdr_conc_pre_polefill = cdr_conc.copy()
-        platform = get_platform_by_date(date, platform_start_dates)
+        platform = get_platform_by_date(date)
         near_pole_hole_mask = nh_polehole_mask(date=date, resolution=resolution, sat=platform)
         cdr_conc_pole_filled = fill_pole_hole(
             conc=cdr_conc,
@@ -1012,7 +997,6 @@ def temporally_interpolated_ecdr_dataset_for_au_si_tbs(
             "hemisphere": hemisphere,
             "resolution": resolution,
             "ecdr_data_dir": ecdr_data_dir,
-            "platform_start_dates": platform_start_dates,
         },
     )
 
@@ -1041,7 +1025,6 @@ def temporally_interpolated_ecdr_dataset_for_au_si_tbs(
             "hemisphere": hemisphere,
             "resolution": resolution,
             "ecdr_data_dir": ecdr_data_dir,
-            "platform_start_dates": platform_start_dates,
         },
     )
 
@@ -1060,7 +1043,7 @@ def temporally_interpolated_ecdr_dataset_for_au_si_tbs(
 
         # Fill pole hole of BT
         bt_conc_pre_polefill = bt_conc_2d.copy()
-        platform = get_platform_by_date(date, platform_start_dates)
+        platform = get_platform_by_date(date)
         near_pole_hole_mask = nh_polehole_mask(date=date, resolution=resolution, sat=platform)
         bt_conc_pole_filled = fill_pole_hole(
             conc=bt_conc_2d,
@@ -1223,7 +1206,6 @@ def write_tie_netcdf(
 def make_tiecdr_netcdf(
     *,
     date: dt.date,
-    platform_start_dates,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     ecdr_data_dir: Path,
@@ -1248,14 +1230,12 @@ def make_tiecdr_netcdf(
         interp_range=interp_range,
         ecdr_data_dir=ecdr_data_dir,
         fill_the_pole_hole=fill_the_pole_hole,
-        platform_start_dates=platform_start_dates,
     )
     output_path = get_tie_filepath(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
         ecdr_data_dir=ecdr_data_dir,
-        platform_start_dates=platform_start_dates,
     )
 
     written_tie_ncfile = write_tie_netcdf(
@@ -1272,7 +1252,6 @@ def create_tiecdr_for_date_range(
     end_date: dt.date,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     ecdr_data_dir: Path,
-    platform_start_dates,
 ) -> None:
     """Generate the temporally composited daily ecdr files for a range of dates."""
     for date in date_range(start_date=start_date, end_date=end_date):
@@ -1282,7 +1261,6 @@ def create_tiecdr_for_date_range(
                 hemisphere=hemisphere,
                 resolution=resolution,
                 ecdr_data_dir=ecdr_data_dir,
-                platform_start_dates=platform_start_dates,
             )
 
         # TODO: either catch and re-throw this exception or throw an error after
@@ -1301,7 +1279,6 @@ def create_tiecdr_for_date_range(
                 hemisphere=hemisphere,
                 resolution=resolution,
                 ecdr_data_dir=ecdr_data_dir,
-                platform_start_dates=platform_start_dates,
             )
             err_filename = err_filepath.name + ".error"
             logger.info(f"Writing error info to {err_filename}")
@@ -1370,19 +1347,6 @@ def create_tiecdr_for_date_range(
     required=True,
     type=click.Choice(get_args(ECDR_SUPPORTED_RESOLUTIONS)),
 )
-@click.option(
-    "--start-dates-cfg",
-    required=False,
-    type=click.Path(
-        exists=True,
-        file_okay=True,
-        dir_okay=False,
-        resolve_path=True,
-        path_type=Path,
-    ),
-    default=None,
-    help="If given, this is the name of a yaml file with platform_start_dates dict",
-)
 def cli(
     *,
     date: dt.date,
@@ -1390,7 +1354,6 @@ def cli(
     hemisphere: Hemisphere,
     ecdr_data_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    start_dates_cfg: Path | None,
 ) -> None:
     """Run the temporal composite daily ECDR algorithm with AMSR2 data.
 
@@ -1404,16 +1367,10 @@ def cli(
     if end_date is None:
         end_date = copy.copy(date)
 
-    if start_dates_cfg is None:
-        platform_start_dates = PLATFORM_START_DATES_DEFAULT
-    else:
-        platform_start_dates = read_platform_start_dates_cfg(start_dates_cfg)
-
     create_tiecdr_for_date_range(
         hemisphere=hemisphere,
         start_date=date,
         end_date=end_date,
         resolution=resolution,
         ecdr_data_dir=ecdr_data_dir,
-        platform_start_dates=platform_start_dates,
     )

--- a/seaice_ecdr/tests/integration/test_complete_daily.py
+++ b/seaice_ecdr/tests/integration/test_complete_daily.py
@@ -3,7 +3,6 @@ import datetime as dt
 from pm_tb_data._types import NORTH
 
 from seaice_ecdr.complete_daily_ecdr import make_cdecdr_netcdf
-from seaice_ecdr.platforms import PLATFORM_START_DATES_DEFAULT
 from seaice_ecdr.tests.integration import ecdr_data_dir_test_path  # noqa
 
 
@@ -14,7 +13,6 @@ def test_make_cdecdr_netcdf(ecdr_data_dir_test_path):  # noqa
             hemisphere=NORTH,
             resolution="12.5",
             ecdr_data_dir=ecdr_data_dir_test_path,
-            platform_start_dates=PLATFORM_START_DATES_DEFAULT,
         )
 
         assert output_path.is_file()

--- a/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
+++ b/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
@@ -16,7 +16,6 @@ from seaice_ecdr.initial_daily_ecdr import (
     make_idecdr_netcdf,
     write_ide_netcdf,
 )
-from seaice_ecdr.platforms import PLATFORM_START_DATES_DEFAULT
 
 cdr_conc_fieldname = "conc"
 
@@ -34,7 +33,6 @@ def sample_idecdr_dataset_nh():
         date=test_date,
         hemisphere=test_hemisphere,
         resolution=test_resolution,
-        platform_start_dates=PLATFORM_START_DATES_DEFAULT,
     )
     return ide_conc_ds
 
@@ -52,7 +50,6 @@ def sample_idecdr_dataset_sh():
         date=test_date,
         hemisphere=test_hemisphere,
         resolution=test_resolution,
-        platform_start_dates=PLATFORM_START_DATES_DEFAULT,
     )
     return ide_conc_ds
 
@@ -139,7 +136,6 @@ def test_cli_idecdr_ncfile_creation(tmpdir):
         hemisphere=test_hemisphere,
         resolution=test_resolution,
         ecdr_data_dir=tmpdir_path,
-        platform_start_dates=PLATFORM_START_DATES_DEFAULT,
     )
     output_path = get_idecdr_filepath(
         hemisphere=test_hemisphere,
@@ -172,7 +168,6 @@ def test_can_drop_fields_from_idecdr_netcdf(
         resolution=test_resolution,
         ecdr_data_dir=tmpdir_path,
         excluded_fields=(cdr_conc_fieldname,),
-        platform_start_dates=PLATFORM_START_DATES_DEFAULT,
     )
     output_path = get_idecdr_filepath(
         hemisphere=test_hemisphere,

--- a/seaice_ecdr/tests/integration/test_monthly.py
+++ b/seaice_ecdr/tests/integration/test_monthly.py
@@ -3,7 +3,6 @@ import xarray as xr
 from pm_tb_data._types import NORTH
 
 from seaice_ecdr import monthly
-from seaice_ecdr.platforms import PLATFORM_START_DATES_DEFAULT
 from seaice_ecdr.tests.integration import ecdr_data_dir_test_path  # noqa
 
 
@@ -22,7 +21,6 @@ def test_make_monthly_nc(ecdr_data_dir_test_path, monkeypatch):  # noqa
         hemisphere=NORTH,
         resolution="12.5",
         ecdr_data_dir=ecdr_data_dir_test_path,
-        platform_start_dates=PLATFORM_START_DATES_DEFAULT,
     )
 
     assert output_path.is_file()

--- a/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
+++ b/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
@@ -13,7 +13,6 @@ from loguru import logger
 from pm_tb_data._types import NORTH
 
 from seaice_ecdr.initial_daily_ecdr import get_idecdr_filepath
-from seaice_ecdr.platforms import PLATFORM_START_DATES_DEFAULT
 from seaice_ecdr.temporal_composite_daily import (
     make_tiecdr_netcdf,
     read_or_create_and_read_idecdr_ds,
@@ -50,7 +49,6 @@ def test_read_or_create_and_read_idecdr_ds(tmpdir):
         hemisphere=hemisphere,
         resolution=resolution,
         ecdr_data_dir=Path(tmpdir),
-        platform_start_dates=PLATFORM_START_DATES_DEFAULT,
     )
 
     assert sample_ide_filepath.exists()
@@ -59,7 +57,6 @@ def test_read_or_create_and_read_idecdr_ds(tmpdir):
         hemisphere=hemisphere,
         resolution=resolution,
         ecdr_data_dir=Path(tmpdir),
-        platform_start_dates=PLATFORM_START_DATES_DEFAULT,
     )
 
     assert test_ide_ds_with_creation == test_ide_ds_with_reading
@@ -82,6 +79,5 @@ def test_create_tiecdr_file(tmpdir):
         hemisphere=hemisphere,
         resolution=resolution,
         ecdr_data_dir=Path(tmpdir),
-        platform_start_dates=PLATFORM_START_DATES_DEFAULT,
         interp_range=2,
     )

--- a/seaice_ecdr/tests/regression/test_daily_aggregate.py
+++ b/seaice_ecdr/tests/regression/test_daily_aggregate.py
@@ -10,7 +10,6 @@ from seaice_ecdr.daily_aggregate import (
     get_daily_aggregate_filepath,
     make_daily_aggregate_netcdf_for_year,
 )
-from seaice_ecdr.platforms import PLATFORM_START_DATES_DEFAULT
 
 
 def test_daily_aggreagate_matches_daily_data(tmpdir):
@@ -28,7 +27,6 @@ def test_daily_aggreagate_matches_daily_data(tmpdir):
             hemisphere=hemisphere,
             resolution=resolution,
             ecdr_data_dir=tmpdir_path,
-            platform_start_dates=PLATFORM_START_DATES_DEFAULT,
         )
         datasets.append(ds)
 
@@ -38,7 +36,6 @@ def test_daily_aggreagate_matches_daily_data(tmpdir):
         hemisphere=hemisphere,
         resolution=resolution,
         ecdr_data_dir=tmpdir_path,
-        platform_start_dates=PLATFORM_START_DATES_DEFAULT,
     )
 
     # Read back in the data.

--- a/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
+++ b/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
@@ -6,7 +6,6 @@ import numpy as np
 from pm_tb_data._types import NORTH, SOUTH
 
 from seaice_ecdr import complete_daily_ecdr as cdecdr
-from seaice_ecdr.platforms import PLATFORM_START_DATES_DEFAULT
 
 
 def test_no_melt_onset_for_southern_hemisphere(tmpdir):
@@ -17,7 +16,6 @@ def test_no_melt_onset_for_southern_hemisphere(tmpdir):
             hemisphere=SOUTH,
             resolution="12.5",
             ecdr_data_dir=Path(tmpdir),
-            platform_start_dates=PLATFORM_START_DATES_DEFAULT,
         )
         assert melt_onset_field is None
 
@@ -34,6 +32,5 @@ def test_melt_onset_field_outside_melt_season(tmpdir):
             resolution="12.5",
             ecdr_data_dir=Path(tmpdir),
             no_melt_flag=no_melt_flag,
-            platform_start_dates=PLATFORM_START_DATES_DEFAULT,
         )
         assert np.all(melt_onset_field == no_melt_flag)

--- a/seaice_ecdr/tests/unit/test_monthly.py
+++ b/seaice_ecdr/tests/unit/test_monthly.py
@@ -23,7 +23,6 @@ from seaice_ecdr.monthly import (
     check_min_days_for_valid_month,
     make_monthly_ds,
 )
-from seaice_ecdr.platforms import PLATFORM_START_DATES_DEFAULT
 
 
 def test__get_daily_complete_filepaths_for_month(fs):
@@ -64,7 +63,6 @@ def test__get_daily_complete_filepaths_for_month(fs):
         ecdr_data_dir=ecdr_data_dir,
         resolution="12.5",
         hemisphere=NORTH,
-        platform_start_dates=PLATFORM_START_DATES_DEFAULT,
     )
 
     assert sorted(_fake_files_for_test_year_month_and_hemisphere) == sorted(actual)

--- a/seaice_ecdr/tests/unit/test_platforms.py
+++ b/seaice_ecdr/tests/unit/test_platforms.py
@@ -4,13 +4,12 @@ from typing import get_args
 
 from seaice_ecdr.platforms import (
     PLATFORM_AVAILABILITY,
-    # PLATFORM_START_DATES,
-    PLATFORM_START_DATES,
     PLATFORMS_FOR_SATS,
     SUPPORTED_SAT,
     _platform_available_for_date,
     _platform_start_dates_are_consistent,
     get_platform_by_date,
+    get_platform_start_dates,
 )
 
 platform_test_dates = {
@@ -49,9 +48,9 @@ def test_default_platform_availability():
 
 
 def test_default_platform_start_dates_are_consistent():
+    platform_start_dates = get_platform_start_dates()
     assert _platform_start_dates_are_consistent(
-        platform_start_dates=PLATFORM_START_DATES,
-        platform_availability=PLATFORM_AVAILABILITY,
+        platform_start_dates=platform_start_dates
     )
 
 
@@ -63,7 +62,6 @@ def test_platform_availability_by_date():
         assert not _platform_available_for_date(
             date=date_before_any_satellites,
             platform=platform,
-            platform_availability=PLATFORM_AVAILABILITY,
         )
 
     date_after_dead_satellites = dt.date(2100, 1, 1)
@@ -78,27 +76,29 @@ def test_platform_availability_by_date():
         assert not _platform_available_for_date(
             date=date_after_dead_satellites,
             platform=platform,
-            platform_availability=PLATFORM_AVAILABILITY,
         )
 
     for platform in platform_test_dates.keys():
         assert _platform_available_for_date(
             date=platform_test_dates[platform],
             platform=platform,
-            platform_availability=PLATFORM_AVAILABILITY,
         )
 
 
 def test_get_platform_by_date():
-    date_list = PLATFORM_START_DATES.keys()
-    platform_list = PLATFORM_START_DATES.values()
+    platform_start_dates = get_platform_start_dates()
+    date_list = platform_start_dates.keys()
+    platform_list = platform_start_dates.values()
 
     for date, expected_platform in zip(date_list, platform_list):
         print(f"testing {date} -> {expected_platform}")
 
         platform = get_platform_by_date(
             date=date,
-            platform_start_dates=PLATFORM_START_DATES,
-            platform_availability=PLATFORM_AVAILABILITY,
         )
         assert platform == expected_platform
+
+
+# TODO
+def test_override_platform_by_date():
+    ...

--- a/seaice_ecdr/tests/unit/test_platforms.py
+++ b/seaice_ecdr/tests/unit/test_platforms.py
@@ -5,7 +5,7 @@ from typing import get_args
 from seaice_ecdr.platforms import (
     PLATFORM_AVAILABILITY,
     # PLATFORM_START_DATES,
-    PLATFORM_START_DATES_DEFAULT,
+    PLATFORM_START_DATES,
     PLATFORMS_FOR_SATS,
     SUPPORTED_SAT,
     _platform_available_for_date,
@@ -50,7 +50,7 @@ def test_default_platform_availability():
 
 def test_default_platform_start_dates_are_consistent():
     assert _platform_start_dates_are_consistent(
-        platform_start_dates=PLATFORM_START_DATES_DEFAULT,
+        platform_start_dates=PLATFORM_START_DATES,
         platform_availability=PLATFORM_AVAILABILITY,
     )
 
@@ -90,15 +90,15 @@ def test_platform_availability_by_date():
 
 
 def test_get_platform_by_date():
-    date_list = PLATFORM_START_DATES_DEFAULT.keys()
-    platform_list = PLATFORM_START_DATES_DEFAULT.values()
+    date_list = PLATFORM_START_DATES.keys()
+    platform_list = PLATFORM_START_DATES.values()
 
     for date, expected_platform in zip(date_list, platform_list):
         print(f"testing {date} -> {expected_platform}")
 
         platform = get_platform_by_date(
             date=date,
-            platform_start_dates=PLATFORM_START_DATES_DEFAULT,
+            platform_start_dates=PLATFORM_START_DATES,
             platform_availability=PLATFORM_AVAILABILITY,
         )
         assert platform == expected_platform

--- a/seaice_ecdr/tests/unit/test_platforms.py
+++ b/seaice_ecdr/tests/unit/test_platforms.py
@@ -2,6 +2,8 @@
 import datetime as dt
 from typing import get_args
 
+import yaml
+
 from seaice_ecdr.platforms import (
     PLATFORM_AVAILABILITY,
     PLATFORMS_FOR_SATS,
@@ -99,6 +101,23 @@ def test_get_platform_by_date():
         assert platform == expected_platform
 
 
-# TODO
-def test_override_platform_by_date():
-    ...
+def test_override_platform_by_date(monkeypatch, tmpdir):
+    override_file = tmpdir / "override_platform_dates.yaml"
+    expected_platform_dates = {
+        dt.date(1987, 7, 10): "F08",
+        dt.date(1991, 12, 3): "F11",
+        dt.date(1995, 10, 1): "F13",
+        dt.date(2002, 6, 1): "ame",
+    }
+
+    with open(override_file, "w") as yaml_file:
+        yaml.safe_dump(expected_platform_dates, yaml_file)
+
+    monkeypatch.setenv("PLATFORM_START_DATES_CFG_OVERRIDE_FILE", str(override_file))
+
+    # This is a cached function. Calls from other tests may interfere, so clear
+    # the cache here.
+    get_platform_start_dates.cache_clear()
+    platform_dates = get_platform_start_dates()
+
+    assert platform_dates == expected_platform_dates


### PR DESCRIPTION
Override platform start dates via a config file and envvar. This approach can also be extended to other overrides you might want to apply to other configuration. For now, this PR just adds support for overriding the platform start dates.

The key change this PR makes is setting up a single place for the code that handles overrides to operate. At runtime, we check if an overrides file is specified. If so, we read start dates from that config file. Otherwise, we use the defaults as defined in our code.