### PR TITLE
Dynamically set `source`, `platform`, `sensor` in daily complete files

### DIFF
--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -514,14 +514,6 @@ def make_cdecdr_netcdf(
 ) -> Path:
     logger.info(f"Creating cdecdr for {date=}, {hemisphere=}, {resolution=}")
 
-    """ Rewriting the au_si specific code here...
-    cde_ds = complete_daily_ecdr_dataset_for_au_si_tbs(
-        date=date,
-        hemisphere=hemisphere,
-        resolution=resolution,
-        ecdr_data_dir=ecdr_data_dir,
-    )
-    """
     cde_ds = complete_daily_ecdr_dataset(
         date=date,
         hemisphere=hemisphere,

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -53,6 +53,10 @@ from seaice_ecdr.regrid_25to12 import reproject_ideds_25to12
 from seaice_ecdr.tb_data import get_ecdr_tb_data
 from seaice_ecdr.util import date_range, standard_daily_filename
 
+# TODO: these TB names are not those expected by the nt/bt algorithms as defined
+# by `pm_icecon`. These are AMSR2 equivilients.
+# Bootstrap needs: v37, h37, v19, v22
+# Nasateam needs: v19, h19, v37
 EXPECTED_TB_NAMES = ("h18", "v18", "v23", "h36", "v36")
 
 

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -226,6 +226,9 @@ def _setup_ecdr_ds(
     # Set data_source attribute
     ecdr_ide_ds.attrs["data_source"] = tb_data.data_source
 
+    # Set the platform
+    ecdr_ide_ds.attrs["platform"] = tb_data.platform
+
     file_date = dt.date(1970, 1, 1) + dt.timedelta(
         days=int(ecdr_ide_ds.variables["time"].data)
     )

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -50,7 +50,7 @@ from seaice_ecdr.grid_id import get_grid_id
 from seaice_ecdr.gridid_to_xr_dataarray import get_dataset_for_grid_id
 from seaice_ecdr.platforms import get_platform_by_date
 from seaice_ecdr.regrid_25to12 import reproject_ideds_25to12
-from seaice_ecdr.tb_data import get_ecdr_tbs
+from seaice_ecdr.tb_data import get_ecdr_tb_data
 from seaice_ecdr.util import date_range, standard_daily_filename
 
 EXPECTED_TB_NAMES = ("h18", "v18", "v23", "h36", "v36")
@@ -825,7 +825,7 @@ def initial_daily_ecdr_dataset(
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
 ) -> xr.Dataset:
     """Create xr dataset containing the first pass of daily enhanced CDR."""
-    tb_data = get_ecdr_tbs(
+    tb_data = get_ecdr_tb_data(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -832,7 +832,6 @@ def initial_daily_ecdr_dataset(
     tb_data = get_ecdr_tb_data(
         date=date,
         hemisphere=hemisphere,
-        resolution=resolution,
     )
     initial_ecdr_ds = compute_initial_daily_ecdr_dataset(
         date=date,

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -42,10 +42,14 @@ def compute_nrt_initial_daily_ecdr_dataset(
         tbs=xr_tbs,
         resolution="12.5",
         data_source="LANCE AU_SI12",
+        platform="am2",
     )
 
     nrt_initial_ecdr_ds = compute_initial_daily_ecdr_dataset(
-        date=date, hemisphere=hemisphere, resolution=resolution, tb_data=tb_data
+        date=date,
+        hemisphere=hemisphere,
+        resolution=resolution,
+        tb_data=tb_data,
     )
 
     return nrt_initial_ecdr_ds

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -21,6 +21,7 @@ from seaice_ecdr.initial_daily_ecdr import (
 from seaice_ecdr.platforms import (
     get_platform_by_date,
 )
+from seaice_ecdr.tb_data import EcdrTbData
 
 
 def compute_nrt_initial_daily_ecdr_dataset(
@@ -37,11 +38,14 @@ def compute_nrt_initial_daily_ecdr_dataset(
         data_dir=lance_amsr2_input_dir,
     )
 
+    tb_data = EcdrTbData(
+        tbs=xr_tbs,
+        resolution="12.5",
+        data_source="LANCE AU_SI12",
+    )
+
     nrt_initial_ecdr_ds = compute_initial_daily_ecdr_dataset(
-        date=date,
-        hemisphere=hemisphere,
-        resolution=resolution,
-        xr_tbs=xr_tbs,
+        date=date, hemisphere=hemisphere, resolution=resolution, tb_data=tb_data
     )
 
     return nrt_initial_ecdr_ds

--- a/seaice_ecdr/set_daily_ncattrs.py
+++ b/seaice_ecdr/set_daily_ncattrs.py
@@ -339,8 +339,7 @@ def finalize_cdecdr_ds(
         temporality="daily",
         aggregate=False,
         source="Generated from {ds_in.data_source}",
-        # TODO: set sat from source
-        sats=["am2"],
+        sats=[ds_in.platform],
     )
     ds.attrs = new_global_attrs
 

--- a/seaice_ecdr/set_daily_ncattrs.py
+++ b/seaice_ecdr/set_daily_ncattrs.py
@@ -338,9 +338,7 @@ def finalize_cdecdr_ds(
         time=ds.time,
         temporality="daily",
         aggregate=False,
-        # TODO: support alternative source datasets. Will be AU_SI12 for AMSR2,
-        # AE_SI12 for AMSR-E, and NSIDC-0001 for SSMIS, SSM/I, and SMMR
-        source="Generated from AU_SI12",
+        source="Generated from {ds_in.data_source}",
         # TODO: set sat from source
         sats=["am2"],
     )

--- a/seaice_ecdr/tb_data.py
+++ b/seaice_ecdr/tb_data.py
@@ -6,9 +6,6 @@ from typing import Final, get_args
 import numpy as np
 import xarray as xr
 from loguru import logger
-
-# TODO: default flag values are specific to the ECDR, and should probably be
-# defined in this repo instead of `pm_icecon`.
 from pm_tb_data._types import Hemisphere
 from pm_tb_data.fetch.amsr.ae_si import get_ae_si_tbs_from_disk
 from pm_tb_data.fetch.amsr.au_si import get_au_si_tbs
@@ -282,5 +279,6 @@ def get_ecdr_tb_data(
             date=date,
             hemisphere=hemisphere,
         )
+    # TODO: support SMMR/platform="n07"
     else:
         raise RuntimeError(f"Platform not supported: {platform}")

--- a/seaice_ecdr/tb_data.py
+++ b/seaice_ecdr/tb_data.py
@@ -163,7 +163,7 @@ class EcdrTbData:
     resolution: ECDR_SUPPORTED_RESOLUTIONS
 
 
-def get_ecdr_tbs(
+def get_ecdr_tb_data(
     *, date: dt.date, hemisphere: Hemisphere, resolution: ECDR_SUPPORTED_RESOLUTIONS
 ) -> EcdrTbData:
     platform = get_platform_by_date(date)

--- a/seaice_ecdr/tb_data.py
+++ b/seaice_ecdr/tb_data.py
@@ -161,6 +161,7 @@ def create_null_au_si_tbs(
 class EcdrTbData:
     tbs: xr.Dataset
     resolution: ECDR_SUPPORTED_RESOLUTIONS
+    data_source: str
 
 
 def _get_am2_tbs(*, date: dt.date, hemisphere: Hemisphere) -> EcdrTbData:
@@ -182,7 +183,9 @@ def _get_am2_tbs(*, date: dt.date, hemisphere: Hemisphere) -> EcdrTbData:
             f" resolution={tb_resolution}"
         )
 
-    ecdr_tb_data = EcdrTbData(tbs=xr_tbs, resolution=tb_resolution)
+    ecdr_tb_data = EcdrTbData(
+        tbs=xr_tbs, resolution=tb_resolution, data_source="AU_SI12"
+    )
 
     return ecdr_tb_data
 
@@ -210,7 +213,9 @@ def _get_ame_tbs(*, date: dt.date, hemisphere: Hemisphere) -> EcdrTbData:
             f" resolution={tb_resolution}"
         )
 
-    ecdr_tb_data = EcdrTbData(tbs=xr_tbs, resolution=tb_resolution)
+    ecdr_tb_data = EcdrTbData(
+        tbs=xr_tbs, resolution=tb_resolution, data_source="AE_SI12"
+    )
 
     return ecdr_tb_data
 
@@ -244,7 +249,9 @@ def _get_nsidc_0001_tbs(
             f" resolution={tb_resolution}"
         )
 
-    ecdr_tb_data = EcdrTbData(tbs=xr_tbs, resolution=tb_resolution)
+    ecdr_tb_data = EcdrTbData(
+        tbs=xr_tbs, resolution=tb_resolution, data_source="NSIDC-0001"
+    )
 
     return ecdr_tb_data
 

--- a/seaice_ecdr/tb_data.py
+++ b/seaice_ecdr/tb_data.py
@@ -1,0 +1,242 @@
+import datetime as dt
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+import numpy as np
+import xarray as xr
+from loguru import logger
+
+# TODO: default flag values are specific to the ECDR, and should probably be
+# defined in this repo instead of `pm_icecon`.
+from pm_tb_data._types import Hemisphere
+from pm_tb_data.fetch.amsr.ae_si import get_ae_si_tbs_from_disk
+from pm_tb_data.fetch.amsr.au_si import get_au_si_tbs
+from pm_tb_data.fetch.amsr.util import AMSR_RESOLUTIONS
+from pm_tb_data.fetch.nsidc_0001 import get_nsidc_0001_tbs_from_disk
+
+from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
+from seaice_ecdr.platforms import get_platform_by_date
+
+
+def _pm_icecon_amsr_res_str(
+    *, resolution: ECDR_SUPPORTED_RESOLUTIONS
+) -> AMSR_RESOLUTIONS:
+    """Given an AMSR ECDR resolution string, return a compatible `pm_icecon` resolution string."""
+    _ecdr_pm_icecon_resolution_mapping: dict[
+        ECDR_SUPPORTED_RESOLUTIONS, AMSR_RESOLUTIONS
+    ] = {
+        "12.5": "12",
+        "25": "25",
+    }
+    au_si_resolution_str = _ecdr_pm_icecon_resolution_mapping[resolution]
+
+    return au_si_resolution_str
+
+
+# TODO: Eventually, these should be renamed based on microwave
+#       band names, not AMSR2 TB channel frequencies
+def rename_0001_tbs(
+    *,
+    input_ds: xr.Dataset,
+) -> xr.Dataset:
+    """Rename 0001 TB fields for use with siconc code written for AMSR2."""
+    nsidc0001_to_amsr_tb_mapping = {
+        "h19": "h18",
+        "v19": "v18",
+        "v22": "v23",
+        "h37": "h36",
+        "v37": "v36",
+    }
+
+    new_tbs = {}
+    for key in input_ds.data_vars.keys():
+        data_var = input_ds.data_vars[key]
+        new_key = nsidc0001_to_amsr_tb_mapping[key]
+        new_tbs[new_key] = xr.DataArray(
+            data_var.data,
+            dims=("fake_y", "fake_x"),
+            attrs=data_var.attrs,
+        )
+
+    new_ds = xr.Dataset(new_tbs)
+
+    return new_ds
+
+
+def create_null_au_si_tbs(
+    *,
+    hemisphere: Hemisphere,
+    resolution: ECDR_SUPPORTED_RESOLUTIONS,
+) -> xr.Dataset:
+    """Create xr dataset containing all null-value data for all tbs."""
+    chan_desc = {
+        "h18": "18.7 GHz horizontal daily average Tbs",
+        "v18": "18.7 GHz vertical daily average Tbs",
+        "h23": "23.8 GHz horizontal daily average Tbs",
+        "v23": "23.8 GHz vertical daily average Tbs",
+        "h36": "36.5 GHz horizontal daily average Tbs",
+        "v36": "36.5 GHz vertical daily average Tbs",
+        "h89": "89.0 GHz horizontal daily average Tbs",
+        "v89": "89.0 GHz vertical daily average Tbs",
+    }
+
+    if hemisphere == "north" and resolution == "12.5":
+        xdim = 608
+        ydim = 896
+    elif hemisphere == "south" and resolution == "12.5":
+        xdim = 632
+        ydim = 664
+    else:
+        value_error_string = f"""
+        Could not create null_set of TBs for
+          hemisphere: {hemisphere}
+          resolution: {resolution}
+        """
+        raise ValueError(value_error_string)
+
+    null_array = np.zeros((ydim, xdim), dtype=np.float64)
+    null_array[:] = np.nan
+    common_tb_attrs = {
+        "_FillValue": 0,
+        "units": "degree_kelvin",
+        "standard_name": "brightness_temperature",
+        "packing_convention": "netCDF",
+        "packing_convention_description": "unpacked = scale_factor x packed + add_offset",
+        "scale_factor": 0.1,
+        "add_offset": 0.0,
+    }
+    null_tbs = xr.Dataset(
+        data_vars=dict(
+            h18=(
+                ["YDim", "XDim"],
+                null_array,
+                common_tb_attrs,
+            ),
+            v18=(
+                ["YDim", "XDim"],
+                null_array,
+                common_tb_attrs,
+            ),
+            h23=(
+                ["YDim", "XDim"],
+                null_array,
+                common_tb_attrs,
+            ),
+            v23=(
+                ["YDim", "XDim"],
+                null_array,
+                common_tb_attrs,
+            ),
+            h36=(
+                ["YDim", "XDim"],
+                null_array,
+                common_tb_attrs,
+            ),
+            v36=(
+                ["YDim", "XDim"],
+                null_array,
+                common_tb_attrs,
+            ),
+            h89=(
+                ["YDim", "XDim"],
+                null_array,
+                common_tb_attrs,
+            ),
+            v89=(
+                ["YDim", "XDim"],
+                null_array,
+                common_tb_attrs,
+            ),
+        ),
+    )
+
+    for key in chan_desc.keys():
+        null_tbs.data_vars[key].attrs.update({"long_name": chan_desc[key]})
+
+    return null_tbs
+
+
+@dataclass
+class EcdrTbData:
+    tbs: xr.Dataset
+    resolution: ECDR_SUPPORTED_RESOLUTIONS
+
+
+def get_ecdr_tbs(
+    *, date: dt.date, hemisphere: Hemisphere, resolution: ECDR_SUPPORTED_RESOLUTIONS
+) -> EcdrTbData:
+    platform = get_platform_by_date(date)
+    if platform == "am2":
+        au_si_resolution_str = _pm_icecon_amsr_res_str(resolution=resolution)
+        try:
+            xr_tbs = get_au_si_tbs(
+                date=date,
+                hemisphere=hemisphere,
+                resolution=au_si_resolution_str,
+            )
+        except FileNotFoundError:
+            xr_tbs = create_null_au_si_tbs(
+                hemisphere=hemisphere,
+                resolution=resolution,
+            )
+            logger.warning(
+                f"Used all-null TBS for date={date},"
+                f" hemisphere={hemisphere},"
+                f" resolution={resolution}"
+            )
+        tb_resolution = resolution
+    elif platform == "ame":
+        ame_resolution_str = _pm_icecon_amsr_res_str(resolution=resolution)
+        AME_DATA_DIR = Path("/ecs/DP4/AMSA/AE_SI12.003/")
+        try:
+            xr_tbs = get_ae_si_tbs_from_disk(
+                date=date,
+                hemisphere=hemisphere,
+                data_dir=AME_DATA_DIR,
+                resolution=ame_resolution_str,
+            )
+        except FileNotFoundError:
+            logger.warning(f"Using null AU_SI12 for AME on {date}")
+            xr_tbs = create_null_au_si_tbs(
+                hemisphere=hemisphere,
+                resolution=resolution,
+            )
+            logger.warning(
+                f"Used all-null TBS for date={date},"
+                f" hemisphere={hemisphere},"
+                f" resolution={resolution}"
+            )
+        tb_resolution = resolution
+    elif platform == "F17":
+        NSIDC0001_DATA_DIR = Path("/ecs/DP4/PM/NSIDC-0001.006/")
+        # NSIDC-0001 TBs for siconc are all at 25km
+        nsidc0001_resolution: Final = "25"
+        try:
+            xr_tbs_0001 = get_nsidc_0001_tbs_from_disk(
+                date=date,
+                hemisphere=hemisphere,
+                data_dir=NSIDC0001_DATA_DIR,
+                resolution=nsidc0001_resolution,
+                sat=platform,
+            )
+            xr_tbs = rename_0001_tbs(input_ds=xr_tbs_0001)
+        except FileNotFoundError:
+            logger.warning(f"Using null TBs for {platform} on {date}")
+            print("this needs to be create_null_0001_tbs()")
+            xr_tbs = create_null_au_si_tbs(
+                hemisphere=hemisphere,
+                resolution=resolution,
+            )
+            logger.warning(
+                f"Used all-null TBS for date={date},"
+                f" hemisphere={hemisphere},"
+                f" resolution={resolution}"
+            )
+        tb_resolution = nsidc0001_resolution
+    else:
+        raise RuntimeError(f"Platform not supported: {platform}")
+
+    ecdr_tb_data = EcdrTbData(tbs=xr_tbs, resolution=tb_resolution)
+
+    return ecdr_tb_data

--- a/seaice_ecdr/tb_data.py
+++ b/seaice_ecdr/tb_data.py
@@ -16,7 +16,7 @@ from pm_tb_data.fetch.amsr.util import AMSR_RESOLUTIONS
 from pm_tb_data.fetch.nsidc_0001 import NSIDC_0001_SATS, get_nsidc_0001_tbs_from_disk
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
-from seaice_ecdr.platforms import get_platform_by_date
+from seaice_ecdr.platforms import SUPPORTED_SAT, get_platform_by_date
 
 
 def _pm_icecon_amsr_res_str(
@@ -162,6 +162,7 @@ class EcdrTbData:
     tbs: xr.Dataset
     resolution: ECDR_SUPPORTED_RESOLUTIONS
     data_source: str
+    platform: SUPPORTED_SAT
 
 
 def _get_am2_tbs(*, date: dt.date, hemisphere: Hemisphere) -> EcdrTbData:
@@ -184,7 +185,10 @@ def _get_am2_tbs(*, date: dt.date, hemisphere: Hemisphere) -> EcdrTbData:
         )
 
     ecdr_tb_data = EcdrTbData(
-        tbs=xr_tbs, resolution=tb_resolution, data_source="AU_SI12"
+        tbs=xr_tbs,
+        resolution=tb_resolution,
+        data_source="AU_SI12",
+        platform="am2",
     )
 
     return ecdr_tb_data
@@ -214,7 +218,10 @@ def _get_ame_tbs(*, date: dt.date, hemisphere: Hemisphere) -> EcdrTbData:
         )
 
     ecdr_tb_data = EcdrTbData(
-        tbs=xr_tbs, resolution=tb_resolution, data_source="AE_SI12"
+        tbs=xr_tbs,
+        resolution=tb_resolution,
+        data_source="AE_SI12",
+        platform="ame",
     )
 
     return ecdr_tb_data
@@ -250,7 +257,10 @@ def _get_nsidc_0001_tbs(
         )
 
     ecdr_tb_data = EcdrTbData(
-        tbs=xr_tbs, resolution=tb_resolution, data_source="NSIDC-0001"
+        tbs=xr_tbs,
+        resolution=tb_resolution,
+        data_source="NSIDC-0001",
+        platform=platform,  # type: ignore[arg-type]
     )
 
     return ecdr_tb_data

--- a/seaice_ecdr/tb_data.py
+++ b/seaice_ecdr/tb_data.py
@@ -164,7 +164,10 @@ class EcdrTbData:
 
 
 def get_ecdr_tb_data(
-    *, date: dt.date, hemisphere: Hemisphere, resolution: ECDR_SUPPORTED_RESOLUTIONS
+    *,
+    date: dt.date,
+    hemisphere: Hemisphere,
+    resolution: ECDR_SUPPORTED_RESOLUTIONS,
 ) -> EcdrTbData:
     platform = get_platform_by_date(date)
     if platform == "am2":


### PR DESCRIPTION
This includes a refactor for how the ECDR code manages TB data, which includes the use of data classes to ensure data related to the TB source is maintained alongside the data.

Code that is responsible for getting tbs based on hemisphere & date has been split into a new module, `seaice_ecdr.pm_data`, which provides the ECDR-specific logic we need in addition to the more generic fetch-related logic in `pm_tb_data`.