### PR TITLE
Create checksums files for new complete data

### DIFF
--- a/seaice_ecdr/checksum.py
+++ b/seaice_ecdr/checksum.py
@@ -17,25 +17,40 @@ def _get_checksum(filepath):
         return hashlib.md5(file.read()).hexdigest()
 
 
+def get_checksum_filepath(
+    *,
+    input_filepath: Path,
+    ecdr_data_dir: Path,
+    product_type: Literal["complete_daily", "monthly", "aggregate"],
+) -> Path:
+    checksum_dir = get_checksum_dir(ecdr_data_dir=ecdr_data_dir)
+    checksum_product_dir = checksum_dir / product_type
+    checksum_product_dir.mkdir(exist_ok=True)
+
+    checksum_filename = input_filepath.name + ".mnf"
+    checksum_dir = get_checksum_dir(ecdr_data_dir=ecdr_data_dir)
+    checksum_filepath = checksum_dir / product_type / checksum_filename
+
+    return checksum_filepath
+
+
 def write_checksum_file(
     *,
     input_filepath: Path,
     ecdr_data_dir: Path,
     product_type: Literal["complete_daily", "monthly", "aggregate"],
 ):
-    checksum_dir = get_checksum_dir(ecdr_data_dir=ecdr_data_dir)
-    checksum_product_dir = checksum_dir / product_type
-    checksum_product_dir.mkdir(exist_ok=True)
-
     checksum = _get_checksum(input_filepath)
 
     size_in_bytes = input_filepath.stat().st_size
-    filename = input_filepath.name
-
-    output_filepath = checksum_product_dir / (filename + ".mnf")
+    output_filepath = get_checksum_filepath(
+        input_filepath=input_filepath,
+        ecdr_data_dir=ecdr_data_dir,
+        product_type=product_type,
+    )
 
     with open(output_filepath, "w") as checksum_file:
-        checksum_file.write(f"{filename},{checksum},{size_in_bytes}")
+        checksum_file.write(f"{input_filepath.name},{checksum},{size_in_bytes}")
 
     logger.info(f"Wrote checksum file {output_filepath}")
 

--- a/seaice_ecdr/checksum.py
+++ b/seaice_ecdr/checksum.py
@@ -39,7 +39,7 @@ def write_checksum_file(
     input_filepath: Path,
     ecdr_data_dir: Path,
     product_type: Literal["complete_daily", "monthly", "aggregate"],
-):
+) -> Path:
     checksum = _get_checksum(input_filepath)
 
     size_in_bytes = input_filepath.stat().st_size
@@ -53,6 +53,8 @@ def write_checksum_file(
         checksum_file.write(f"{input_filepath.name},{checksum},{size_in_bytes}")
 
     logger.info(f"Wrote checksum file {output_filepath}")
+
+    return output_filepath
 
 
 def get_checksum_dir(*, ecdr_data_dir: Path):

--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -13,6 +13,7 @@ from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import get_ancillary_ds
+from seaice_ecdr.checksum import write_checksum_file
 from seaice_ecdr.complete_daily_ecdr import get_ecdr_filepath
 from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
 from seaice_ecdr.nc_attrs import get_global_attrs
@@ -157,6 +158,13 @@ def make_daily_aggregate_netcdf_for_year(
         )
 
     logger.info(f"Wrote daily aggregate file for year={year} to {output_path}")
+
+    # Write checksum file for the aggregate daily output.
+    write_checksum_file(
+        input_filepath=output_path,
+        ecdr_data_dir=ecdr_data_dir,
+        product_type="aggregate",
+    )
 
 
 @click.command(name="daily-aggregate")

--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -37,6 +37,7 @@ from pm_tb_data._types import NORTH, Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS, SUPPORTED_SAT
 from seaice_ecdr.ancillary import flag_value_for_meaning
+from seaice_ecdr.checksum import write_checksum_file
 from seaice_ecdr.complete_daily_ecdr import get_ecdr_filepath
 from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
 from seaice_ecdr.nc_attrs import get_global_attrs
@@ -665,6 +666,13 @@ def make_monthly_nc(
         ],
     )
     logger.info(f"Wrote monthly file for {year=} and {month=} to {output_path}")
+
+    # Write checksum file for the monthly output.
+    write_checksum_file(
+        input_filepath=output_path,
+        ecdr_data_dir=ecdr_data_dir,
+        product_type="monthly",
+    )
 
     return output_path
 

--- a/seaice_ecdr/monthly_aggregate.py
+++ b/seaice_ecdr/monthly_aggregate.py
@@ -12,6 +12,7 @@ from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import get_ancillary_ds
+from seaice_ecdr.checksum import write_checksum_file
 from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
 from seaice_ecdr.monthly import get_monthly_dir
 from seaice_ecdr.nc_attrs import get_global_attrs
@@ -188,6 +189,13 @@ def cli(
         )
 
     logger.info(f"Wrote monthly aggregate file to {output_filepath}")
+
+    # Write checksum file for the aggregate monthly output.
+    write_checksum_file(
+        input_filepath=output_filepath,
+        ecdr_data_dir=ecdr_data_dir,
+        product_type="aggregate",
+    )
 
     # Cleanup previously existing monthly aggregates.
     existing_fn_pattern = f"sic_ps{hemisphere[0]}{resolution}_??????-??????_*.nc"

--- a/seaice_ecdr/tests/integration/test_complete_daily.py
+++ b/seaice_ecdr/tests/integration/test_complete_daily.py
@@ -2,6 +2,7 @@ import datetime as dt
 
 from pm_tb_data._types import NORTH
 
