### PR TITLE
Persistent logging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,4 +50,4 @@ jobs:
 
       # Unit tests
       - name: "Run typecheck and tests"
-        run: "PYTHONPATH=/home/runner/work/seaice_ecdr/seaice_ecdr/:/home/runner/work/seaice_ecdr/seaice_ecdr/pm_icecon/:/home/runner/work/seaice_ecdr/seaice_ecdr/pm_tb_data/ invoke test.ci"
+        run: "PYTHONPATH=/home/runner/work/seaice_ecdr/seaice_ecdr/:/home/runner/work/seaice_ecdr/seaice_ecdr/pm_icecon/:/home/runner/work/seaice_ecdr/seaice_ecdr/pm_tb_data/ DISABLE_FILE_LOGGING=TRUE invoke test.ci"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ Commands:
   nrt     Run NRT Sea Ice ECDR.
 ```
 
+### Logging
+
+By default, logs are written to disk at
+`/share/apps/G02202_V5/{ECDR_PRODUCT_VERSION}/{YYYY-MM-DD}.log`. Up to 31 of
+these logs can exist at once (older log files get removed).
+
+During large re-processing efforts, it may be desirable to temporarily disable
+logging to improve processing speed and reduce disk usage. To do so, set the
+`DISABLE_FILE_LOGGING` envvar to `TRUE`.
+
+```
+export DISABLE_FILE_LOGGING=TRUE
+```
+
 ## Development/contributing
 
 See [doc/development.md](doc/development.md) for more information.

--- a/seaice_ecdr/__init__.py
+++ b/seaice_ecdr/__init__.py
@@ -25,6 +25,11 @@ logger.configure(
 # level?) for speed and space consideration issues.
 do_not_log = os.environ.get("DISABLE_FILE_LOGGING")
 if not do_not_log:
+    # One file per day.
     file_sink_fp = LOGS_DIR / "{time:%Y-%m-%d}.log"
-    # Retain logs for up to a month.
-    logger.add(file_sink_fp, level=DEFAULT_LOG_LEVEL, retention=31)
+    logger.add(
+        file_sink_fp,
+        level=DEFAULT_LOG_LEVEL,
+        # Retain logs for up to a month.
+        retention=31,
+    )

--- a/seaice_ecdr/__init__.py
+++ b/seaice_ecdr/__init__.py
@@ -31,6 +31,7 @@ do_not_log = disable_file_logging is not None and disable_file_logging.upper() i
 
 if not do_not_log:
     # One file per day.
+    LOGS_DIR.mkdir(exist_ok=True)
     file_sink_fp = LOGS_DIR / "{time:%Y-%m-%d}.log"
     logger.debug(f"Logging to {file_sink_fp}")
     logger.add(

--- a/seaice_ecdr/__init__.py
+++ b/seaice_ecdr/__init__.py
@@ -23,13 +23,21 @@ logger.configure(
 # regular ops runs up to a certain date, which might help w/ debugging
 # issues...Larger reprocessing efforts could disable file logging (or change the
 # level?) for speed and space consideration issues.
-do_not_log = os.environ.get("DISABLE_FILE_LOGGING")
+disable_file_logging = os.environ.get("DISABLE_FILE_LOGGING")
+do_not_log = disable_file_logging is not None and disable_file_logging.upper() in (
+    "TRUE",
+    "YES",
+)
+
 if not do_not_log:
     # One file per day.
     file_sink_fp = LOGS_DIR / "{time:%Y-%m-%d}.log"
+    logger.debug(f"Logging to {file_sink_fp}")
     logger.add(
         file_sink_fp,
         level=DEFAULT_LOG_LEVEL,
         # Retain logs for up to a month.
         retention=31,
     )
+else:
+    logger.debug(f"Not logging to file (DISABLE_FILE_LOGGING={disable_file_logging}).")

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -6,6 +6,10 @@ ECDR_PRODUCT_VERSION = "v05r01"
 # NSIDC infrastructure-specific paths:
 NSIDC_NFS_SHARE_DIR = Path("/share/apps/G02202_V5")
 
+# Logs from running the ECDR code are saved here.
+LOGS_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_logs"
+LOGS_DIR.mkdir(exist_ok=True)
+
 # TODO: dev-specific directories for the outputs!
 
 # Outputs from the `seaice_ecdr` go to these locations.

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -8,7 +8,6 @@ NSIDC_NFS_SHARE_DIR = Path("/share/apps/G02202_V5")
 
 # Logs from running the ECDR code are saved here.
 LOGS_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_logs"
-LOGS_DIR.mkdir(exist_ok=True)
 
 # TODO: dev-specific directories for the outputs!
 


### PR DESCRIPTION
Adds "persistent" logging.

Logs are now written to `/share/apps/G02202_V5/v05r01/logs/{YYYY-MM-DD}.log`. Where YYYY-MM-DD reflects the current date.

Logs are retained for 31 days, so if a problem occurs that's how long we'd have to look at these logs. I haven't setup long-term archival for these logs, but we could.

 _Usually_ when something goes wrong in prod w/ a CLI program like this, the Jenkins logs provide enough detail (and persistence) for us to figure out what's going on w/o needing to ever look at application logs directly anyway.