### PR TITLE
Move all logging-related config to `seaice_ecdr` init file

### DIFF
--- a/seaice_ecdr/__init__.py
+++ b/seaice_ecdr/__init__.py
@@ -1,1 +1,11 @@
-"""Blank __init__.py."""
+import sys
+
+from loguru import logger
+
+# Set the default minimum log notification to Warning
+try:
+    logger.remove(0)  # Removes previous logger info
+except ValueError:
+    logger.debug(f"Started logging in {__name__}")
+
+logger.add(sys.stderr, level="WARNING")

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -31,14 +31,6 @@ from seaice_ecdr.platforms import (
 )
 from seaice_ecdr.util import date_range, standard_daily_filename
 
-# Set the default minimum log notification to "info"
-try:
-    logger.remove(0)  # Removes previous logger info
-    logger.add(sys.stderr, level="INFO")
-except ValueError:
-    logger.debug(f"Started logging in {__name__}")
-    logger.add(sys.stderr, level="INFO")
-
 
 def yield_dates_from_temporal_interpolation_flags(
     ref_date: dt.date,

--- a/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
+++ b/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
@@ -5,11 +5,9 @@
 #  tests/integration/ directory.
 
 import datetime as dt
-import sys
 from pathlib import Path
 from typing import Final
 
-from loguru import logger
 from pm_tb_data._types import NORTH
 
 from seaice_ecdr.initial_daily_ecdr import get_idecdr_filepath
@@ -17,15 +15,6 @@ from seaice_ecdr.temporal_composite_daily import (
     make_tiecdr_netcdf,
     read_or_create_and_read_idecdr_ds,
 )
-
-# Set the default minimum log notification to Warning
-try:
-    logger.remove(0)  # Removes previous logger info
-    logger.add(sys.stderr, level="WARNING")
-except ValueError:
-    logger.debug(f"Started logging in {__name__}")
-    logger.add(sys.stderr, level="WARNING")
-
 
 date = dt.date(2021, 2, 19)
 hemisphere = NORTH

--- a/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
+++ b/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
@@ -1,7 +1,6 @@
 """Unit tests for initial daily ECDR generation."""
 
 import datetime as dt
-import sys
 from pathlib import Path
 from typing import Final
 
@@ -9,7 +8,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from loguru import logger
 from pm_tb_data._types import NORTH
 
 from seaice_ecdr.constants import ECDR_PRODUCT_VERSION
@@ -20,15 +18,6 @@ from seaice_ecdr.temporal_composite_daily import (
     temporally_interpolate_dataarray_using_flags,
     yield_dates_from_temporal_interpolation_flags,
 )
-
-# Set the default minimum log notification to Warning
-# TODO: Think about logging holistically...
-try:
-    logger.remove(0)  # Removes previous logger info
-    logger.add(sys.stderr, level="WARNING")
-except ValueError:
-    logger.debug(f"Started logging in {__name__}")
-    logger.add(sys.stderr, level="WARNING")
 
 
 def compose_tyx_dataarray(


### PR DESCRIPTION
This places logging config in `seaice_ecdr/__init__.py`. 

We have had this same config spread across multiple modules. Now it just exists in one place, resulting in a consistent logging output across the entire codebase.

Currently, this defaults the log-level to WARNING (meaning that info-level logs are no longer printed). This seems reasonable for operational use. Ideally this gets switched to "DEBUG" or something more verbose in dev environments by default. For now, we can manually adjust this as needed.