### PR TITLE
Remove invidualized log files for failures creating specific outputs

### DIFF
--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -36,7 +36,6 @@ from seaice_ecdr.platforms import (
 from seaice_ecdr.set_daily_ncattrs import finalize_cdecdr_ds
 from seaice_ecdr.temporal_composite_daily import get_tie_filepath, make_tiecdr_netcdf
 from seaice_ecdr.util import (
-    create_err_logfile,
     date_range,
     get_ecdr_grid_shape,
     raise_error_for_dates,
@@ -663,17 +662,7 @@ def create_standard_ecdr_for_dates(
             )
         except Exception:
             error_dates.append(date)
-            ecdr_filepath = get_ecdr_filepath(
-                date=date,
-                hemisphere=hemisphere,
-                resolution=resolution,
-                ecdr_data_dir=ecdr_data_dir,
-            )
-            create_err_logfile(
-                filename=ecdr_filepath.name,
-                ecdr_data_dir=ecdr_data_dir,
-                product_type="complete_daily",
-            )
+
     return error_dates
 
 

--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -21,7 +21,6 @@ from seaice_ecdr.nc_attrs import get_global_attrs
 from seaice_ecdr.nc_util import concatenate_nc_files
 from seaice_ecdr.platforms import get_first_platform_start_date
 from seaice_ecdr.util import (
-    create_err_logfile,
     sat_from_filename,
     standard_daily_aggregate_filename,
 )
@@ -248,16 +247,6 @@ def cli(
             )
         except Exception:
             failed_years.append(year_to_process)
-            create_err_logfile(
-                filename=standard_daily_aggregate_filename(
-                    hemisphere=hemisphere,
-                    resolution=resolution,
-                    start_date=dt.date(year, 1, 1),
-                    end_date=dt.date(year, 12, 31),
-                ),
-                ecdr_data_dir=ecdr_data_dir,
-                product_type="aggregate",
-            )
 
     if failed_years:
         str_formatted_years = "\n".join(str(year) for year in failed_years)

--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -42,7 +42,6 @@ from seaice_ecdr.complete_daily_ecdr import get_ecdr_filepath
 from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
 from seaice_ecdr.nc_attrs import get_global_attrs
 from seaice_ecdr.util import (
-    create_err_logfile,
     get_num_missing_pixels,
     sat_from_filename,
     standard_monthly_filename,
@@ -767,17 +766,6 @@ def cli(
             error_periods.append(period)
             logger.exception(
                 f"Failed to create monthly data for year={period.year} month={period.month}"
-            )
-            create_err_logfile(
-                filename=standard_monthly_filename(
-                    hemisphere=hemisphere,
-                    resolution=resolution,
-                    sat="error",  # type: ignore[arg-type]
-                    year=period.year,
-                    month=period.month,
-                ),
-                ecdr_data_dir=ecdr_data_dir,
-                product_type="monthly",
             )
 
     if error_periods:

--- a/seaice_ecdr/monthly_aggregate.py
+++ b/seaice_ecdr/monthly_aggregate.py
@@ -19,7 +19,6 @@ from seaice_ecdr.monthly import get_monthly_dir
 from seaice_ecdr.nc_attrs import get_global_attrs
 from seaice_ecdr.nc_util import concatenate_nc_files
 from seaice_ecdr.util import (
-    create_err_logfile,
     sat_from_filename,
     standard_monthly_aggregate_filename,
 )
@@ -218,10 +217,5 @@ def cli(
     except Exception as e:
         logger.exception(
             f"Failed to create monthly aggregate for {hemisphere=} {resolution=}"
-        )
-        create_err_logfile(
-            filename=f"monthly_aggregate_{hemisphere}_{resolution}",
-            ecdr_data_dir=ecdr_data_dir,
-            product_type="aggregate",
         )
         raise e

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -49,7 +49,7 @@ from seaice_ecdr.temporal_composite_daily import (
     temporal_interpolation,
     write_tie_netcdf,
 )
-from seaice_ecdr.util import create_err_logfile, date_range
+from seaice_ecdr.util import date_range
 
 LANCE_RESOLUTION: Final = "12.5"
 
@@ -340,11 +340,6 @@ def nrt_ecdr_for_day(
             logger.info(f"Wrote complete daily ncfile: {written_cde_ncfile}")
         except Exception as e:
             logger.exception(f"Failed to create NRT ECDR for {date=} {hemisphere=}")
-            create_err_logfile(
-                filename=cde_filepath.name,
-                ecdr_data_dir=ecdr_data_dir,
-                product_type="complete_daily",
-            )
             raise e
 
 

--- a/seaice_ecdr/tests/unit/test_util.py
+++ b/seaice_ecdr/tests/unit/test_util.py
@@ -1,5 +1,4 @@
 import datetime as dt
-from pathlib import Path
 from typing import Final
 
 import numpy as np
@@ -11,7 +10,6 @@ from seaice_ecdr import util
 from seaice_ecdr.constants import ECDR_PRODUCT_VERSION
 from seaice_ecdr.multiprocess_daily import get_dates_by_year
 from seaice_ecdr.util import (
-    create_err_logfile,
     date_range,
     get_num_missing_pixels,
     raise_error_for_dates,
@@ -211,22 +209,3 @@ def test_raise_error_for_dates():
     # If one or more dates are passed, an error should be raised.
     with pytest.raises(RuntimeError):
         raise_error_for_dates(error_dates=[dt.date(2011, 1, 1)])
-
-
-def test_create_err_logfile(tmpdir):
-    some_imaginary_product = "some_imaginary_product"
-    ecdr_data_dir = Path(tmpdir)
-    try:
-        1 / 0
-    except Exception:
-        create_err_logfile(
-            filename="foo",
-            ecdr_data_dir=ecdr_data_dir,
-            product_type=some_imaginary_product,
-        )
-
-    expected_err_path = Path(
-        ecdr_data_dir / "errors" / some_imaginary_product / "foo.error"
-    )
-    assert expected_err_path.is_file()
-    assert "ZeroDivisionError" in expected_err_path.read_text()

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -1,6 +1,5 @@
 import datetime as dt
 import re
-from pathlib import Path
 from typing import Iterator, cast, get_args
 
 import numpy as np
@@ -153,19 +152,6 @@ def get_num_missing_pixels(
     num_missing_pixels = int((seaice_conc_var.isnull() & ocean_mask).astype(int).sum())
 
     return num_missing_pixels
-
-
-def get_err_logfile_dir(
-    *,
-    ecdr_data_dir: Path,
-    product_type: str,
-):
-    errors_dir = ecdr_data_dir / "errors"
-    errors_dir.mkdir(exist_ok=True)
-    err_logfile_dir = errors_dir / product_type
-    err_logfile_dir.mkdir(exist_ok=True)
-
-    return err_logfile_dir
 
 
 def raise_error_for_dates(*, error_dates: list[dt.date]) -> None:

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -1,13 +1,11 @@
 import datetime as dt
 import re
-import traceback
 from pathlib import Path
 from typing import Iterator, cast, get_args
 
 import numpy as np
 import pandas as pd
 import xarray as xr
-from loguru import logger
 from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS, SUPPORTED_SAT
@@ -168,33 +166,6 @@ def get_err_logfile_dir(
     err_logfile_dir.mkdir(exist_ok=True)
 
     return err_logfile_dir
-
-
-def create_err_logfile(
-    *,
-    filename: str,
-    ecdr_data_dir: Path,
-    product_type: str,
-) -> None:
-    """Write the most recent exception to an error file.
-
-    Intended for logging errors around the creation of ECDR output files for
-    publication. If an exception is raised durign the production of a e.g.,
-    complete daily file, this function can be called by the complete daily
-    exception handling code to generate a file w/ the most recent
-    exception. This file has the same name as the provided `filename`, with
-    `.error` appended to the end.
-
-    Error files appear in a directory like:
-        `ecdr_data_dir / "errors" / product_type / "f{filename}.err`
-    """
-    err_logfile_dir = get_err_logfile_dir(
-        ecdr_data_dir=ecdr_data_dir, product_type=product_type
-    )
-    err_filepath = err_logfile_dir / (filename + ".error")
-    with open(err_filepath, "w") as f:
-        traceback.print_exc(file=f)
-    logger.warning(f"Wrote error info to {err_filepath}")
 
 
 def raise_error_for_dates(*, error_dates: list[dt.date]) -> None:


### PR DESCRIPTION
We'll use `loguru` to log exceptions and contextual information to a single file