### PR TITLE
Cleanup default flag value

### DIFF
--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -665,25 +665,22 @@ def compute_initial_daily_ecdr_dataset(
     cdr_conc[cdr_conc > 100] = 100
 
     # Add the BT raw field to the dataset
-    if bt_conc is not None:
-        bt_conc = bt_conc / 100.0  # re-set range from 0 to 1
-        ecdr_ide_ds["raw_bt_seaice_conc"] = (
-            ("time", "y", "x"),
-            np.expand_dims(bt_conc, axis=0),
-            {
-                "grid_mapping": "crs",
-                "standard_name": "sea_ice_area_fraction",
-                "long_name": (
-                    "Bootstrap sea ice concentration, raw field with no masking"
-                ),
-            },
-            {
-                "zlib": True,
-                "dtype": "uint8",
-                "scale_factor": 0.01,
-                "_FillValue": 255,
-            },
-        )
+    bt_conc = bt_conc / 100.0  # re-set range from 0 to 1
+    ecdr_ide_ds["raw_bt_seaice_conc"] = (
+        ("time", "y", "x"),
+        np.expand_dims(bt_conc, axis=0),
+        {
+            "grid_mapping": "crs",
+            "standard_name": "sea_ice_area_fraction",
+            "long_name": ("Bootstrap sea ice concentration, raw field with no masking"),
+        },
+        {
+            "zlib": True,
+            "dtype": "uint8",
+            "scale_factor": 0.01,
+            "_FillValue": 255,
+        },
+    )
 
     # Add the BT coefficients to the raw_bt_seaice_conc DataArray
     for attr in sorted(bt_coefs.keys()):
@@ -695,32 +692,29 @@ def compute_initial_daily_ecdr_dataset(
             )
 
     # Add the NT raw field to the dataset
-    if nt_conc is not None:
-        if (nt_conc > 200).any():
-            logger.warning(
-                "Raw nasateam concentrations above 200 were found."
-                " This is unexpected may need to be investigated."
-                f" Max nt value: {np.nanmax(nt_conc)}"
-            )
-
-        nt_conc = nt_conc / 100.0
-        ecdr_ide_ds["raw_nt_seaice_conc"] = (
-            ("time", "y", "x"),
-            np.expand_dims(nt_conc, axis=0),
-            {
-                "grid_mapping": "crs",
-                "standard_name": "sea_ice_area_fraction",
-                "long_name": (
-                    "NASA Team sea ice concentration, raw field with no masking"
-                ),
-            },
-            {
-                "zlib": True,
-                "dtype": "uint8",
-                "scale_factor": 0.01,
-                "_FillValue": 255,
-            },
+    if (nt_conc > 200).any():
+        logger.warning(
+            "Raw nasateam concentrations above 200 were found."
+            " This is unexpected may need to be investigated."
+            f" Max nt value: {np.nanmax(nt_conc)}"
         )
+
+    nt_conc = nt_conc / 100.0
+    ecdr_ide_ds["raw_nt_seaice_conc"] = (
+        ("time", "y", "x"),
+        np.expand_dims(nt_conc, axis=0),
+        {
+            "grid_mapping": "crs",
+            "standard_name": "sea_ice_area_fraction",
+            "long_name": ("NASA Team sea ice concentration, raw field with no masking"),
+        },
+        {
+            "zlib": True,
+            "dtype": "uint8",
+            "scale_factor": 0.01,
+            "_FillValue": 255,
+        },
+    )
 
     # Add the NT coefficients to the raw_nt_seaice_conc DataArray
     for attr in sorted(nt_coefs.keys()):

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -239,7 +239,6 @@ def _setup_ecdr_ds(
         tbdata = tb_data.tbs.variables[tbname].data
         freq = tbname[1:]
         pol = tbname[:1]
-        # TODO: AU_SI is specified here, but should be calculated
         tb_longname = f"Daily TB {freq}{pol} from {tb_data.data_source}"
         tb_units = "K"
         ecdr_ide_ds[tb_varname] = (

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -265,7 +265,6 @@ def compute_initial_daily_ecdr_dataset(
     date: dt.date,
     hemisphere: Hemisphere,
     tb_data: EcdrTbData,
-    resolution: ECDR_SUPPORTED_RESOLUTIONS,
     fill_the_pole_hole: bool = False,
 ) -> xr.Dataset:
     """Create intermediate daily ECDR xarray dataset.
@@ -820,7 +819,6 @@ def initial_daily_ecdr_dataset(
     initial_ecdr_ds = compute_initial_daily_ecdr_dataset(
         date=date,
         hemisphere=hemisphere,
-        resolution=resolution,
         tb_data=tb_data,
     )
 

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -48,7 +48,6 @@ def compute_nrt_initial_daily_ecdr_dataset(
     nrt_initial_ecdr_ds = compute_initial_daily_ecdr_dataset(
         date=date,
         hemisphere=hemisphere,
-        resolution=resolution,
         tb_data=tb_data,
     )
 

--- a/seaice_ecdr/regrid_25to12.py
+++ b/seaice_ecdr/regrid_25to12.py
@@ -15,10 +15,6 @@ import xarray as xr
 #   hence the type-ignore here
 from cv2 import INTER_LINEAR, resize  # type: ignore[import-not-found]
 from loguru import logger
-
-# TODO: default flag values are specific to the ECDR, and should probably be
-# defined in this repo instead of `pm_icecon`.
-from pm_icecon.constants import DEFAULT_FLAG_VALUES
 from pm_tb_data._types import Hemisphere
 from scipy.interpolate import griddata
 from scipy.signal import convolve2d
@@ -57,7 +53,6 @@ def _setup_ecdr_ds_replacement(
     # Note: these attributes should probably go with
     #       a variable named "CDR_parameters" or similar
     ecdr_ide_ds.attrs["grid_id"] = grid_id
-    ecdr_ide_ds.attrs["missing_value"] = DEFAULT_FLAG_VALUES.missing
 
     file_date = dt.date(1970, 1, 1) + dt.timedelta(
         days=int(ecdr_ide_ds.variables["time"].data)


### PR DESCRIPTION
We do not need to keep track of a `missing_value`. This is only used by the bootstrap algorithm and gets overwritten with `np.nan`.

Also, a few other items I noticed along the way.