### PR TITLE
Refactor remapping tbs

### DIFF
--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -151,8 +151,8 @@ def read_melt_elements(
     )
     return (
         np.squeeze(tie_ds["cdr_conc"].to_numpy()),
-        tie_ds["h18_day_si"].to_numpy(),
-        tie_ds["h36_day_si"].to_numpy(),
+        tie_ds["h19_day_si"].to_numpy(),
+        tie_ds["h37_day_si"].to_numpy(),
     )
 
 

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -21,7 +21,7 @@ from seaice_ecdr.initial_daily_ecdr import (
 from seaice_ecdr.platforms import (
     get_platform_by_date,
 )
-from seaice_ecdr.tb_data import EcdrTbData
+from seaice_ecdr.tb_data import EcdrTbData, ecdr_tbs_from_amsr_channels
 
 
 def compute_nrt_initial_daily_ecdr_dataset(
@@ -39,7 +39,7 @@ def compute_nrt_initial_daily_ecdr_dataset(
     )
 
     tb_data = EcdrTbData(
-        tbs=xr_tbs,
+        tbs=ecdr_tbs_from_amsr_channels(xr_tbs=xr_tbs),
         resolution="12.5",
         data_source="LANCE AU_SI12",
         platform="am2",


### PR DESCRIPTION
Refactor how Tbs are remapped for the ECDR and passing on to `pm_icecon`.

Prior to these changes, we assumed input tbs had channel names consistent with AMSR, which were then mapped onto Tb channels expected by `pm_icecon` and the melt algorithm.

Now we expect just one consistent set of Tb channel names. It is the responsibility of the `seaice_ecdr.tb_data` module to provide data for those channels.