### PR TITLE
Support SH runs

### DIFF
--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -159,7 +159,7 @@ def make_daily_aggregate_netcdf_for_year(
     "--year",
     required=True,
     type=int,
-    help="Year for which to create the monthly file.",
+    help="Year for which to create the daily-aggregate file.",
 )
 @click.option(
     "-h",
@@ -196,7 +196,7 @@ def make_daily_aggregate_netcdf_for_year(
     "--end-year",
     required=False,
     type=int,
-    help="Year for which to create the monthly file.",
+    help="Last year for which to create the daily-aggregate file.",
     default=None,
 )
 def cli(

--- a/seaice_ecdr/multiprocess_daily.py
+++ b/seaice_ecdr/multiprocess_daily.py
@@ -120,4 +120,5 @@ def cli(
     with Pool(6) as multi_pool:
         multi_pool.map(_create_idecdr_wrapper, initial_file_dates)
         multi_pool.map(_create_tiecdr_wrapper, dates)
-        multi_pool.map(_complete_daily_wrapper, dates)
+        # Cannot do complete_daily this way because melt requires prior dates
+        # multi_pool.map(_complete_daily_wrapper, dates)

--- a/seaice_ecdr/regrid_25to12.py
+++ b/seaice_ecdr/regrid_25to12.py
@@ -347,7 +347,6 @@ def reproject_ideds_25to12(
     block_regrid_vars = (
         "spatial_interpolation_flag",
         "invalid_ice_mask",
-        "pole_mask",
         "invalid_tb_mask",
         "bt_weather_mask",
         "nt_weather_mask",
@@ -355,6 +354,15 @@ def reproject_ideds_25to12(
     for var_name in block_regrid_vars:
         reprojected_ideds[var_name] = regrid_da_25to12(
             da25=initial_ecdr_ds[var_name],
+            hemisphere=hemisphere,
+            reprojection_da=reprojection_da,
+            prefer_block=True,
+        )
+
+    # pole_mask is only in Northern Hemisphere
+    if hemisphere == "north":
+        reprojected_ideds["pole_mask"] = regrid_da_25to12(
+            da25=initial_ecdr_ds["pole_mask"],
             hemisphere=hemisphere,
             reprojection_da=reprojection_da,
             prefer_block=True,


### PR DESCRIPTION
There were some issues with running the southern hemisphere, eg that the pole_mask field does not occur there and therefore doesn't need to be regridded from 25km to 12.5km.

Also, because the complete_daily file generation process uses the prior-day's melt_onset field, the complete_daily files cannot be created in a multiprocessor batch...because the order matters.  (At least from March - Sep which is the melt season).  

So I commented out that part of the multiprocess loop.  This could be replaced with, say, a year-by-year set of processes?