### PR TITLE
Lance complete daily

### DIFF
--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -259,7 +259,11 @@ def create_melt_onset_field(
         return None
 
     day_of_year = int(date.strftime("%j"))
-    if (day_of_year < first_melt_doy) or (day_of_year > last_melt_doy):
+    outside_of_melt_season = (day_of_year < first_melt_doy) or (
+        day_of_year > last_melt_doy
+    )
+    is_first_day_of_melt = day_of_year == first_melt_doy
+    if is_first_day_of_melt or outside_of_melt_season:
         melt_onset_field = _filled_ndarray(
             hemisphere=hemisphere,
             resolution=resolution,
@@ -268,15 +272,6 @@ def create_melt_onset_field(
         )
         logger.info(f"returning empty melt_onset_field for {day_of_year}")
         return melt_onset_field
-    elif day_of_year == first_melt_doy:
-        # This is the first day with melt onset
-        prior_melt_onset_field = _filled_ndarray(
-            hemisphere=hemisphere,
-            resolution=resolution,
-            fill_value=no_melt_flag,
-            dtype=np.uint8,
-        )
-        logger.info(f"using empty melt_onset_field for prior for {day_of_year}")
     else:
         prior_melt_onset_field = read_or_create_and_read_melt_onset_field(
             date=date - dt.timedelta(days=1),

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -116,7 +116,7 @@ def filled_ndarray(
     return array
 
 
-def read_melt_onset_field(
+def read_or_create_and_read_melt_onset_field(
     *,
     date,
     hemisphere,
@@ -137,7 +137,7 @@ def read_melt_onset_field(
     return melt_onset_from_ds
 
 
-def read_melt_elements(
+def read_or_create_and_read_melt_elements(
     *,
     date,
     hemisphere,
@@ -206,7 +206,7 @@ def create_melt_onset_field(
         )
         logger.info(f"using empty melt_onset_field for prior for {day_of_year}")
     else:
-        prior_melt_onset_field = read_melt_onset_field(
+        prior_melt_onset_field = read_or_create_and_read_melt_onset_field(
             date=date - dt.timedelta(days=1),
             hemisphere=hemisphere,
             resolution=resolution,
@@ -214,7 +214,7 @@ def create_melt_onset_field(
         )
         logger.info(f"using read melt_onset_field for prior for {day_of_year}")
 
-    cdr_conc_ti, tb_h19, tb_h37 = read_melt_elements(
+    cdr_conc_ti, tb_h19, tb_h37 = read_or_create_and_read_melt_elements(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -243,10 +243,7 @@ def create_melt_onset_field(
 
     day_of_year = int(date.strftime("%j"))
     # Determine if the given day of year is within the melt season. If it's not,
-    # return an empty melt onset field. The first day should also have an empty
-    # melt onset field.
-
-    is_first_day_of_melt = day_of_year == MELT_SEASON_FIRST_DOY
+    # return an empty melt onset field.
     if not date_in_nh_melt_season(date=date):
         logger.info(f"returning empty melt_onset_field for {day_of_year}")
         return _empty_melt_onset_field(
@@ -254,13 +251,19 @@ def create_melt_onset_field(
             resolution=resolution,
         )
 
+    is_first_day_of_melt = day_of_year == MELT_SEASON_FIRST_DOY
     if is_first_day_of_melt:
+        # The first day of the melt seasion should start with an empty melt
+        # onset field.
         prior_melt_onset_field = _empty_melt_onset_field(
             hemisphere=hemisphere,
             resolution=resolution,
         )
         logger.info(f"using empty melt_onset_field for prior for {day_of_year}")
     else:
+        # During the melt season, try to read the previous day's input as a
+        # starting point. Use an empty melt onset field if no data for the
+        # previous day is available.
         try:
             prior_melt_onset_field = read_melt_onset_field_from_complete_daily(
                 date=date - dt.timedelta(days=1),

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -367,7 +367,7 @@ def create_melt_onset_field(
     return updated_melt_onset
 
 
-def standard_complete_daily_ecdr_dataset(
+def complete_daily_ecdr_ds(
     *,
     tie_ds: xr.Dataset,
     date: dt.date,
@@ -562,7 +562,7 @@ def make_standard_cdecdr_netcdf(
                 overwrite_cde=overwrite_cde,
             )
 
-        cde_ds = standard_complete_daily_ecdr_dataset(
+        cde_ds = complete_daily_ecdr_ds(
             tie_ds=tie_ds,
             date=date,
             hemisphere=hemisphere,

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -518,6 +518,9 @@ def make_standard_cdecdr_netcdf(
     """Create a 'standard', complete (ready for prod) daily CDR NetCDF file.
 
     'standard' files are those that use the non-NRT input sources.
+
+    This function is recursive. It will attempt to create earlier complete daily
+    files if they do not exist.
     """
     cde_filepath = get_ecdr_filepath(
         date=date,

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -88,7 +88,7 @@ def read_tiecdr_ds(
 
 
 # TODO: this should be in the temporal interpolation module.
-def read_or_create_and_read_tiecdr_ds(
+def read_or_create_and_read_standard_tiecdr_ds(
     *,
     date: dt.date,
     hemisphere: Hemisphere,
@@ -96,7 +96,10 @@ def read_or_create_and_read_tiecdr_ds(
     ecdr_data_dir: Path,
     overwrite_tie: bool = False,
 ) -> xr.Dataset:
-    """Read an tiecdr netCDF file, creating it if it doesn't exist."""
+    """Read an tiecdr netCDF file, creating it if it doesn't exist.
+
+    Uses standard input sources (non-NRT).
+    """
     make_tiecdr_netcdf(
         date=date,
         hemisphere=hemisphere,
@@ -157,7 +160,7 @@ def read_melt_onset_field_from_complete_daily(
     return melt_onset_from_ds
 
 
-def read_or_create_and_read_melt_onset_field(
+def read_or_create_and_read_standard_melt_onset_field(
     *,
     date,
     hemisphere,
@@ -165,7 +168,10 @@ def read_or_create_and_read_melt_onset_field(
     ecdr_data_dir: Path,
     overwrite: bool,
 ) -> npt.NDArray:
-    """Return the melt onset field for this complete daily eCDR file."""
+    """Return the melt onset field for this complete daily eCDR file.
+
+    Uses standard input sources (non-NRT).
+    """
     make_standard_cdecdr_netcdf(
         date=date,
         hemisphere=hemisphere,
@@ -205,7 +211,7 @@ def read_melt_elements_from_tiecdr(
     )
 
 
-def read_or_create_and_read_melt_elements(
+def read_or_create_and_read_standard_melt_elements(
     *,
     date: dt.date,
     hemisphere: Hemisphere,
@@ -213,7 +219,10 @@ def read_or_create_and_read_melt_elements(
     ecdr_data_dir: Path,
     overwrite: bool,
 ):
-    """Return the elements from tiecdr needed to calculate melt."""
+    """Return the elements from tiecdr needed to calculate melt.
+
+    Uses standard input sources (non-NRT).
+    """
     make_tiecdr_netcdf(
         date=date,
         hemisphere=hemisphere,
@@ -313,7 +322,7 @@ def create_melt_onset_field(
         )
         logger.info(f"using empty melt_onset_field for prior for {day_of_year}")
     else:
-        prior_melt_onset_field = read_or_create_and_read_melt_onset_field(
+        prior_melt_onset_field = read_or_create_and_read_standard_melt_onset_field(
             date=date - dt.timedelta(days=1),
             hemisphere=hemisphere,
             resolution=resolution,
@@ -322,7 +331,7 @@ def create_melt_onset_field(
         )
         logger.info(f"using read melt_onset_field for prior for {day_of_year}")
 
-    cdr_conc_ti, tb_h19, tb_h37 = read_or_create_and_read_melt_elements(
+    cdr_conc_ti, tb_h19, tb_h37 = read_or_create_and_read_standard_melt_elements(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
@@ -361,7 +370,7 @@ def complete_daily_ecdr_dataset(
       - The melt onset field
       - All appropriate QA and QC fields
     """
-    tie_ds = read_or_create_and_read_tiecdr_ds(
+    tie_ds = read_or_create_and_read_standard_tiecdr_ds(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
@@ -557,7 +566,7 @@ def read_cdecdr_ds(
     return cde_ds
 
 
-def read_or_create_and_read_cdecdr_ds(
+def read_or_create_and_read_standard_cdecdr_ds(
     *,
     date: dt.date,
     hemisphere: Hemisphere,
@@ -566,6 +575,8 @@ def read_or_create_and_read_cdecdr_ds(
     overwrite_cde: bool = False,
 ) -> xr.Dataset:
     """Read an cdecdr netCDF file, creating it if it doesn't exist.
+
+    Uses standard input sources (non-NRT).
 
     Note: this can be recursive because the melt onset field calculation
     requires the prior day's field values during the melt season.

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -160,36 +160,6 @@ def read_melt_onset_field_from_complete_daily(
     return melt_onset_from_ds
 
 
-def read_or_create_and_read_standard_melt_onset_field(
-    *,
-    date,
-    hemisphere,
-    resolution,
-    ecdr_data_dir: Path,
-    overwrite: bool,
-) -> npt.NDArray:
-    """Return the melt onset field for this complete daily eCDR file.
-
-    Uses standard input sources (non-NRT).
-    """
-    make_standard_cdecdr_netcdf(
-        date=date,
-        hemisphere=hemisphere,
-        resolution=resolution,
-        ecdr_data_dir=ecdr_data_dir,
-        overwrite_cde=overwrite,
-    )
-
-    melt_onset = read_melt_onset_field_from_complete_daily(
-        date=date,
-        hemisphere=hemisphere,
-        resolution=resolution,
-        ecdr_data_dir=ecdr_data_dir,
-    )
-
-    return melt_onset
-
-
 def read_melt_elements_from_tiecdr(
     *,
     date: dt.date,
@@ -209,36 +179,6 @@ def read_melt_elements_from_tiecdr(
         tie_ds["h19_day_si"].to_numpy(),
         tie_ds["h37_day_si"].to_numpy(),
     )
-
-
-def read_or_create_and_read_standard_melt_elements(
-    *,
-    date: dt.date,
-    hemisphere: Hemisphere,
-    resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ecdr_data_dir: Path,
-    overwrite: bool,
-):
-    """Return the elements from tiecdr needed to calculate melt.
-
-    Uses standard input sources (non-NRT).
-    """
-    make_tiecdr_netcdf(
-        date=date,
-        hemisphere=hemisphere,
-        resolution=resolution,
-        ecdr_data_dir=ecdr_data_dir,
-        overwrite=overwrite,
-    )
-
-    melt_elements = read_melt_elements_from_tiecdr(
-        date=date,
-        hemisphere=hemisphere,
-        resolution=resolution,
-        ecdr_data_dir=ecdr_data_dir,
-    )
-
-    return melt_elements
 
 
 def update_melt_onset_for_day(

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -166,7 +166,7 @@ def read_or_create_and_read_melt_onset_field(
     overwrite: bool,
 ) -> npt.NDArray:
     """Return the melt onset field for this complete daily eCDR file."""
-    make_cdecdr_netcdf(
+    make_standard_cdecdr_netcdf(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
@@ -498,7 +498,7 @@ def write_cde_netcdf(
     return output_filepath
 
 
-def make_cdecdr_netcdf(
+def make_standard_cdecdr_netcdf(
     *,
     date: dt.date,
     hemisphere: Hemisphere,
@@ -506,6 +506,10 @@ def make_cdecdr_netcdf(
     ecdr_data_dir: Path,
     overwrite_cde: bool = False,
 ) -> Path:
+    """Create a 'standard', complete (ready for prod) daily CDR NetCDF file.
+
+    'standard' files are those that use the non-NRT input sources.
+    """
     cde_filepath = get_ecdr_filepath(
         date=date,
         hemisphere=hemisphere,
@@ -566,7 +570,7 @@ def read_or_create_and_read_cdecdr_ds(
     Note: this can be recursive because the melt onset field calculation
     requires the prior day's field values during the melt season.
     """
-    make_cdecdr_netcdf(
+    make_standard_cdecdr_netcdf(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
@@ -593,7 +597,7 @@ def create_cdecdr_for_date(
     overwrite_cde: bool = False,
 ) -> None:
     try:
-        make_cdecdr_netcdf(
+        make_standard_cdecdr_netcdf(
             date=date,
             hemisphere=hemisphere,
             resolution=resolution,

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -28,6 +28,7 @@ from seaice_ecdr.melt import (
     MELT_ONSET_FILL_VALUE,
     MELT_SEASON_FIRST_DOY,
     MELT_SEASON_LAST_DOY,
+    date_in_nh_melt_season,
     melting,
 )
 from seaice_ecdr.platforms import (
@@ -215,17 +216,6 @@ def update_melt_onset_for_day(
     return melt_onset_field
 
 
-def date_in_melt_season(*, date: dt.date) -> bool:
-    day_of_year = int(date.strftime("%j"))
-    outside_of_melt_season = (day_of_year < MELT_SEASON_FIRST_DOY) or (
-        day_of_year > MELT_SEASON_LAST_DOY
-    )
-
-    inside_melt_season = not outside_of_melt_season
-
-    return inside_melt_season
-
-
 def create_melt_onset_field(
     *,
     date: dt.date,
@@ -257,7 +247,7 @@ def create_melt_onset_field(
     # melt onset field.
 
     is_first_day_of_melt = day_of_year == MELT_SEASON_FIRST_DOY
-    if not date_in_melt_season(date=date):
+    if not date_in_nh_melt_season(date=date):
         logger.info(f"returning empty melt_onset_field for {day_of_year}")
         return _empty_melt_onset_field(
             hemisphere=hemisphere,
@@ -493,7 +483,7 @@ def make_standard_cdecdr_netcdf(
         # generates the necessary intermediate files for the target date, and
         # then this code would be solely responsible for reading the previous
         # day's complete field.
-        if date_in_melt_season(date=date - dt.timedelta(days=1)):
+        if date_in_nh_melt_season(date=date - dt.timedelta(days=1)):
             make_standard_cdecdr_netcdf(
                 date=date - dt.timedelta(days=1),
                 hemisphere=hemisphere,

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -358,6 +358,7 @@ def create_melt_onset_field(
 
 def standard_complete_daily_ecdr_dataset(
     *,
+    tie_ds: xr.Dataset,
     date: dt.date,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
@@ -370,12 +371,6 @@ def standard_complete_daily_ecdr_dataset(
       - The melt onset field
       - All appropriate QA and QC fields
     """
-    tie_ds = read_or_create_and_read_standard_tiecdr_ds(
-        date=date,
-        hemisphere=hemisphere,
-        resolution=resolution,
-        ecdr_data_dir=ecdr_data_dir,
-    )
     cde_ds = tie_ds.copy()
 
     melt_onset_field = create_melt_onset_field(
@@ -530,7 +525,15 @@ def make_standard_cdecdr_netcdf(
 
     if overwrite_cde or not cde_filepath.is_file():
         logger.info(f"Creating cdecdr for {date=}, {hemisphere=}, {resolution=}")
+
+        tie_ds = read_or_create_and_read_standard_tiecdr_ds(
+            date=date,
+            hemisphere=hemisphere,
+            resolution=resolution,
+            ecdr_data_dir=ecdr_data_dir,
+        )
         cde_ds = standard_complete_daily_ecdr_dataset(
+            tie_ds=tie_ds,
             date=date,
             hemisphere=hemisphere,
             resolution=resolution,

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -215,7 +215,7 @@ def update_melt_onset_for_day(
     return melt_onset_field
 
 
-def date_in_melt_seasion(*, date: dt.date) -> bool:
+def date_in_melt_season(*, date: dt.date) -> bool:
     day_of_year = int(date.strftime("%j"))
     outside_of_melt_season = (day_of_year < MELT_SEASON_FIRST_DOY) or (
         day_of_year > MELT_SEASON_LAST_DOY
@@ -257,7 +257,7 @@ def create_melt_onset_field(
     # melt onset field.
 
     is_first_day_of_melt = day_of_year == MELT_SEASON_FIRST_DOY
-    if not date_in_melt_seasion(date=date):
+    if not date_in_melt_season(date=date):
         logger.info(f"returning empty melt_onset_field for {day_of_year}")
         return _empty_melt_onset_field(
             hemisphere=hemisphere,
@@ -493,7 +493,7 @@ def make_standard_cdecdr_netcdf(
         # generates the necessary intermediate files for the target date, and
         # then this code would be solely responsible for reading the previous
         # day's complete field.
-        if date_in_melt_seasion(date=date - dt.timedelta(days=1)):
+        if date_in_melt_season(date=date - dt.timedelta(days=1)):
             make_standard_cdecdr_netcdf(
                 date=date - dt.timedelta(days=1),
                 hemisphere=hemisphere,

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -114,7 +114,7 @@ def read_or_create_and_read_tiecdr_ds(
     return tie_ds
 
 
-def filled_ndarray(
+def _filled_ndarray(
     *,
     hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
@@ -260,7 +260,7 @@ def create_melt_onset_field(
 
     day_of_year = int(date.strftime("%j"))
     if (day_of_year < first_melt_doy) or (day_of_year > last_melt_doy):
-        melt_onset_field = filled_ndarray(
+        melt_onset_field = _filled_ndarray(
             hemisphere=hemisphere,
             resolution=resolution,
             fill_value=no_melt_flag,
@@ -270,7 +270,7 @@ def create_melt_onset_field(
         return melt_onset_field
     elif day_of_year == first_melt_doy:
         # This is the first day with melt onset
-        prior_melt_onset_field = filled_ndarray(
+        prior_melt_onset_field = _filled_ndarray(
             hemisphere=hemisphere,
             resolution=resolution,
             fill_value=no_melt_flag,

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -599,7 +599,7 @@ def read_or_create_and_read_standard_cdecdr_ds(
     return cde_ds
 
 
-def create_cdecdr_for_date(
+def create_standard_cdecdr_for_date(
     date: dt.date,
     *,
     hemisphere: Hemisphere,
@@ -640,7 +640,7 @@ def create_cdecdr_for_date(
             traceback.print_exc(file=sys.stdout)
 
 
-def create_cdecdr_for_date_range(
+def create_standard_cdecdr_for_date_range(
     *,
     hemisphere: Hemisphere,
     start_date: dt.date,
@@ -651,7 +651,7 @@ def create_cdecdr_for_date_range(
 ) -> None:
     """Generate the complete daily ecdr files for a range of dates."""
     for date in date_range(start_date=start_date, end_date=end_date):
-        create_cdecdr_for_date(
+        create_standard_cdecdr_for_date(
             hemisphere=hemisphere,
             date=date,
             resolution=resolution,
@@ -740,7 +740,7 @@ def cli(
     if end_date is None:
         end_date = copy.copy(date)
 
-    create_cdecdr_for_date_range(
+    create_standard_cdecdr_for_date_range(
         hemisphere=hemisphere,
         start_date=date,
         end_date=end_date,

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -356,7 +356,7 @@ def create_melt_onset_field(
     return updated_melt_onset
 
 
-def complete_daily_ecdr_dataset(
+def standard_complete_daily_ecdr_dataset(
     *,
     date: dt.date,
     hemisphere: Hemisphere,
@@ -450,6 +450,8 @@ def complete_daily_ecdr_dataset(
         other=np.bitwise_or(cde_ds["qa_of_cdr_seaice_conc"], 128),
     )
 
+    cde_ds = finalize_cdecdr_ds(cde_ds, hemisphere)
+
     return cde_ds
 
 
@@ -528,14 +530,12 @@ def make_standard_cdecdr_netcdf(
 
     if overwrite_cde or not cde_filepath.is_file():
         logger.info(f"Creating cdecdr for {date=}, {hemisphere=}, {resolution=}")
-        cde_ds = complete_daily_ecdr_dataset(
+        cde_ds = standard_complete_daily_ecdr_dataset(
             date=date,
             hemisphere=hemisphere,
             resolution=resolution,
             ecdr_data_dir=ecdr_data_dir,
         )
-
-        cde_ds = finalize_cdecdr_ds(cde_ds, hemisphere)
 
         written_cde_ncfile = write_cde_netcdf(
             cde_ds=cde_ds,

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -67,6 +67,24 @@ def get_ecdr_filepath(
     return ecdr_filepath
 
 
+def read_tiecdr_ds(
+    date: dt.date,
+    hemisphere: Hemisphere,
+    resolution: ECDR_SUPPORTED_RESOLUTIONS,
+    ecdr_data_dir: Path,
+) -> xr.Dataset:
+    tie_filepath = get_tie_filepath(
+        date=date,
+        hemisphere=hemisphere,
+        resolution=resolution,
+        ecdr_data_dir=ecdr_data_dir,
+    )
+    logger.info(f"Reading tieCDR file from: {tie_filepath}")
+    tie_ds = xr.load_dataset(tie_filepath)
+
+    return tie_ds
+
+
 def read_or_create_and_read_tiecdr_ds(
     *,
     date: dt.date,
@@ -89,8 +107,13 @@ def read_or_create_and_read_tiecdr_ds(
             resolution=resolution,
             ecdr_data_dir=ecdr_data_dir,
         )
-    logger.info(f"Reading tieCDR file from: {tie_filepath}")
-    tie_ds = xr.load_dataset(tie_filepath)
+
+    tie_ds = read_tiecdr_ds(
+        date=date,
+        hemisphere=hemisphere,
+        resolution=resolution,
+        ecdr_data_dir=ecdr_data_dir,
+    )
 
     return tie_ds
 
@@ -434,6 +457,25 @@ def make_cdecdr_netcdf(
     return cde_filepath
 
 
+def read_cdecdr_ds(
+    *,
+    date: dt.date,
+    hemisphere: Hemisphere,
+    resolution: ECDR_SUPPORTED_RESOLUTIONS,
+    ecdr_data_dir: Path,
+) -> xr.Dataset:
+    cde_filepath = get_ecdr_filepath(
+        date,
+        hemisphere,
+        resolution,
+        ecdr_data_dir=ecdr_data_dir,
+    )
+    logger.info(f"Reading cdeCDR file from: {cde_filepath}")
+    cde_ds = xr.load_dataset(cde_filepath)
+
+    return cde_ds
+
+
 def read_or_create_and_read_cdecdr_ds(
     *,
     date: dt.date,
@@ -462,8 +504,13 @@ def read_or_create_and_read_cdecdr_ds(
             ecdr_data_dir=ecdr_data_dir,
             overwrite_cde=overwrite_cde,
         )
-    logger.info(f"Reading cdeCDR file from: {cde_filepath}")
-    cde_ds = xr.load_dataset(cde_filepath)
+
+    cde_ds = read_cdecdr_ds(
+        date=date,
+        hemisphere=hemisphere,
+        resolution=resolution,
+        ecdr_data_dir=ecdr_data_dir,
+    )
 
     return cde_ds
 

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -253,7 +253,14 @@ def create_melt_onset_field(
             hemisphere=hemisphere,
             resolution=resolution,
         )
-    elif not is_first_day_of_melt:
+
+    if is_first_day_of_melt:
+        prior_melt_onset_field = _empty_melt_onset_field(
+            hemisphere=hemisphere,
+            resolution=resolution,
+        )
+        logger.info(f"using empty melt_onset_field for prior for {day_of_year}")
+    else:
         try:
             prior_melt_onset_field = read_melt_onset_field_from_complete_daily(
                 date=date - dt.timedelta(days=1),
@@ -266,12 +273,11 @@ def create_melt_onset_field(
             logger.warning(
                 f"Tried to read previous melt field for {day_of_year} but the file was not found."
             )
-
-    prior_melt_onset_field = _empty_melt_onset_field(
-        hemisphere=hemisphere,
-        resolution=resolution,
-    )
-    logger.info(f"using empty melt_onset_field for prior for {day_of_year}")
+            prior_melt_onset_field = _empty_melt_onset_field(
+                hemisphere=hemisphere,
+                resolution=resolution,
+            )
+            logger.info(f"using empty melt_onset_field for prior for {day_of_year}")
 
     cdr_conc_ti, tb_h19, tb_h37 = read_melt_elements_from_tiecdr(
         date=date,

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -998,7 +998,7 @@ def make_idecdr_netcdf(
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     ecdr_data_dir: Path,
-    excluded_fields: Iterable[str] = [],
+    excluded_fields,
 ) -> None:
     logger.info(f"Creating idecdr for {date=}, {hemisphere=}, {resolution=}")
     ide_ds = initial_daily_ecdr_dataset(

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -998,7 +998,7 @@ def make_idecdr_netcdf(
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     ecdr_data_dir: Path,
-    excluded_fields,
+    excluded_fields: Iterable[str],
 ) -> None:
     logger.info(f"Creating idecdr for {date=}, {hemisphere=}, {resolution=}")
     ide_ds = initial_daily_ecdr_dataset(

--- a/seaice_ecdr/melt.py
+++ b/seaice_ecdr/melt.py
@@ -28,6 +28,8 @@ Other notes:
 
 * In the CDR code, it looks like we use spatially interpolated TBs as input.
 """
+import datetime as dt
+
 import numpy as np
 import numpy.typing as npt
 
@@ -48,6 +50,18 @@ TB_DELTA_THRESHOLD_K = 2
 
 # Concentrations are provided as sea_ice_area_fraction, a number between 0 and 1
 MAX_VALID_CONCENTRATION = 1.0
+
+
+def date_in_nh_melt_season(*, date: dt.date) -> bool:
+    """Return `True` if the date is during the NH melt season."""
+    day_of_year = int(date.strftime("%j"))
+    outside_of_melt_season = (day_of_year < MELT_SEASON_FIRST_DOY) or (
+        day_of_year > MELT_SEASON_LAST_DOY
+    )
+
+    inside_melt_season = not outside_of_melt_season
+
+    return inside_melt_season
 
 
 def melting(

--- a/seaice_ecdr/multiprocess_daily.py
+++ b/seaice_ecdr/multiprocess_daily.py
@@ -8,14 +8,14 @@ import click
 from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr.cli.util import datetime_to_date
-from seaice_ecdr.complete_daily_ecdr import create_cdecdr_for_date
+from seaice_ecdr.complete_daily_ecdr import create_standard_cdecdr_for_date
 from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
 from seaice_ecdr.initial_daily_ecdr import create_idecdr_for_date
 from seaice_ecdr.temporal_composite_daily import create_tiecdr_for_date
 from seaice_ecdr.util import date_range, get_dates_by_year
 
 
-def create_cdecdr_for_dates(
+def create_standard_cdecdr_for_dates(
     dates: list[dt.date],
     *,
     hemisphere: Hemisphere,
@@ -24,7 +24,7 @@ def create_cdecdr_for_dates(
     overwrite_cde: bool = False,
 ):
     for date in dates:
-        create_cdecdr_for_date(
+        create_standard_cdecdr_for_date(
             date=date,
             hemisphere=hemisphere,
             resolution=resolution,
@@ -127,7 +127,7 @@ def cli(
     )
 
     _complete_daily_wrapper = partial(
-        create_cdecdr_for_dates,
+        create_standard_cdecdr_for_dates,
         hemisphere=hemisphere,
         resolution=resolution,
         ecdr_data_dir=ecdr_data_dir,

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -122,9 +122,27 @@ def read_or_create_and_read_nrt_idecdr_ds(
             hemisphere=hemisphere,
         )
 
+        excluded_idecdr_fields = [
+            "h19_day",
+            "v19_day",
+            "v22_day",
+            "h37_day",
+            "v37_day",
+            # "h19_day_si",  # include this field for melt onset calculation
+            "v19_day_si",
+            "v22_day_si",
+            # "h37_day_si",  # include this field for melt onset calculation
+            "v37_day_si",
+            "non_ocean_mask",
+            "invalid_ice_mask",
+            "pole_mask",
+            "bt_weather_mask",
+            "nt_weather_mask",
+        ]
         write_ide_netcdf(
             ide_ds=nrt_initial_ecdr_ds,
             output_filepath=idecdr_filepath,
+            excluded_fields=excluded_idecdr_fields,
         )
 
     ide_ds = xr.load_dataset(idecdr_filepath)

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -155,7 +155,7 @@ def temporally_interpolated_nrt_ecdr_dataset(
     date: dt.date,
     ecdr_data_dir: Path,
     overwrite: bool,
-    days_to_look_previously: int = 4,
+    days_to_look_previously: int = 5,
 ) -> xr.Dataset:
     init_datasets = []
     for date in date_range(
@@ -176,6 +176,8 @@ def temporally_interpolated_nrt_ecdr_dataset(
         hemisphere=hemisphere,
         resolution=LANCE_RESOLUTION,
         data_stack=data_stack,
+        interp_range=days_to_look_previously,
+        one_sided_limit=days_to_look_previously,
     )
 
     return temporally_interpolated_ds

--- a/seaice_ecdr/tb_data.py
+++ b/seaice_ecdr/tb_data.py
@@ -16,6 +16,7 @@ from pm_tb_data.fetch.nsidc_0007 import get_nsidc_0007_tbs_from_disk
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.platforms import SUPPORTED_SAT, get_platform_by_date
+from seaice_ecdr.util import get_ecdr_grid_shape
 
 EXPECTED_ECDR_TB_NAMES = ("h19", "v19", "v22", "h37", "v37")
 
@@ -40,12 +41,11 @@ class EcdrTbData:
 def get_null_grid(
     *, hemisphere: Hemisphere, resolution: ECDR_SUPPORTED_RESOLUTIONS
 ) -> npt.NDArray:
-    grid_shapes = {
-        "25": {"north": (448, 304), "south": (332, 316)},
-        "12.5": {"north": (896, 608), "south": (664, 632)},
-    }
-
-    null_grid = np.full(grid_shapes[resolution][hemisphere], np.nan)
+    grid_shape = get_ecdr_grid_shape(
+        hemisphere=hemisphere,
+        resolution=resolution,
+    )
+    null_grid = np.full(grid_shape, np.nan)
 
     return null_grid
 

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -841,16 +841,8 @@ def make_tiecdr_netcdf(
     ecdr_data_dir: Path,
     interp_range: int = 5,
     fill_the_pole_hole: bool = True,
+    overwrite: bool = False,
 ) -> None:
-    logger.info(f"Creating tiecdr for {date=}, {hemisphere=}, {resolution=}")
-    tie_ds = temporally_interpolated_ecdr_dataset(
-        date=date,
-        hemisphere=hemisphere,
-        resolution=resolution,
-        interp_range=interp_range,
-        ecdr_data_dir=ecdr_data_dir,
-        fill_the_pole_hole=fill_the_pole_hole,
-    )
     output_path = get_tie_filepath(
         date=date,
         hemisphere=hemisphere,
@@ -858,11 +850,22 @@ def make_tiecdr_netcdf(
         ecdr_data_dir=ecdr_data_dir,
     )
 
-    written_tie_ncfile = write_tie_netcdf(
-        tie_ds=tie_ds,
-        output_filepath=output_path,
-    )
-    logger.info(f"Wrote temporally interpolated daily ncfile: {written_tie_ncfile}")
+    if overwrite or not output_path.is_file():
+        logger.info(f"Creating tiecdr for {date=}, {hemisphere=}, {resolution=}")
+        tie_ds = temporally_interpolated_ecdr_dataset(
+            date=date,
+            hemisphere=hemisphere,
+            resolution=resolution,
+            interp_range=interp_range,
+            ecdr_data_dir=ecdr_data_dir,
+            fill_the_pole_hole=fill_the_pole_hole,
+        )
+
+        written_tie_ncfile = write_tie_netcdf(
+            tie_ds=tie_ds,
+            output_filepath=output_path,
+        )
+        logger.info(f"Wrote temporally interpolated daily ncfile: {written_tie_ncfile}")
 
 
 def create_tiecdr_for_date(

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -494,6 +494,7 @@ def temporal_interpolation(
     data_stack: xr.Dataset,
     fill_the_pole_hole: bool = True,
     interp_range: int = 5,
+    one_sided_limit: int = 3,
 ) -> xr.Dataset:
     # Initialize a new xr "temporally interpolated CDR" (tiecdr) dataset. The
     # target date is used to initialize this dataset. We retain the `time`
@@ -516,6 +517,7 @@ def temporal_interpolation(
         da=data_stack.conc,
         interp_range=interp_range,
         non_ocean_mask=non_ocean_mask,
+        one_sided_limit=one_sided_limit,
     )
 
     tie_ds["cdr_conc_ti"] = ti_var
@@ -615,6 +617,7 @@ def temporal_interpolation(
         da=data_stack.raw_bt_seaice_conc,
         interp_range=interp_range,
         non_ocean_mask=non_ocean_mask,
+        one_sided_limit=one_sided_limit,
     )
 
     nt_conc, _ = temporally_composite_dataarray(
@@ -622,6 +625,7 @@ def temporal_interpolation(
         da=data_stack.raw_bt_seaice_conc,
         interp_range=interp_range,
         non_ocean_mask=non_ocean_mask,
+        one_sided_limit=one_sided_limit,
     )
 
     # Note: this pole-filling code is copy-pasted from the cdr_conc

--- a/seaice_ecdr/tests/integration/test_complete_daily.py
+++ b/seaice_ecdr/tests/integration/test_complete_daily.py
@@ -3,13 +3,13 @@ import datetime as dt
 from pm_tb_data._types import NORTH
 
 from seaice_ecdr.checksum import get_checksum_filepath
-from seaice_ecdr.complete_daily_ecdr import make_cdecdr_netcdf
+from seaice_ecdr.complete_daily_ecdr import make_standard_cdecdr_netcdf
 from seaice_ecdr.tests.integration import ecdr_data_dir_test_path  # noqa
 
 
-def test_make_cdecdr_netcdf(ecdr_data_dir_test_path):  # noqa
+def test_make_standard_cdecdr_netcdf(ecdr_data_dir_test_path):  # noqa
     for day in range(1, 5):
-        output_path = make_cdecdr_netcdf(
+        output_path = make_standard_cdecdr_netcdf(
             date=dt.date(2022, 3, day),
             hemisphere=NORTH,
             resolution="12.5",

--- a/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
+++ b/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
@@ -135,6 +135,7 @@ def test_cli_idecdr_ncfile_creation(tmpdir):
         hemisphere=test_hemisphere,
         resolution=test_resolution,
         ecdr_data_dir=tmpdir_path,
+        excluded_fields=[],
     )
     output_path = get_idecdr_filepath(
         hemisphere=test_hemisphere,

--- a/seaice_ecdr/tests/regression/test_daily_aggregate.py
+++ b/seaice_ecdr/tests/regression/test_daily_aggregate.py
@@ -6,7 +6,7 @@ import xarray as xr
 from pm_tb_data._types import NORTH
 
 from seaice_ecdr.checksum import get_checksum_filepath
-from seaice_ecdr.complete_daily_ecdr import read_or_create_and_read_cdecdr_ds
+from seaice_ecdr.complete_daily_ecdr import read_or_create_and_read_standard_cdecdr_ds
 from seaice_ecdr.daily_aggregate import (
     get_daily_aggregate_filepath,
     make_daily_aggregate_netcdf_for_year,
@@ -23,7 +23,7 @@ def test_daily_aggreagate_matches_daily_data(tmpdir):
     # First, ensure some daily data is created.
     datasets = []
     for day in range(1, 3 + 1):
-        ds = read_or_create_and_read_cdecdr_ds(
+        ds = read_or_create_and_read_standard_cdecdr_ds(
             date=dt.date(year, 3, day),
             hemisphere=hemisphere,
             resolution=resolution,

--- a/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
+++ b/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
@@ -6,6 +6,7 @@ import numpy as np
 from pm_tb_data._types import NORTH, SOUTH
 
 from seaice_ecdr import complete_daily_ecdr as cdecdr
+from seaice_ecdr.melt import MELT_ONSET_FILL_VALUE
 
 
 def test_no_melt_onset_for_southern_hemisphere(tmpdir):
@@ -23,7 +24,6 @@ def test_no_melt_onset_for_southern_hemisphere(tmpdir):
 def test_melt_onset_field_outside_melt_season(tmpdir):
     """Verify that melt onset is all fill value when not in melt season."""
     hemisphere = NORTH
-    no_melt_flag = 255
 
     for date in (dt.date(2020, 2, 1), dt.date(2020, 10, 3)):
         melt_onset_field = cdecdr.create_melt_onset_field(
@@ -31,6 +31,5 @@ def test_melt_onset_field_outside_melt_season(tmpdir):
             hemisphere=hemisphere,
             resolution="12.5",
             ecdr_data_dir=Path(tmpdir),
-            no_melt_flag=no_melt_flag,
         )
-        assert np.all(melt_onset_field == no_melt_flag)
+        assert np.all(melt_onset_field == MELT_ONSET_FILL_VALUE)

--- a/seaice_ecdr/tests/unit/test_melt.py
+++ b/seaice_ecdr/tests/unit/test_melt.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 import numpy as np
 import numpy.testing as npt
 
@@ -91,3 +93,8 @@ def test_with_both_missing_values():
     actual = melt.melting(concentrations=concentrations, tb_h19=tb19, tb_h37=tb37)
 
     npt.assert_array_equal(expected, actual)
+
+
+def test_date_in_melt_season():
+    assert melt.date_in_nh_melt_season(date=dt.date(2021, 5, 1))
+    assert not melt.date_in_nh_melt_season(date=dt.date(2021, 1, 1))

--- a/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
+++ b/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
@@ -292,9 +292,6 @@ def test_temporal_composite_da_multiday_nrt():
     """
     still_missing_flag = 255
 
-    # Set up mock array so that left (=prior) day test values are 20 if exist
-    # Temporal flag values start at zero; add 10*prior_dist, add 1*next_dist,
-
     expected_temporal_flags = np.array(
         [
             [40, 30, 10],

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -118,3 +118,18 @@ def get_dates_by_year(dates: list[dt.date]) -> list[list[dt.date]]:
     dates_by_year_list = list(dates_by_year.values())
 
     return dates_by_year_list
+
+
+def get_ecdr_grid_shape(
+    *,
+    hemisphere: Hemisphere,
+    resolution: ECDR_SUPPORTED_RESOLUTIONS,
+) -> tuple[int, int]:
+    grid_shapes = {
+        "25": {"north": (448, 304), "south": (332, 316)},
+        "12.5": {"north": (896, 608), "south": (664, 632)},
+    }
+
+    grid_shape = grid_shapes[resolution][hemisphere]
+
+    return grid_shape

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -19,7 +19,7 @@ def typecheck(ctx):
 def unit(ctx):
     """Run unit tests."""
     print_and_run(
-        f"pytest --cov=seaice_ecdr --cov-fail-under 45 -s {PROJECT_DIR}/seaice_ecdr/tests/unit",
+        f"pytest --cov=seaice_ecdr --cov-fail-under 50 -s {PROJECT_DIR}/seaice_ecdr/tests/unit",
         pty=True,
     )
 
@@ -49,7 +49,7 @@ def pytest(ctx):
     Includes a code-coverage check.
     """
     print_and_run(
-        "pytest --cov=seaice_ecdr --cov-fail-under 75 -s",
+        "pytest --cov=seaice_ecdr --cov-fail-under 80 -s",
         pty=True,
     )
 


### PR DESCRIPTION
This PR completes the work started in #117 . This PR focuses on implementing the complete daily processing for NRT data, but also touches some elements of the temporal interpolation code as well.

To support NRT processing, some refactoring was required. The complete daily processing included steps for standard (non-NRT) processing that assumed the standard input data sources. This PR begins the work of extracting the logic necessary to generate dependent data (e.g., previous days' worth of data during the melt season) to a higher level, so that e.g., the logic to update the melt field for a given day doesn't need to be recursive. 

I also began  renaming functions that are specific to standard data inputs/processing to indicate if they are "standard" vs NRT, so that it's a little clearer which functions have built-in assumptions about how to create new data if it doesn't already exist.

There's more work that could be done here to simplify the logic and separate concerns (e.g., I'd like to split out logic that requires touching data on disk from performing operations on the resultant data more thoroughly). The work I did to add "standard" to function names in the complete daily module could also be applied to the temporal interpolation module. However, this PR still represents an improvement and the code works as expected  in my testing. Standard processing should continue to work as expected.

Still TODO: add attribute to complete daily conc fields indicating the number of missing pixels.