### PR TITLE
cause multiprocess to handle overwrite flag

### DIFF
--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -999,13 +999,8 @@ def make_idecdr_netcdf(
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     ecdr_data_dir: Path,
     excluded_fields: Iterable[str],
+    overwrite_ide: bool = False,
 ) -> None:
-    logger.info(f"Creating idecdr for {date=}, {hemisphere=}, {resolution=}")
-    ide_ds = initial_daily_ecdr_dataset(
-        date=date,
-        hemisphere=hemisphere,
-        resolution=resolution,
-    )
     platform = get_platform_by_date(date)
     output_path = get_idecdr_filepath(
         date=date,
@@ -1015,12 +1010,22 @@ def make_idecdr_netcdf(
         resolution=resolution,
     )
 
-    written_ide_ncfile = write_ide_netcdf(
-        ide_ds=ide_ds,
-        output_filepath=output_path,
-        excluded_fields=excluded_fields,
-    )
-    logger.info(f"Wrote initial daily ncfile: {written_ide_ncfile}")
+    if overwrite_ide or not output_path.is_file():
+        logger.info(f"Creating idecdr for {date=}, {hemisphere=}, {resolution=}")
+        ide_ds = initial_daily_ecdr_dataset(
+            date=date,
+            hemisphere=hemisphere,
+            resolution=resolution,
+        )
+
+        written_ide_ncfile = write_ide_netcdf(
+            ide_ds=ide_ds,
+            output_filepath=output_path,
+            excluded_fields=excluded_fields,
+        )
+        logger.info(f"Wrote initial daily ncfile: {written_ide_ncfile}")
+    else:
+        logger.info(f"idecdr file exists and {overwrite_ide=}: {output_path=}")
 
 
 def create_idecdr_for_date(
@@ -1029,6 +1034,7 @@ def create_idecdr_for_date(
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     ecdr_data_dir: Path,
+    overwrite_ide: bool = False,
     verbose_intermed_ncfile: bool = False,
 ) -> None:
     platform = get_platform_by_date(date)
@@ -1059,6 +1065,7 @@ def create_idecdr_for_date(
             resolution=resolution,
             ecdr_data_dir=ecdr_data_dir,
             excluded_fields=excluded_fields,
+            overwrite_ide=overwrite_ide,
         )
 
     # TODO: either catch and re-throw this exception or throw an error after

--- a/seaice_ecdr/multiprocess_daily.py
+++ b/seaice_ecdr/multiprocess_daily.py
@@ -119,6 +119,7 @@ def cli(
         hemisphere=hemisphere,
         resolution=resolution,
         ecdr_data_dir=ecdr_data_dir,
+        overwrite_ide=overwrite,
     )
 
     _create_tiecdr_wrapper = partial(
@@ -126,6 +127,7 @@ def cli(
         hemisphere=hemisphere,
         resolution=resolution,
         ecdr_data_dir=ecdr_data_dir,
+        overwrite_tie=overwrite,
     )
 
     _complete_daily_wrapper = partial(

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -846,7 +846,7 @@ def make_tiecdr_netcdf(
     ecdr_data_dir: Path,
     interp_range: int = 5,
     fill_the_pole_hole: bool = True,
-    overwrite: bool = False,
+    overwrite_tie: bool = False,
 ) -> None:
     output_path = get_tie_filepath(
         date=date,
@@ -855,7 +855,7 @@ def make_tiecdr_netcdf(
         ecdr_data_dir=ecdr_data_dir,
     )
 
-    if overwrite or not output_path.is_file():
+    if overwrite_tie or not output_path.is_file():
         logger.info(f"Creating tiecdr for {date=}, {hemisphere=}, {resolution=}")
         tie_ds = temporally_interpolated_ecdr_dataset(
             date=date,
@@ -879,6 +879,7 @@ def create_tiecdr_for_date(
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     ecdr_data_dir: Path,
+    overwrite_tie: bool = False,
 ) -> None:
     try:
         make_tiecdr_netcdf(
@@ -886,6 +887,7 @@ def create_tiecdr_for_date(
             hemisphere=hemisphere,
             resolution=resolution,
             ecdr_data_dir=ecdr_data_dir,
+            overwrite_tie=overwrite_tie,
         )
 
     # TODO: either catch and re-throw this exception or throw an error after


### PR DESCRIPTION
The multiprocess cli runs pools of initial_daily, temporal_interp, and complete_daily sequentially.  The means that it will end up generating all underlying files.

Because of this, the existence of a complete_daily file does not prevent the multiprocess code from generating the initial_daily and temporal_interp files.

This PR causes initial_daily and temporal_interp to respect the overwrite flag passed to the multiprocess cli.