### PR TITLE
Update pre-commit version of `black` and update files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         args: ["--fix", "--exit-non-zero-on-fix", "--verbose", "--line-length=88"]
 
   - repo: "https://github.com/psf/black"
-    rev: "23.10.1"
+    rev: "24.2.0"
     hooks:
       - id: "black"
 

--- a/scripts/ancillary/daily_clim_from_v4.py
+++ b/scripts/ancillary/daily_clim_from_v4.py
@@ -1,5 +1,6 @@
 """Adapt the CDR v4 ancillary daily climatology files for CDR v5.
 """
+
 from pathlib import Path
 from typing import get_args
 

--- a/scripts/ancillary/fix-sh-xy-attrs.py
+++ b/scripts/ancillary/fix-sh-xy-attrs.py
@@ -3,6 +3,7 @@
 The x/y variables in the SH files was missing attributes as of Jan 10,
 2024. This script fixes that issue. Should only need to be run once!
 """
+
 from typing import Final
 
 import xarray as xr

--- a/scripts/make_noaa_archive.py
+++ b/scripts/make_noaa_archive.py
@@ -6,6 +6,7 @@ release, to archive alongside the output data.
 This script creates a .zip file containing a copy of the `seaice_ecdr` git
 repository and the seaice_ecdr.constants.CDR_ANCILLARY_DIR ancillary dir.
 """
+
 import datetime as dt
 import shutil
 import subprocess

--- a/seaice_ecdr/checksum.py
+++ b/seaice_ecdr/checksum.py
@@ -3,6 +3,7 @@
 This module can be run as a script to (re-)generate checksum files for all
 existing standard (not NRT) output files.
 """
+
 import hashlib
 from pathlib import Path
 from typing import Literal

--- a/seaice_ecdr/cli/entrypoint.py
+++ b/seaice_ecdr/cli/entrypoint.py
@@ -1,4 +1,5 @@
 """entrypoint.py  Contains click commands fo seaice_ecdr."""
+
 import click
 
 from seaice_ecdr.complete_daily_ecdr import cli as complete_daily_cli

--- a/seaice_ecdr/cli/util.py
+++ b/seaice_ecdr/cli/util.py
@@ -1,4 +1,5 @@
 """util.py  cli routines common to seaice_ecdr."""
+
 import datetime as dt
 
 

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -1,6 +1,7 @@
 """Routines for generating completely filled daily eCDR files.
 
 """
+
 import copy
 import datetime as dt
 import sys

--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -1,5 +1,6 @@
 """Code to produce daily aggregate files from daily complete data.
 """
+
 import datetime as dt
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/seaice_ecdr/melt.py
+++ b/seaice_ecdr/melt.py
@@ -28,6 +28,7 @@ Other notes:
 
 * In the CDR code, it looks like we use spatially interpolated TBs as input.
 """
+
 import datetime as dt
 
 import numpy as np

--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -556,9 +556,9 @@ def make_monthly_ds(
         melt_onset_day_cdr_seaice_conc_monthly = calc_melt_onset_day_cdr_seaice_conc_monthly(
             daily_melt_onset_for_month=daily_ds_for_month.melt_onset_day_cdr_seaice_conc,
         )
-        monthly_ds_data_vars[
-            "melt_onset_day_cdr_seaice_conc_monthly"
-        ] = melt_onset_day_cdr_seaice_conc_monthly
+        monthly_ds_data_vars["melt_onset_day_cdr_seaice_conc_monthly"] = (
+            melt_onset_day_cdr_seaice_conc_monthly
+        )
 
     monthly_ds = xr.Dataset(
         data_vars=monthly_ds_data_vars,

--- a/seaice_ecdr/monthly_aggregate.py
+++ b/seaice_ecdr/monthly_aggregate.py
@@ -1,5 +1,6 @@
 """Code to produce monthly aggregate files from monthly complete data.
 """
+
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import get_args

--- a/seaice_ecdr/nc_util.py
+++ b/seaice_ecdr/nc_util.py
@@ -1,5 +1,6 @@
 """Code related to interacting with NetCDF files.
 """
+
 import subprocess
 from pathlib import Path
 

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -14,6 +14,7 @@ TODO:
   processing. Some way to tell the code on a global level that it's dealing w/
   NRT maybe?
 """
+
 import datetime as dt
 from pathlib import Path
 from typing import Final, get_args

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -1,6 +1,7 @@
 """Routines for generating temporally composited file.
 
 """
+
 import copy
 import datetime as dt
 import sys

--- a/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
+++ b/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
@@ -1,4 +1,5 @@
 """Tests of the routines in test_complete_daily_ecdr.py.  """
+
 import datetime as dt
 from pathlib import Path
 

--- a/seaice_ecdr/tests/unit/test_platforms.py
+++ b/seaice_ecdr/tests/unit/test_platforms.py
@@ -1,4 +1,5 @@
 """Test the platforms.py routine for seaice_ecdr."""
+
 import datetime as dt
 from typing import get_args
 

--- a/seaice_ecdr/validation.py
+++ b/seaice_ecdr/validation.py
@@ -39,6 +39,7 @@ varying log file parameters:
     bad: pixels that have an error (invalid sea ice value), should always be 0
     melt: pixels that have ice and are melting (north only, 1 March - 1 September only)
 """
+
 import csv
 import datetime as dt
 import itertools

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,4 +1,5 @@
 """Add format and test to collections."""
+
 from invoke import Collection
 
 from . import test

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -1,4 +1,5 @@
 """Task to run tests for this package."""
+
 from invoke import task
 
 from .util import PROJECT_DIR, print_and_run

--- a/tasks/util.py
+++ b/tasks/util.py
@@ -1,4 +1,5 @@
 """Utility routines."""
+
 from pathlib import Path
 
 from invoke import run


### PR DESCRIPTION
Update to the latest pre-commit version of `black`, which results in some changes to the formatting of most modules. The main difference is the addition of a newline between module-level docstrings and imports.