+from seaice_ecdr.checksum import get_checksum_filepath
 from seaice_ecdr.complete_daily_ecdr import make_cdecdr_netcdf
 from seaice_ecdr.tests.integration import ecdr_data_dir_test_path  # noqa
 
@@ -16,3 +17,11 @@ def test_make_cdecdr_netcdf(ecdr_data_dir_test_path):  # noqa
         )
 
         assert output_path.is_file()
+
+        # Assert that the checksums exist where we expect them to be.
+        checksum_filepath = get_checksum_filepath(
+            input_filepath=output_path,
+            ecdr_data_dir=ecdr_data_dir_test_path,
+            product_type="complete_daily",
+        )
+        assert checksum_filepath.is_file()

--- a/seaice_ecdr/tests/integration/test_monthly.py
+++ b/seaice_ecdr/tests/integration/test_monthly.py
@@ -3,6 +3,7 @@ import xarray as xr
 from pm_tb_data._types import NORTH
 
 from seaice_ecdr import monthly
+from seaice_ecdr.checksum import get_checksum_filepath
 from seaice_ecdr.tests.integration import ecdr_data_dir_test_path  # noqa
 
 
@@ -29,3 +30,11 @@ def test_make_monthly_nc(ecdr_data_dir_test_path, monkeypatch):  # noqa
     # by `make_monthly_ds`
     ds = xr.open_dataset(output_path)
     assert ds is not None
+
+    # Assert that the checksums exist where we expect them to be.
+    checksum_filepath = get_checksum_filepath(
+        input_filepath=output_path,
+        ecdr_data_dir=ecdr_data_dir_test_path,
+        product_type="monthly",
+    )
+    assert checksum_filepath.is_file()

--- a/seaice_ecdr/tests/regression/test_daily_aggregate.py
+++ b/seaice_ecdr/tests/regression/test_daily_aggregate.py
@@ -5,6 +5,7 @@ from typing import Final
 import xarray as xr
 from pm_tb_data._types import NORTH
 
+from seaice_ecdr.checksum import get_checksum_filepath
 from seaice_ecdr.complete_daily_ecdr import read_or_create_and_read_cdecdr_ds
 from seaice_ecdr.daily_aggregate import (
     get_daily_aggregate_filepath,
@@ -50,6 +51,14 @@ def test_daily_aggreagate_matches_daily_data(tmpdir):
     # Assert that there are data for each of the three expected dates, and that
     # they match the daily final datasets.
     agg_ds = xr.open_dataset(aggregate_filepath)
+
+    # Assert that the checksums exist where we expect them to be.
+    checksum_filepath = get_checksum_filepath(
+        input_filepath=aggregate_filepath,
+        ecdr_data_dir=tmpdir_path,
+        product_type="aggregate",
+    )
+    assert checksum_filepath.is_file()
 
     for day, daily_ds in zip(range(1, 3 + 1), datasets):
         # Select the current day from the aggregate dataset. This drops `time`

--- a/seaice_ecdr/tests/unit/test_checksum.py
+++ b/seaice_ecdr/tests/unit/test_checksum.py
@@ -1,0 +1,27 @@
+from seaice_ecdr.checksum import _get_checksum, write_checksum_file
+
+
+def test_write_checksum_file(tmp_path):
+    example_file = tmp_path / "foo.nc"
+
+    some_completely_random_data = b"some completely random data"
+    with open(example_file, "wb") as mock_nc_file:
+        mock_nc_file.write(some_completely_random_data)
+
+    size_in_bytes = example_file.stat().st_size
+    checksum_of_data = _get_checksum(example_file)
+
+    checksum_file = write_checksum_file(
+        input_filepath=example_file,
+        ecdr_data_dir=tmp_path,
+        product_type="complete_daily",
+    )
+
+    assert checksum_file.is_file()
+    # The checksum file should be the input file's name + ".mnf".
+    assert checksum_file.name == example_file.name + ".mnf"
+
+    assert (
+        checksum_file.read_text()
+        == f"{example_file.name},{checksum_of_data},{size_in_bytes}"
+    )

--- a/seaice_ecdr/tests/unit/test_checksum.py
+++ b/seaice_ecdr/tests/unit/test_checksum.py
@@ -2,25 +2,29 @@ from seaice_ecdr.checksum import _get_checksum, write_checksum_file
 
 
 def test_write_checksum_file(tmp_path):
+    # Write mock data to a temporary file.
     example_file = tmp_path / "foo.nc"
-
-    some_completely_random_data = b"some completely random data"
     with open(example_file, "wb") as mock_nc_file:
-        mock_nc_file.write(some_completely_random_data)
+        mock_nc_file.write(b"some completely random data")
 
+    # Get the size and checksum.
     size_in_bytes = example_file.stat().st_size
     checksum_of_data = _get_checksum(example_file)
 
+    # Use the function being tested to create a checksum file.
     checksum_file = write_checksum_file(
         input_filepath=example_file,
         ecdr_data_dir=tmp_path,
         product_type="complete_daily",
     )
 
+    # Assert that it was written.
     assert checksum_file.is_file()
     # The checksum file should be the input file's name + ".mnf".
     assert checksum_file.name == example_file.name + ".mnf"
 
+    # The contents should be the a single line of comma-separated-values:
+    # {input_filename},{checksum},{size_in_bytes}`
     assert (
         checksum_file.read_text()
         == f"{example_file.name},{checksum_of_data},{size_in_bytes}"


### PR DESCRIPTION
Adds code to generate checksum files when producing complete/final nc files. For our beta release, we just ran the `checksums` module as a script and generated the checksum files all at once, after we had generated the data. Operationally, we'll generate checksum files as new data are produced.