### PR TITLE
remove obsolete cli option from monthly cli

### DIFF
--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -716,19 +716,6 @@ def make_monthly_nc(
     required=True,
     type=click.Choice(get_args(ECDR_SUPPORTED_RESOLUTIONS)),
 )
-@click.option(
-    "--start-dates-cfg",
-    required=False,
-    type=click.Path(
-        exists=True,
-        file_okay=True,
-        dir_okay=False,
-        resolve_path=True,
-        path_type=Path,
-    ),
-    default=None,
-    help="If given, this is the name of a yaml file with platform_start_dates dict",
-)
 def cli(
     *,
     year: int,


### PR DESCRIPTION
Quick PR to remove an obsolete click option in the monthly cli interface.