### PR TITLE
Allow raw nt conc over 100

### DIFF
--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -720,9 +720,10 @@ def compute_initial_daily_ecdr_dataset(
     # Add the NT raw field to the dataset
     if nt_conc is not None:
         if (nt_conc > 200).any():
-            raise RuntimeError(
+            logger.warning(
                 "Raw nasateam concentrations above 200 were found."
-                " This is unexpected and needs to be investigated."
+                " This is unexpected may need to be investigated."
+                f" Max nt value: {np.nanmax(nt_conc)}"
             )
 
         nt_conc = nt_conc / 100.0

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -675,8 +675,6 @@ def compute_initial_daily_ecdr_dataset(
 
     # Add the NT raw field to the dataset
     if nt_conc is not None:
-        # Remove nt_conc flags
-        nt_conc[nt_conc > 200] = np.nan
         nt_conc = nt_conc / 100.0
         ecdr_ide_ds["raw_nt_seaice_conc"] = (
             ("time", "y", "x"),

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -719,6 +719,12 @@ def compute_initial_daily_ecdr_dataset(
 
     # Add the NT raw field to the dataset
     if nt_conc is not None:
+        if (nt_conc > 200).any():
+            raise RuntimeError(
+                "Raw nasateam concentrations above 200 were found."
+                " This is unexpected and needs to be investigated."
+            )
+
         nt_conc = nt_conc / 100.0
         ecdr_ide_ds["raw_nt_seaice_conc"] = (
             ("time", "y", "x"),

--- a/seaice_ecdr/set_daily_ncattrs.py
+++ b/seaice_ecdr/set_daily_ncattrs.py
@@ -324,7 +324,7 @@ def finalize_cdecdr_ds(
                 " raw field with no masking or filtering"
             ),
             "grid_mapping": "crs",
-            "valid_range": np.array((0, 100), dtype=np.uint8),
+            "valid_min": np.uint8(0),
         },
     )
 

--- a/seaice_ecdr/set_daily_ncattrs.py
+++ b/seaice_ecdr/set_daily_ncattrs.py
@@ -324,9 +324,9 @@ def finalize_cdecdr_ds(
                 " raw field with no masking or filtering"
             ),
             "grid_mapping": "crs",
-            # We set a valid max of 200 because we allow nasateam raw
-            # concentrations >100%. We don't think values of >200 are realistic.
-            "valid_range": np.array((0, 200), dtype=np.uint8),
+            # We set a `valid_min` of 0 because we allow nasateam raw
+            # concentrations >100%. We do not set an upper limit.
+            "valid_min": 0,
         },
     )
 

--- a/seaice_ecdr/set_daily_ncattrs.py
+++ b/seaice_ecdr/set_daily_ncattrs.py
@@ -324,7 +324,9 @@ def finalize_cdecdr_ds(
                 " raw field with no masking or filtering"
             ),
             "grid_mapping": "crs",
-            "valid_min": np.uint8(0),
+            # We set a valid max of 200 because we allow nasateam raw
+            # concentrations >100%. We don't think values of >200 are realistic.
+            "valid_range": np.array((0, 200), dtype=np.uint8),
         },
     )
 


### PR DESCRIPTION
* Replace `valid_range` with `valid_min`
* Stop setting values > 200 to `np.nan`. This is old code to remove flags that are not present in the NT field anyway.