### PR TITLE
Expect monthly data to have vlaues < 10%.

### DIFF
--- a/seaice_ecdr/validation.py
+++ b/seaice_ecdr/validation.py
@@ -266,9 +266,15 @@ def get_pixel_counts(
     # Note: we use 0.0999 instead of 0.1 because SIC values of 10% are
     # decoded from the integer value of 10 to 0.1, which is represented
     # as 0.099999 as a floating point data.
-    less_than_10_sic = int(((seaice_conc_var > 0) & (seaice_conc_var <= 0.0999)).sum())
     gt_100_sic = int((seaice_conc_var > 1).sum())
-    num_bad_pixels = less_than_10_sic + gt_100_sic
+    if product == "daily":
+        less_than_10_sic = int(
+            ((seaice_conc_var > 0) & (seaice_conc_var <= 0.0999)).sum()
+        )
+        num_bad_pixels = less_than_10_sic + gt_100_sic
+    else:
+        # We expect monthly data to contain values < 10%.
+        num_bad_pixels = gt_100_sic
 
     # Number of melt pixels
     if hemisphere == "north":


### PR DESCRIPTION
Expect monthly data to have SIC values < 10%. When daily data is averaged, pixels can take on values < 10%, especially along the ice edge.

The daily data still get flagged if values of <10% occur, but we know this happens. For now, we'll allow it. We think this is the result of temporal interpolation, because the initial daily code sets anything <10% to 0.