### PR TITLE
Adjusted output dirs

### DIFF
--- a/seaice_ecdr/checksum.py
+++ b/seaice_ecdr/checksum.py
@@ -18,11 +18,11 @@ def _get_checksum(filepath):
 def get_checksum_filepath(
     *,
     input_filepath: Path,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
 ) -> Path:
     checksum_filename = input_filepath.name + ".mnf"
-    input_filepath_subdir = input_filepath.relative_to(ecdr_data_dir).parent
-    checksum_dir = ecdr_data_dir / "checksums" / input_filepath_subdir
+    input_filepath_subdir = input_filepath.relative_to(base_output_dir).parent
+    checksum_dir = base_output_dir / "checksums" / input_filepath_subdir
     checksum_dir.mkdir(parents=True, exist_ok=True)
     checksum_filepath = checksum_dir / checksum_filename
 
@@ -32,14 +32,14 @@ def get_checksum_filepath(
 def write_checksum_file(
     *,
     input_filepath: Path,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
 ) -> Path:
     checksum = _get_checksum(input_filepath)
 
     size_in_bytes = input_filepath.stat().st_size
     output_filepath = get_checksum_filepath(
         input_filepath=input_filepath,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
     )
 
     with open(output_filepath, "w") as checksum_file:

--- a/seaice_ecdr/checksum.py
+++ b/seaice_ecdr/checksum.py
@@ -15,33 +15,14 @@ def _get_checksum(filepath):
         return hashlib.md5(file.read()).hexdigest()
 
 
-def get_checksum_filepath(
-    *,
-    input_filepath: Path,
-    base_output_dir: Path,
-) -> Path:
-    checksum_filename = input_filepath.name + ".mnf"
-    input_filepath_subdir = input_filepath.relative_to(base_output_dir).parent
-    checksum_dir = base_output_dir / "checksums" / input_filepath_subdir
-    checksum_dir.mkdir(parents=True, exist_ok=True)
-    checksum_filepath = checksum_dir / checksum_filename
-
-    return checksum_filepath
-
-
-def write_checksum_file(
-    *,
-    input_filepath: Path,
-    base_output_dir: Path,
-) -> Path:
+def write_checksum_file(*, input_filepath: Path, output_dir: Path) -> Path:
     checksum = _get_checksum(input_filepath)
 
     size_in_bytes = input_filepath.stat().st_size
-    output_filepath = get_checksum_filepath(
-        input_filepath=input_filepath,
-        base_output_dir=base_output_dir,
-    )
 
+    checksum_filename = input_filepath.name + ".mnf"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_filepath = output_dir / checksum_filename
     with open(output_filepath, "w") as checksum_file:
         checksum_file.write(f"{input_filepath.name},{checksum},{size_in_bytes}")
 

--- a/seaice_ecdr/checksum.py
+++ b/seaice_ecdr/checksum.py
@@ -6,7 +6,6 @@ existing standard (not NRT) output files.
 
 import hashlib
 from pathlib import Path
-from typing import Literal
 
 from loguru import logger
 
@@ -20,15 +19,12 @@ def get_checksum_filepath(
     *,
     input_filepath: Path,
     ecdr_data_dir: Path,
-    product_type: Literal["daily", "monthly", "aggregate"],
 ) -> Path:
-    checksum_dir = get_checksum_dir(ecdr_data_dir=ecdr_data_dir)
-    checksum_product_dir = checksum_dir / product_type
-    checksum_product_dir.mkdir(exist_ok=True)
-
     checksum_filename = input_filepath.name + ".mnf"
-    checksum_dir = get_checksum_dir(ecdr_data_dir=ecdr_data_dir)
-    checksum_filepath = checksum_dir / product_type / checksum_filename
+    input_filepath_subdir = input_filepath.relative_to(ecdr_data_dir).parent
+    checksum_dir = ecdr_data_dir / "checksums" / input_filepath_subdir
+    checksum_dir.mkdir(parents=True, exist_ok=True)
+    checksum_filepath = checksum_dir / checksum_filename
 
     return checksum_filepath
 
@@ -37,7 +33,6 @@ def write_checksum_file(
     *,
     input_filepath: Path,
     ecdr_data_dir: Path,
-    product_type: Literal["daily", "monthly", "aggregate"],
 ) -> Path:
     checksum = _get_checksum(input_filepath)
 
@@ -45,7 +40,6 @@ def write_checksum_file(
     output_filepath = get_checksum_filepath(
         input_filepath=input_filepath,
         ecdr_data_dir=ecdr_data_dir,
-        product_type=product_type,
     )
 
     with open(output_filepath, "w") as checksum_file:
@@ -54,10 +48,3 @@ def write_checksum_file(
     logger.success(f"Wrote checksum file {output_filepath}")
 
     return output_filepath
-
-
-def get_checksum_dir(*, ecdr_data_dir: Path):
-    checksum_dir = ecdr_data_dir / "checksums"
-    checksum_dir.mkdir(exist_ok=True)
-
-    return checksum_dir

--- a/seaice_ecdr/checksum.py
+++ b/seaice_ecdr/checksum.py
@@ -10,8 +10,6 @@ from typing import Literal
 
 from loguru import logger
 
-from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
-
 
 def _get_checksum(filepath):
     with filepath.open("rb") as file:
@@ -22,7 +20,7 @@ def get_checksum_filepath(
     *,
     input_filepath: Path,
     ecdr_data_dir: Path,
-    product_type: Literal["complete_daily", "monthly", "aggregate"],
+    product_type: Literal["daily", "monthly", "aggregate"],
 ) -> Path:
     checksum_dir = get_checksum_dir(ecdr_data_dir=ecdr_data_dir)
     checksum_product_dir = checksum_dir / product_type
@@ -39,7 +37,7 @@ def write_checksum_file(
     *,
     input_filepath: Path,
     ecdr_data_dir: Path,
-    product_type: Literal["complete_daily", "monthly", "aggregate"],
+    product_type: Literal["daily", "monthly", "aggregate"],
 ) -> Path:
     checksum = _get_checksum(input_filepath)
 
@@ -63,15 +61,3 @@ def get_checksum_dir(*, ecdr_data_dir: Path):
     checksum_dir.mkdir(exist_ok=True)
 
     return checksum_dir
-
-
-if __name__ == "__main__":
-    ecdr_data_dir = STANDARD_BASE_OUTPUT_DIR
-    for product in ("complete_daily", "monthly", "aggregate"):
-        input_dir = ecdr_data_dir / product
-        for nc_filepath in input_dir.glob("*.nc"):
-            write_checksum_file(
-                input_filepath=nc_filepath,
-                ecdr_data_dir=ecdr_data_dir,
-                product_type=product,  # type: ignore[arg-type]
-            )

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -44,9 +44,11 @@ from seaice_ecdr.util import (
 
 
 @cache
-def get_ecdr_dir(*, ecdr_data_dir: Path) -> Path:
+def get_ecdr_dir(*, ecdr_data_dir: Path, year: int) -> Path:
     """Daily complete output dir for ECDR processing"""
-    ecdr_dir = ecdr_data_dir / "complete_daily"
+    complete_daily_dir = ecdr_data_dir / "complete_daily"
+    complete_daily_dir.mkdir(exist_ok=True)
+    ecdr_dir = complete_daily_dir / str(year)
     ecdr_dir.mkdir(exist_ok=True)
 
     return ecdr_dir
@@ -66,7 +68,7 @@ def get_ecdr_filepath(
         sat=platform,
         resolution=resolution,
     )
-    ecdr_dir = get_ecdr_dir(ecdr_data_dir=ecdr_data_dir)
+    ecdr_dir = get_ecdr_dir(ecdr_data_dir=ecdr_data_dir, year=date.year)
 
     ecdr_filepath = ecdr_dir / ecdr_filename
 
@@ -672,6 +674,7 @@ def create_standard_ecdr_for_dates(
                 overwrite_cde=overwrite_cde,
             )
         except Exception:
+            logger.exception(f"Failed to create standard ECDR for {date=}")
             error_dates.append(date)
 
     return error_dates

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -44,12 +44,10 @@ from seaice_ecdr.util import (
 
 
 @cache
-def get_ecdr_dir(*, ecdr_data_dir: Path, year: int) -> Path:
+def get_ecdr_dir(*, ecdr_data_dir: Path, hemisphere: Hemisphere, year: int) -> Path:
     """Daily complete output dir for ECDR processing"""
-    complete_daily_dir = ecdr_data_dir / "daily"
-    complete_daily_dir.mkdir(exist_ok=True)
-    ecdr_dir = complete_daily_dir / str(year)
-    ecdr_dir.mkdir(exist_ok=True)
+    ecdr_dir = ecdr_data_dir / hemisphere / "daily" / str(year)
+    ecdr_dir.mkdir(parents=True)
 
     return ecdr_dir
 
@@ -68,7 +66,10 @@ def get_ecdr_filepath(
         sat=platform,
         resolution=resolution,
     )
-    ecdr_dir = get_ecdr_dir(ecdr_data_dir=ecdr_data_dir, year=date.year)
+
+    ecdr_dir = get_ecdr_dir(
+        ecdr_data_dir=ecdr_data_dir, hemisphere=hemisphere, year=date.year
+    )
 
     ecdr_filepath = ecdr_dir / ecdr_filename
 

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -22,7 +22,7 @@ from seaice_ecdr.ancillary import (
 )
 from seaice_ecdr.checksum import write_checksum_file
 from seaice_ecdr.cli.util import datetime_to_date
-from seaice_ecdr.constants import BASE_OUTPUT_DIR
+from seaice_ecdr.constants import DEFAULT_BASE_OUTPUT_DIR
 from seaice_ecdr.melt import (
     MELT_ONSET_FILL_VALUE,
     MELT_SEASON_FIRST_DOY,
@@ -749,7 +749,7 @@ def create_standard_ecdr_for_dates(
         resolve_path=True,
         path_type=Path,
     ),
-    default=BASE_OUTPUT_DIR,
+    default=DEFAULT_BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -22,7 +22,7 @@ from seaice_ecdr.ancillary import (
 )
 from seaice_ecdr.checksum import write_checksum_file
 from seaice_ecdr.cli.util import datetime_to_date
-from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
+from seaice_ecdr.constants import BASE_OUTPUT_DIR
 from seaice_ecdr.melt import (
     MELT_ONSET_FILL_VALUE,
     MELT_SEASON_FIRST_DOY,
@@ -749,7 +749,7 @@ def create_standard_ecdr_for_dates(
         resolve_path=True,
         path_type=Path,
     ),
-    default=STANDARD_BASE_OUTPUT_DIR,
+    default=BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -47,7 +47,7 @@ from seaice_ecdr.util import (
 def get_ecdr_dir(*, ecdr_data_dir: Path, year: int) -> Path:
     """Daily complete output dir for ECDR processing"""
     ecdr_dir = ecdr_data_dir / "daily" / str(year)
-    ecdr_dir.mkdir(parents=True)
+    ecdr_dir.mkdir(parents=True, exist_ok=True)
 
     return ecdr_dir
 
@@ -510,7 +510,6 @@ def write_cde_netcdf(
     write_checksum_file(
         input_filepath=output_filepath,
         ecdr_data_dir=ecdr_data_dir,
-        product_type="daily",
     )
 
     return output_filepath

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -46,7 +46,7 @@ from seaice_ecdr.util import (
 @cache
 def get_ecdr_dir(*, ecdr_data_dir: Path, year: int) -> Path:
     """Daily complete output dir for ECDR processing"""
-    complete_daily_dir = ecdr_data_dir / "complete_daily"
+    complete_daily_dir = ecdr_data_dir / "daily"
     complete_daily_dir.mkdir(exist_ok=True)
     ecdr_dir = complete_daily_dir / str(year)
     ecdr_dir.mkdir(exist_ok=True)

--- a/seaice_ecdr/complete_daily_ecdr.py
+++ b/seaice_ecdr/complete_daily_ecdr.py
@@ -44,9 +44,9 @@ from seaice_ecdr.util import (
 
 
 @cache
-def get_ecdr_dir(*, ecdr_data_dir: Path, hemisphere: Hemisphere, year: int) -> Path:
+def get_ecdr_dir(*, ecdr_data_dir: Path, year: int) -> Path:
     """Daily complete output dir for ECDR processing"""
-    ecdr_dir = ecdr_data_dir / hemisphere / "daily" / str(year)
+    ecdr_dir = ecdr_data_dir / "daily" / str(year)
     ecdr_dir.mkdir(parents=True)
 
     return ecdr_dir
@@ -67,9 +67,7 @@ def get_ecdr_filepath(
         resolution=resolution,
     )
 
-    ecdr_dir = get_ecdr_dir(
-        ecdr_data_dir=ecdr_data_dir, hemisphere=hemisphere, year=date.year
-    )
+    ecdr_dir = get_ecdr_dir(ecdr_data_dir=ecdr_data_dir, year=date.year)
 
     ecdr_filepath = ecdr_dir / ecdr_filename
 
@@ -512,7 +510,7 @@ def write_cde_netcdf(
     write_checksum_file(
         input_filepath=output_filepath,
         ecdr_data_dir=ecdr_data_dir,
-        product_type="complete_daily",
+        product_type="daily",
     )
 
     return output_filepath
@@ -765,6 +763,10 @@ def cli(
     """
     if end_date is None:
         end_date = copy.copy(date)
+
+    # The data should be organized by hemisphere.
+    ecdr_data_dir = ecdr_data_dir / hemisphere
+    ecdr_data_dir.mkdir(exist_ok=True)
 
     error_dates = create_standard_ecdr_for_dates(
         dates=date_range(start_date=date, end_date=end_date),

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -11,7 +11,8 @@ LOGS_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_logs"
 
 # TODO: dev-specific directories for the outputs!
 
-# Outputs from the `seaice_ecdr` go to these locations.
+# Outputs from the `seaice_ecdr` go to these locations by default. The CLI
+# provides the option to change this.
 DEFAULT_BASE_OUTPUT_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_outputs"
 
 # Location of LANCE AMSR2 NRT data files:

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -16,11 +16,9 @@ BASE_OUTPUT_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_outputs"
 
 # Daily initial/intermediate output for 'standard' (not NRT) ECDR processing
 # (e.g, using input data from AU_SI12)
-STANDARD_BASE_OUTPUT_DIR = BASE_OUTPUT_DIR / "standard"
-
-# Daily initial/intermediate output for 'Near Real Time' (NRT) ECDR processing
-# (using data from AU_SI12_NRT_R04)
-NRT_BASE_OUTPUT_DIR = BASE_OUTPUT_DIR / "nrt"
+# TODO: utilize these.
+INTERMEDIATE_OUTPUT_DIR = BASE_OUTPUT_DIR / "intermediate"
+COMPLETE_OUTPUT_DIR = BASE_OUTPUT_DIR / "complete"
 
 # Location of LANCE AMSR2 NRT data files:
 # TODO: nest the subdir under an `ecdr_inputs` or similar?

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -14,11 +14,11 @@ LOGS_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_logs"
 # Outputs from the `seaice_ecdr` go to these locations.
 BASE_OUTPUT_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_outputs"
 
-# Daily initial/intermiedate output for 'standard' (not NRT) ECDR processing
+# Daily initial/intermediate output for 'standard' (not NRT) ECDR processing
 # (e.g, using input data from AU_SI12)
 STANDARD_BASE_OUTPUT_DIR = BASE_OUTPUT_DIR / "standard"
 
-# Daily initial/intermiedate output for 'Near Real Time' (NRT) ECDR processing
+# Daily initial/intermediate output for 'Near Real Time' (NRT) ECDR processing
 # (using data from AU_SI12_NRT_R04)
 NRT_BASE_OUTPUT_DIR = BASE_OUTPUT_DIR / "nrt"
 

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -12,13 +12,7 @@ LOGS_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_logs"
 # TODO: dev-specific directories for the outputs!
 
 # Outputs from the `seaice_ecdr` go to these locations.
-BASE_OUTPUT_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_outputs"
-
-# Daily initial/intermediate output for 'standard' (not NRT) ECDR processing
-# (e.g, using input data from AU_SI12)
-# TODO: utilize these.
-INTERMEDIATE_OUTPUT_DIR = BASE_OUTPUT_DIR / "intermediate"
-COMPLETE_OUTPUT_DIR = BASE_OUTPUT_DIR / "complete"
+DEFAULT_BASE_OUTPUT_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_outputs"
 
 # Location of LANCE AMSR2 NRT data files:
 # TODO: nest the subdir under an `ecdr_inputs` or similar?

--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -65,7 +65,7 @@ def get_daily_aggregate_filepath(
     start_date: dt.date,
     end_date: dt.date,
 ) -> Path:
-    output_dir = complete_output_dir / hemisphere / "aggregate"
+    output_dir = complete_output_dir / "aggregate"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     output_fn = standard_daily_aggregate_filename(
@@ -172,9 +172,7 @@ def make_daily_aggregate_netcdf_for_year(
         logger.success(f"Wrote daily aggregate file for year={year} to {output_path}")
 
         # Write checksum file for the aggregate daily output.
-        checksum_output_dir = (
-            complete_output_dir / hemisphere / "checksums" / "aggregate"
-        )
+        checksum_output_dir = complete_output_dir / "checksums" / "aggregate"
         write_checksum_file(
             input_filepath=output_path,
             output_dir=checksum_output_dir,
@@ -242,6 +240,8 @@ def cli(
 
     complete_output_dir = get_complete_output_dir(
         base_output_dir=base_output_dir,
+        hemisphere=hemisphere,
+        is_nrt=False,
     )
     failed_years = []
     for year_to_process in range(year, end_year + 1):

--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -64,8 +64,8 @@ def get_daily_aggregate_filepath(
     start_date: dt.date,
     end_date: dt.date,
 ) -> Path:
-    output_dir = base_output_dir / "aggregate"
-    output_dir.mkdir(exist_ok=True)
+    output_dir = base_output_dir / "complete" / hemisphere / "aggregate"
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     output_fn = standard_daily_aggregate_filename(
         hemisphere=hemisphere,
@@ -173,7 +173,11 @@ def make_daily_aggregate_netcdf_for_year(
         # Write checksum file for the aggregate daily output.
         write_checksum_file(
             input_filepath=output_path,
-            base_output_dir=base_output_dir,
+            output_dir=base_output_dir
+            / "complete"
+            / hemisphere
+            / "checksums"
+            / "aggregate",
         )
     except Exception as e:
         logger.exception(f"Failed to create daily aggregate for {year=} {hemisphere=}")
@@ -194,7 +198,7 @@ def make_daily_aggregate_netcdf_for_year(
     type=click.Choice(get_args(Hemisphere)),
 )
 @click.option(
-    "--ecdr-data-dir",
+    "--base-output-dir",
     required=True,
     type=click.Path(
         exists=True,
@@ -235,10 +239,6 @@ def cli(
 ) -> None:
     if end_year is None:
         end_year = year
-
-    # The data should be organized by hemisphere.
-    base_output_dir = base_output_dir / hemisphere
-    base_output_dir.mkdir(exist_ok=True)
 
     failed_years = []
     for year_to_process in range(year, end_year + 1):

--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -16,7 +16,7 @@ from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import get_ancillary_ds
 from seaice_ecdr.checksum import write_checksum_file
 from seaice_ecdr.complete_daily_ecdr import get_ecdr_filepath
-from seaice_ecdr.constants import BASE_OUTPUT_DIR
+from seaice_ecdr.constants import DEFAULT_BASE_OUTPUT_DIR
 from seaice_ecdr.nc_attrs import get_global_attrs
 from seaice_ecdr.nc_util import concatenate_nc_files
 from seaice_ecdr.platforms import get_first_platform_start_date
@@ -204,7 +204,7 @@ def make_daily_aggregate_netcdf_for_year(
         resolve_path=True,
         path_type=Path,
     ),
-    default=BASE_OUTPUT_DIR,
+    default=DEFAULT_BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -173,7 +173,6 @@ def make_daily_aggregate_netcdf_for_year(
         write_checksum_file(
             input_filepath=output_path,
             ecdr_data_dir=ecdr_data_dir,
-            product_type="aggregate",
         )
     except Exception as e:
         logger.exception(f"Failed to create daily aggregate for {year=} {hemisphere=}")

--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -16,7 +16,7 @@ from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import get_ancillary_ds
 from seaice_ecdr.checksum import write_checksum_file
 from seaice_ecdr.complete_daily_ecdr import get_ecdr_filepath
-from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
+from seaice_ecdr.constants import BASE_OUTPUT_DIR
 from seaice_ecdr.nc_attrs import get_global_attrs
 from seaice_ecdr.nc_util import concatenate_nc_files
 from seaice_ecdr.platforms import get_first_platform_start_date
@@ -204,7 +204,7 @@ def make_daily_aggregate_netcdf_for_year(
         resolve_path=True,
         path_type=Path,
     ),
-    default=STANDARD_BASE_OUTPUT_DIR,
+    default=BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -43,6 +43,7 @@ def _get_daily_complete_filepaths_for_year(
             hemisphere=hemisphere,
             resolution=resolution,
             ecdr_data_dir=ecdr_data_dir,
+            is_nrt=False,
         )
         if expected_fp.is_file():
             data_list.append(expected_fp)

--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -236,6 +236,10 @@ def cli(
     if end_year is None:
         end_year = year
 
+    # The data should be organized by hemisphere.
+    ecdr_data_dir = ecdr_data_dir / hemisphere
+    ecdr_data_dir.mkdir(exist_ok=True)
+
     failed_years = []
     for year_to_process in range(year, end_year + 1):
         try:

--- a/seaice_ecdr/grid_id.py
+++ b/seaice_ecdr/grid_id.py
@@ -8,7 +8,9 @@ GRID_ID = Literal["psn12.5", "pss12.5", "psn25", "pss25"]
 
 
 def get_grid_id(
-    *, hemisphere: Hemisphere, resolution: ECDR_SUPPORTED_RESOLUTIONS
+    *,
+    hemisphere: Hemisphere,
+    resolution: ECDR_SUPPORTED_RESOLUTIONS,
 ) -> GRID_ID:
     grid_id = f"ps{hemisphere[0]}{resolution}"
     if grid_id not in get_args(GRID_ID):

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -959,9 +959,9 @@ def write_ide_netcdf(
 
 
 @cache
-def get_idecdr_dir(*, intermediate_output_dir: Path, hemisphere: Hemisphere) -> Path:
+def get_idecdr_dir(*, intermediate_output_dir: Path) -> Path:
     """Daily initial output dir for ECDR processing."""
-    idecdr_dir = intermediate_output_dir / hemisphere / "initial_daily"
+    idecdr_dir = intermediate_output_dir / "initial_daily"
     idecdr_dir.mkdir(parents=True, exist_ok=True)
 
     return idecdr_dir
@@ -986,7 +986,6 @@ def get_idecdr_filepath(
     idecdr_fn = "idecdr_" + standard_fn
     idecdr_dir = get_idecdr_dir(
         intermediate_output_dir=intermediate_output_dir,
-        hemisphere=hemisphere,
     )
     idecdr_path = idecdr_dir / idecdr_fn
 
@@ -1147,6 +1146,7 @@ def cli(
     """
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=base_output_dir,
+        hemisphere=hemisphere,
         is_nrt=False,
     )
     create_idecdr_for_date(

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -959,10 +959,10 @@ def write_ide_netcdf(
 
 
 @cache
-def get_idecdr_dir(*, base_output_dir: Path) -> Path:
+def get_idecdr_dir(*, base_output_dir: Path, hemisphere: Hemisphere) -> Path:
     """Daily initial output dir for ECDR processing."""
-    idecdr_dir = base_output_dir / "initial_daily"
-    idecdr_dir.mkdir(exist_ok=True)
+    idecdr_dir = base_output_dir / "intermediate" / hemisphere / "initial_daily"
+    idecdr_dir.mkdir(parents=True, exist_ok=True)
 
     return idecdr_dir
 
@@ -984,7 +984,7 @@ def get_idecdr_filepath(
         resolution=resolution,
     )
     idecdr_fn = "idecdr_" + standard_fn
-    idecdr_dir = get_idecdr_dir(base_output_dir=base_output_dir)
+    idecdr_dir = get_idecdr_dir(base_output_dir=base_output_dir, hemisphere=hemisphere)
     idecdr_path = idecdr_dir / idecdr_fn
 
     return idecdr_path
@@ -1093,7 +1093,7 @@ def create_idecdr_for_date(
     type=click.Choice(get_args(Hemisphere)),
 )
 @click.option(
-    "--ecdr-data-dir",
+    "--base-output-dir",
     required=True,
     type=click.Path(
         exists=True,
@@ -1142,11 +1142,6 @@ def cli(
     projection, resolution, and bounds), and TBtype (TB type includes source and
     methodology for getting those TBs onto the grid)
     """
-
-    # The data should be organized by hemisphere.
-    base_output_dir = base_output_dir / hemisphere
-    base_output_dir.mkdir(exist_ok=True)
-
     create_idecdr_for_date(
         hemisphere=hemisphere,
         date=date,

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -42,7 +42,7 @@ from seaice_ecdr.ancillary import (
     nh_polehole_mask,
 )
 from seaice_ecdr.cli.util import datetime_to_date
-from seaice_ecdr.constants import BASE_OUTPUT_DIR
+from seaice_ecdr.constants import DEFAULT_BASE_OUTPUT_DIR
 from seaice_ecdr.grid_id import get_grid_id
 from seaice_ecdr.platforms import get_platform_by_date
 from seaice_ecdr.regrid_25to12 import reproject_ideds_25to12
@@ -1103,7 +1103,7 @@ def create_idecdr_for_date(
         resolve_path=True,
         path_type=Path,
     ),
-    default=BASE_OUTPUT_DIR,
+    default=DEFAULT_BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -42,7 +42,7 @@ from seaice_ecdr.ancillary import (
     nh_polehole_mask,
 )
 from seaice_ecdr.cli.util import datetime_to_date
-from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
+from seaice_ecdr.constants import BASE_OUTPUT_DIR
 from seaice_ecdr.grid_id import get_grid_id
 from seaice_ecdr.platforms import get_platform_by_date
 from seaice_ecdr.regrid_25to12 import reproject_ideds_25to12
@@ -1103,7 +1103,7 @@ def create_idecdr_for_date(
         resolve_path=True,
         path_type=Path,
     ),
-    default=STANDARD_BASE_OUTPUT_DIR,
+    default=BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -1143,6 +1143,10 @@ def cli(
     methodology for getting those TBs onto the grid)
     """
 
+    # The data should be organized by hemisphere.
+    ecdr_data_dir = ecdr_data_dir / hemisphere
+    ecdr_data_dir.mkdir(exist_ok=True)
+
     create_idecdr_for_date(
         hemisphere=hemisphere,
         date=date,

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -959,9 +959,9 @@ def write_ide_netcdf(
 
 
 @cache
-def get_idecdr_dir(*, ecdr_data_dir: Path) -> Path:
+def get_idecdr_dir(*, base_output_dir: Path) -> Path:
     """Daily initial output dir for ECDR processing."""
-    idecdr_dir = ecdr_data_dir / "initial_daily"
+    idecdr_dir = base_output_dir / "initial_daily"
     idecdr_dir.mkdir(exist_ok=True)
 
     return idecdr_dir
@@ -973,7 +973,7 @@ def get_idecdr_filepath(
     platform,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
 ) -> Path:
     """Yields the filepath of the pass1 -- idecdr -- intermediate file."""
 
@@ -984,7 +984,7 @@ def get_idecdr_filepath(
         resolution=resolution,
     )
     idecdr_fn = "idecdr_" + standard_fn
-    idecdr_dir = get_idecdr_dir(ecdr_data_dir=ecdr_data_dir)
+    idecdr_dir = get_idecdr_dir(base_output_dir=base_output_dir)
     idecdr_path = idecdr_dir / idecdr_fn
 
     return idecdr_path
@@ -995,7 +995,7 @@ def make_idecdr_netcdf(
     date: dt.date,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
     excluded_fields: Iterable[str],
     overwrite_ide: bool = False,
 ) -> None:
@@ -1004,7 +1004,7 @@ def make_idecdr_netcdf(
         date=date,
         platform=platform,
         hemisphere=hemisphere,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
         resolution=resolution,
     )
 
@@ -1031,7 +1031,7 @@ def create_idecdr_for_date(
     *,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
     overwrite_ide: bool = False,
     verbose_intermed_ncfile: bool = False,
 ) -> None:
@@ -1060,7 +1060,7 @@ def create_idecdr_for_date(
             date=date,
             hemisphere=hemisphere,
             resolution=resolution,
-            ecdr_data_dir=ecdr_data_dir,
+            base_output_dir=base_output_dir,
             excluded_fields=excluded_fields,
             overwrite_ide=overwrite_ide,
         )
@@ -1132,7 +1132,7 @@ def cli(
     *,
     date: dt.date,
     hemisphere: Hemisphere,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     verbose_intermed_ncfile: bool,
 ) -> None:
@@ -1144,13 +1144,13 @@ def cli(
     """
 
     # The data should be organized by hemisphere.
-    ecdr_data_dir = ecdr_data_dir / hemisphere
-    ecdr_data_dir.mkdir(exist_ok=True)
+    base_output_dir = base_output_dir / hemisphere
+    base_output_dir.mkdir(exist_ok=True)
 
     create_idecdr_for_date(
         hemisphere=hemisphere,
         date=date,
         resolution=resolution,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
         verbose_intermed_ncfile=verbose_intermed_ncfile,
     )

--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -743,6 +743,10 @@ def cli(
     ecdr_data_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
 ):
+    # The data should be organized by hemisphere.
+    ecdr_data_dir = ecdr_data_dir / hemisphere
+    ecdr_data_dir.mkdir(exist_ok=True)
+
     if end_year is None:
         end_year = year
     if end_month is None:

--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -89,6 +89,7 @@ def _get_daily_complete_filepaths_for_month(
             hemisphere=hemisphere,
             resolution=resolution,
             ecdr_data_dir=ecdr_data_dir,
+            is_nrt=False,
         )
         if expected_fp.is_file():
             data_list.append(expected_fp)

--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -39,7 +39,7 @@ from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS, SUPPORTED_SAT
 from seaice_ecdr.ancillary import flag_value_for_meaning
 from seaice_ecdr.checksum import write_checksum_file
 from seaice_ecdr.complete_daily_ecdr import get_ecdr_filepath
-from seaice_ecdr.constants import BASE_OUTPUT_DIR
+from seaice_ecdr.constants import DEFAULT_BASE_OUTPUT_DIR
 from seaice_ecdr.nc_attrs import get_global_attrs
 from seaice_ecdr.util import (
     get_num_missing_pixels,
@@ -719,7 +719,7 @@ def make_monthly_nc(
         resolve_path=True,
         path_type=Path,
     ),
-    default=BASE_OUTPUT_DIR,
+    default=DEFAULT_BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -72,7 +72,7 @@ def _get_daily_complete_filepaths_for_month(
     *,
     year: int,
     month: int,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
 ) -> list[Path]:
@@ -88,7 +88,7 @@ def _get_daily_complete_filepaths_for_month(
             date=period.to_timestamp().date(),
             hemisphere=hemisphere,
             resolution=resolution,
-            ecdr_data_dir=ecdr_data_dir,
+            base_output_dir=base_output_dir,
             is_nrt=False,
         )
         if expected_fp.is_file():
@@ -124,7 +124,7 @@ def get_daily_ds_for_month(
     *,
     year: int,
     month: int,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
 ) -> xr.Dataset:
@@ -137,7 +137,7 @@ def get_daily_ds_for_month(
     data_list = _get_daily_complete_filepaths_for_month(
         year=year,
         month=month,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
         hemisphere=hemisphere,
         resolution=resolution,
     )
@@ -586,8 +586,8 @@ def make_monthly_ds(
     return monthly_ds.compute()
 
 
-def get_monthly_dir(*, ecdr_data_dir: Path) -> Path:
-    monthly_dir = ecdr_data_dir / "monthly"
+def get_monthly_dir(*, base_output_dir: Path) -> Path:
+    monthly_dir = base_output_dir / "monthly"
     monthly_dir.mkdir(exist_ok=True)
 
     return monthly_dir
@@ -600,9 +600,9 @@ def get_monthly_filepath(
     sat: SUPPORTED_SAT,
     year: int,
     month: int,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
 ) -> Path:
-    output_dir = get_monthly_dir(ecdr_data_dir=ecdr_data_dir)
+    output_dir = get_monthly_dir(base_output_dir=base_output_dir)
 
     output_fn = standard_monthly_filename(
         hemisphere=hemisphere,
@@ -622,13 +622,13 @@ def make_monthly_nc(
     year: int,
     month: int,
     hemisphere: Hemisphere,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
 ) -> Path:
     daily_ds_for_month = get_daily_ds_for_month(
         year=year,
         month=month,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
         hemisphere=hemisphere,
         resolution=resolution,
     )
@@ -641,7 +641,7 @@ def make_monthly_nc(
         sat=sat,
         year=year,
         month=month,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
     )
 
     monthly_ds = make_monthly_ds(
@@ -669,7 +669,7 @@ def make_monthly_nc(
     # Write checksum file for the monthly output.
     write_checksum_file(
         input_filepath=output_path,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
     )
 
     return output_path
@@ -740,12 +740,12 @@ def cli(
     end_year: int | None,
     end_month: int | None,
     hemisphere: Hemisphere,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
 ):
     # The data should be organized by hemisphere.
-    ecdr_data_dir = ecdr_data_dir / hemisphere
-    ecdr_data_dir.mkdir(exist_ok=True)
+    base_output_dir = base_output_dir / hemisphere
+    base_output_dir.mkdir(exist_ok=True)
 
     if end_year is None:
         end_year = year
@@ -762,7 +762,7 @@ def cli(
             make_monthly_nc(
                 year=period.year,
                 month=period.month,
-                ecdr_data_dir=ecdr_data_dir,
+                base_output_dir=base_output_dir,
                 hemisphere=hemisphere,
                 resolution=resolution,
             )

--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -39,7 +39,7 @@ from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS, SUPPORTED_SAT
 from seaice_ecdr.ancillary import flag_value_for_meaning
 from seaice_ecdr.checksum import write_checksum_file
 from seaice_ecdr.complete_daily_ecdr import get_ecdr_filepath
-from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
+from seaice_ecdr.constants import BASE_OUTPUT_DIR
 from seaice_ecdr.nc_attrs import get_global_attrs
 from seaice_ecdr.util import (
     get_num_missing_pixels,
@@ -719,7 +719,7 @@ def make_monthly_nc(
         resolve_path=True,
         path_type=Path,
     ),
-    default=STANDARD_BASE_OUTPUT_DIR,
+    default=BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -587,8 +587,8 @@ def make_monthly_ds(
     return monthly_ds.compute()
 
 
-def get_monthly_dir(*, complete_output_dir: Path, hemisphere: Hemisphere) -> Path:
-    monthly_dir = complete_output_dir / hemisphere / "monthly"
+def get_monthly_dir(*, complete_output_dir: Path) -> Path:
+    monthly_dir = complete_output_dir / "monthly"
     monthly_dir.mkdir(parents=True, exist_ok=True)
 
     return monthly_dir
@@ -605,7 +605,6 @@ def get_monthly_filepath(
 ) -> Path:
     output_dir = get_monthly_dir(
         complete_output_dir=complete_output_dir,
-        hemisphere=hemisphere,
     )
 
     output_fn = standard_monthly_filename(
@@ -673,7 +672,7 @@ def make_monthly_nc(
     # Write checksum file for the monthly output.
     write_checksum_file(
         input_filepath=output_path,
-        output_dir=complete_output_dir / hemisphere / "checksums" / "monthly",
+        output_dir=complete_output_dir / "checksums" / "monthly",
     )
 
     return output_path
@@ -754,6 +753,8 @@ def cli(
 
     complete_output_dir = get_complete_output_dir(
         base_output_dir=base_output_dir,
+        hemisphere=hemisphere,
+        is_nrt=False,
     )
     error_periods = []
     for period in pd.period_range(

--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -669,7 +669,6 @@ def make_monthly_nc(
     write_checksum_file(
         input_filepath=output_path,
         ecdr_data_dir=ecdr_data_dir,
-        product_type="monthly",
     )
 
     return output_path

--- a/seaice_ecdr/monthly.py
+++ b/seaice_ecdr/monthly.py
@@ -586,9 +586,9 @@ def make_monthly_ds(
     return monthly_ds.compute()
 
 
-def get_monthly_dir(*, base_output_dir: Path) -> Path:
-    monthly_dir = base_output_dir / "monthly"
-    monthly_dir.mkdir(exist_ok=True)
+def get_monthly_dir(*, base_output_dir: Path, hemisphere: Hemisphere) -> Path:
+    monthly_dir = base_output_dir / "complete" / hemisphere / "monthly"
+    monthly_dir.mkdir(parents=True, exist_ok=True)
 
     return monthly_dir
 
@@ -602,7 +602,7 @@ def get_monthly_filepath(
     month: int,
     base_output_dir: Path,
 ) -> Path:
-    output_dir = get_monthly_dir(base_output_dir=base_output_dir)
+    output_dir = get_monthly_dir(base_output_dir=base_output_dir, hemisphere=hemisphere)
 
     output_fn = standard_monthly_filename(
         hemisphere=hemisphere,
@@ -669,7 +669,7 @@ def make_monthly_nc(
     # Write checksum file for the monthly output.
     write_checksum_file(
         input_filepath=output_path,
-        base_output_dir=base_output_dir,
+        output_dir=base_output_dir / "complete" / hemisphere / "checksums" / "monthly",
     )
 
     return output_path
@@ -709,7 +709,7 @@ def make_monthly_nc(
     type=click.Choice(get_args(Hemisphere)),
 )
 @click.option(
-    "--ecdr-data-dir",
+    "--base-output-dir",
     required=True,
     type=click.Path(
         exists=True,
@@ -743,10 +743,6 @@ def cli(
     base_output_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
 ):
-    # The data should be organized by hemisphere.
-    base_output_dir = base_output_dir / hemisphere
-    base_output_dir.mkdir(exist_ok=True)
-
     if end_year is None:
         end_year = year
     if end_month is None:

--- a/seaice_ecdr/monthly_aggregate.py
+++ b/seaice_ecdr/monthly_aggregate.py
@@ -19,6 +19,7 @@ from seaice_ecdr.monthly import get_monthly_dir
 from seaice_ecdr.nc_attrs import get_global_attrs
 from seaice_ecdr.nc_util import concatenate_nc_files
 from seaice_ecdr.util import (
+    get_complete_output_dir,
     sat_from_filename,
     standard_monthly_aggregate_filename,
 )
@@ -28,10 +29,10 @@ def _get_monthly_complete_filepaths(
     *,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    base_output_dir: Path,
+    complete_output_dir: Path,
 ) -> list[Path]:
     monthly_dir = get_monthly_dir(
-        base_output_dir=base_output_dir,
+        complete_output_dir=complete_output_dir,
         hemisphere=hemisphere,
     )
 
@@ -148,9 +149,12 @@ def cli(
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
 ) -> None:
     try:
+        complete_output_dir = get_complete_output_dir(
+            base_output_dir=base_output_dir,
+        )
         monthly_filepaths = _get_monthly_complete_filepaths(
             hemisphere=hemisphere,
-            base_output_dir=base_output_dir,
+            complete_output_dir=complete_output_dir,
             resolution=resolution,
         )
 

--- a/seaice_ecdr/monthly_aggregate.py
+++ b/seaice_ecdr/monthly_aggregate.py
@@ -14,7 +14,7 @@ from pm_tb_data._types import Hemisphere
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import get_ancillary_ds
 from seaice_ecdr.checksum import write_checksum_file
-from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
+from seaice_ecdr.constants import BASE_OUTPUT_DIR
 from seaice_ecdr.monthly import get_monthly_dir
 from seaice_ecdr.nc_attrs import get_global_attrs
 from seaice_ecdr.nc_util import concatenate_nc_files
@@ -126,7 +126,7 @@ def _update_ncrcat_monthly_ds(
         resolve_path=True,
         path_type=Path,
     ),
-    default=STANDARD_BASE_OUTPUT_DIR,
+    default=BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/monthly_aggregate.py
+++ b/seaice_ecdr/monthly_aggregate.py
@@ -33,7 +33,6 @@ def _get_monthly_complete_filepaths(
 ) -> list[Path]:
     monthly_dir = get_monthly_dir(
         complete_output_dir=complete_output_dir,
-        hemisphere=hemisphere,
     )
 
     # TODO: the monthly filenames are encoded in the
@@ -56,9 +55,9 @@ def get_monthly_aggregate_filepath(
     start_month: int,
     end_year: int,
     end_month: int,
-    base_output_dir: Path,
+    complete_output_dir: Path,
 ) -> Path:
-    output_dir = base_output_dir / "complete" / hemisphere / "aggregate"
+    output_dir = complete_output_dir / "aggregate"
     output_dir.mkdir(exist_ok=True)
 
     output_fn = standard_monthly_aggregate_filename(
@@ -151,6 +150,8 @@ def cli(
     try:
         complete_output_dir = get_complete_output_dir(
             base_output_dir=base_output_dir,
+            hemisphere=hemisphere,
+            is_nrt=False,
         )
         monthly_filepaths = _get_monthly_complete_filepaths(
             hemisphere=hemisphere,
@@ -192,7 +193,7 @@ def cli(
                 start_month=start_date.month,
                 end_year=end_date.year,
                 end_month=end_date.month,
-                base_output_dir=base_output_dir,
+                complete_output_dir=complete_output_dir,
             )
             ds.to_netcdf(
                 output_filepath,

--- a/seaice_ecdr/monthly_aggregate.py
+++ b/seaice_ecdr/monthly_aggregate.py
@@ -32,6 +32,7 @@ def _get_monthly_complete_filepaths(
 ) -> list[Path]:
     monthly_dir = get_monthly_dir(
         base_output_dir=base_output_dir,
+        hemisphere=hemisphere,
     )
 
     # TODO: the monthly filenames are encoded in the
@@ -56,7 +57,7 @@ def get_monthly_aggregate_filepath(
     end_month: int,
     base_output_dir: Path,
 ) -> Path:
-    output_dir = base_output_dir / "aggregate"
+    output_dir = base_output_dir / "complete" / hemisphere / "aggregate"
     output_dir.mkdir(exist_ok=True)
 
     output_fn = standard_monthly_aggregate_filename(
@@ -116,7 +117,7 @@ def _update_ncrcat_monthly_ds(
     type=click.Choice(get_args(Hemisphere)),
 )
 @click.option(
-    "--ecdr-data-dir",
+    "--base-output-dir",
     required=True,
     type=click.Path(
         exists=True,
@@ -146,11 +147,6 @@ def cli(
     base_output_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
 ) -> None:
-
-    # The data should be organized by hemisphere.
-    base_output_dir = base_output_dir / hemisphere
-    base_output_dir.mkdir(exist_ok=True)
-
     try:
         monthly_filepaths = _get_monthly_complete_filepaths(
             hemisphere=hemisphere,
@@ -206,7 +202,11 @@ def cli(
         # Write checksum file for the aggregate monthly output.
         write_checksum_file(
             input_filepath=output_filepath,
-            base_output_dir=base_output_dir,
+            output_dir=base_output_dir
+            / "complete"
+            / hemisphere
+            / "checksums"
+            / "aggregate",
         )
 
         # Cleanup previously existing monthly aggregates.

--- a/seaice_ecdr/monthly_aggregate.py
+++ b/seaice_ecdr/monthly_aggregate.py
@@ -14,7 +14,7 @@ from pm_tb_data._types import Hemisphere
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import get_ancillary_ds
 from seaice_ecdr.checksum import write_checksum_file
-from seaice_ecdr.constants import BASE_OUTPUT_DIR
+from seaice_ecdr.constants import DEFAULT_BASE_OUTPUT_DIR
 from seaice_ecdr.monthly import get_monthly_dir
 from seaice_ecdr.nc_attrs import get_global_attrs
 from seaice_ecdr.nc_util import concatenate_nc_files
@@ -126,7 +126,7 @@ def _update_ncrcat_monthly_ds(
         resolve_path=True,
         path_type=Path,
     ),
-    default=BASE_OUTPUT_DIR,
+    default=DEFAULT_BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/monthly_aggregate.py
+++ b/seaice_ecdr/monthly_aggregate.py
@@ -207,7 +207,6 @@ def cli(
         write_checksum_file(
             input_filepath=output_filepath,
             ecdr_data_dir=ecdr_data_dir,
-            product_type="aggregate",
         )
 
         # Cleanup previously existing monthly aggregates.

--- a/seaice_ecdr/monthly_aggregate.py
+++ b/seaice_ecdr/monthly_aggregate.py
@@ -146,6 +146,11 @@ def cli(
     ecdr_data_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
 ) -> None:
+
+    # The data should be organized by hemisphere.
+    ecdr_data_dir = ecdr_data_dir / hemisphere
+    ecdr_data_dir.mkdir(exist_ok=True)
+
     try:
         monthly_filepaths = _get_monthly_complete_filepaths(
             hemisphere=hemisphere,

--- a/seaice_ecdr/multiprocess_daily.py
+++ b/seaice_ecdr/multiprocess_daily.py
@@ -82,6 +82,10 @@ def cli(
     ecdr_data_dir: Path,
     overwrite: bool,
 ):
+    # The data should be organized by hemisphere.
+    ecdr_data_dir = ecdr_data_dir / hemisphere
+    ecdr_data_dir.mkdir(exist_ok=True)
+
     dates = list(date_range(start_date=start_date, end_date=end_date))
     dates_by_year = get_dates_by_year(dates)
 

--- a/seaice_ecdr/multiprocess_daily.py
+++ b/seaice_ecdr/multiprocess_daily.py
@@ -10,7 +10,7 @@ from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr.cli.util import datetime_to_date
 from seaice_ecdr.complete_daily_ecdr import create_standard_ecdr_for_dates
-from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
+from seaice_ecdr.constants import BASE_OUTPUT_DIR
 from seaice_ecdr.initial_daily_ecdr import create_idecdr_for_date
 from seaice_ecdr.platforms import get_first_platform_start_date
 from seaice_ecdr.temporal_composite_daily import make_tiecdr_netcdf
@@ -63,7 +63,7 @@ from seaice_ecdr.util import date_range, get_dates_by_year, raise_error_for_date
         resolve_path=True,
         path_type=Path,
     ),
-    default=STANDARD_BASE_OUTPUT_DIR,
+    default=BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/multiprocess_daily.py
+++ b/seaice_ecdr/multiprocess_daily.py
@@ -79,12 +79,12 @@ def cli(
     start_date: dt.date,
     end_date: dt.date,
     hemisphere: Hemisphere,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
     overwrite: bool,
 ):
     # The data should be organized by hemisphere.
-    ecdr_data_dir = ecdr_data_dir / hemisphere
-    ecdr_data_dir.mkdir(exist_ok=True)
+    base_output_dir = base_output_dir / hemisphere
+    base_output_dir.mkdir(exist_ok=True)
 
     dates = list(date_range(start_date=start_date, end_date=end_date))
     dates_by_year = get_dates_by_year(dates)
@@ -105,7 +105,7 @@ def cli(
         create_idecdr_for_date,
         hemisphere=hemisphere,
         resolution=resolution,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
         overwrite_ide=overwrite,
     )
 
@@ -113,7 +113,7 @@ def cli(
         make_tiecdr_netcdf,
         hemisphere=hemisphere,
         resolution=resolution,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
         overwrite_tie=overwrite,
     )
 
@@ -121,7 +121,7 @@ def cli(
         create_standard_ecdr_for_dates,
         hemisphere=hemisphere,
         resolution=resolution,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
         overwrite_cde=overwrite,
     )
 

--- a/seaice_ecdr/multiprocess_daily.py
+++ b/seaice_ecdr/multiprocess_daily.py
@@ -14,7 +14,12 @@ from seaice_ecdr.constants import DEFAULT_BASE_OUTPUT_DIR
 from seaice_ecdr.initial_daily_ecdr import create_idecdr_for_date
 from seaice_ecdr.platforms import get_first_platform_start_date
 from seaice_ecdr.temporal_composite_daily import make_tiecdr_netcdf
-from seaice_ecdr.util import date_range, get_dates_by_year, raise_error_for_dates
+from seaice_ecdr.util import (
+    date_range,
+    get_dates_by_year,
+    get_intermediate_output_dir,
+    raise_error_for_dates,
+)
 
 
 @click.command(name="multiprocess-daily")
@@ -95,13 +100,18 @@ def cli(
         date_range(start_date=initial_start_date, end_date=initial_end_date)
     )
 
+    intermediate_output_dir = get_intermediate_output_dir(
+        base_output_dir=base_output_dir,
+        is_nrt=False,
+    )
+
     resolution: Final = "12.5"
 
     _create_idecdr_wrapper = partial(
         create_idecdr_for_date,
         hemisphere=hemisphere,
         resolution=resolution,
-        base_output_dir=base_output_dir,
+        intermediate_output_dir=intermediate_output_dir,
         overwrite_ide=overwrite,
     )
 
@@ -109,7 +119,7 @@ def cli(
         make_tiecdr_netcdf,
         hemisphere=hemisphere,
         resolution=resolution,
-        base_output_dir=base_output_dir,
+        intermediate_output_dir=intermediate_output_dir,
         overwrite_tie=overwrite,
     )
 

--- a/seaice_ecdr/multiprocess_daily.py
+++ b/seaice_ecdr/multiprocess_daily.py
@@ -10,7 +10,7 @@ from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr.cli.util import datetime_to_date
 from seaice_ecdr.complete_daily_ecdr import create_standard_ecdr_for_dates
-from seaice_ecdr.constants import BASE_OUTPUT_DIR
+from seaice_ecdr.constants import DEFAULT_BASE_OUTPUT_DIR
 from seaice_ecdr.initial_daily_ecdr import create_idecdr_for_date
 from seaice_ecdr.platforms import get_first_platform_start_date
 from seaice_ecdr.temporal_composite_daily import make_tiecdr_netcdf
@@ -63,7 +63,7 @@ from seaice_ecdr.util import date_range, get_dates_by_year, raise_error_for_date
         resolve_path=True,
         path_type=Path,
     ),
-    default=BASE_OUTPUT_DIR,
+    default=DEFAULT_BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/multiprocess_daily.py
+++ b/seaice_ecdr/multiprocess_daily.py
@@ -53,7 +53,7 @@ from seaice_ecdr.util import date_range, get_dates_by_year, raise_error_for_date
     type=click.Choice(get_args(Hemisphere)),
 )
 @click.option(
-    "--ecdr-data-dir",
+    "--base-output-dir",
     required=True,
     type=click.Path(
         exists=True,
@@ -82,10 +82,6 @@ def cli(
     base_output_dir: Path,
     overwrite: bool,
 ):
-    # The data should be organized by hemisphere.
-    base_output_dir = base_output_dir / hemisphere
-    base_output_dir.mkdir(exist_ok=True)
-
     dates = list(date_range(start_date=start_date, end_date=end_date))
     dates_by_year = get_dates_by_year(dates)
 

--- a/seaice_ecdr/multiprocess_daily.py
+++ b/seaice_ecdr/multiprocess_daily.py
@@ -102,6 +102,7 @@ def cli(
 
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=base_output_dir,
+        hemisphere=hemisphere,
         is_nrt=False,
     )
 

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -215,7 +215,11 @@ def nrt_ecdr_for_day(
     overwrite: bool,
 ):
     """Create an initial daily ECDR NetCDF using NRT LANCE AMSR2 data."""
-    complete_output_dir = get_complete_output_dir(base_output_dir=base_output_dir)
+    complete_output_dir = get_complete_output_dir(
+        base_output_dir=base_output_dir,
+        hemisphere=hemisphere,
+        is_nrt=True,
+    )
     cde_filepath = get_ecdr_filepath(
         date=date,
         hemisphere=hemisphere,
@@ -231,6 +235,7 @@ def nrt_ecdr_for_day(
     if not cde_filepath.is_file() or overwrite:
         intermediate_output_dir = get_intermediate_output_dir(
             base_output_dir=base_output_dir,
+            hemisphere=hemisphere,
             is_nrt=True,
         )
         try:

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -35,7 +35,7 @@ from seaice_ecdr.complete_daily_ecdr import (
     get_ecdr_filepath,
     write_cde_netcdf,
 )
-from seaice_ecdr.constants import LANCE_NRT_DATA_DIR, NRT_BASE_OUTPUT_DIR
+from seaice_ecdr.constants import BASE_OUTPUT_DIR, LANCE_NRT_DATA_DIR
 from seaice_ecdr.initial_daily_ecdr import (
     compute_initial_daily_ecdr_dataset,
     get_idecdr_filepath,
@@ -346,7 +346,7 @@ def download_latest_nrt_data(*, output_dir: Path, overwrite: bool) -> None:
         resolve_path=True,
         path_type=Path,
     ),
-    default=NRT_BASE_OUTPUT_DIR,
+    default=BASE_OUTPUT_DIR,
     help=(
         "Base output directory for NRT ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -35,7 +35,7 @@ from seaice_ecdr.complete_daily_ecdr import (
     get_ecdr_filepath,
     write_cde_netcdf,
 )
-from seaice_ecdr.constants import BASE_OUTPUT_DIR, LANCE_NRT_DATA_DIR
+from seaice_ecdr.constants import DEFAULT_BASE_OUTPUT_DIR, LANCE_NRT_DATA_DIR
 from seaice_ecdr.initial_daily_ecdr import (
     compute_initial_daily_ecdr_dataset,
     get_idecdr_filepath,
@@ -346,7 +346,7 @@ def download_latest_nrt_data(*, output_dir: Path, overwrite: bool) -> None:
         resolve_path=True,
         path_type=Path,
     ),
-    default=BASE_OUTPUT_DIR,
+    default=DEFAULT_BASE_OUTPUT_DIR,
     help=(
         "Base output directory for NRT ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -304,6 +304,10 @@ def nrt_ecdr_for_day(
     overwrite: bool,
 ):
     """Create an initial daily ECDR NetCDF using NRT LANCE AMSR2 data."""
+    # The data should be organized by hemisphere.
+    ecdr_data_dir = ecdr_data_dir / hemisphere
+    ecdr_data_dir.mkdir(exist_ok=True)
+
     cde_filepath = get_ecdr_filepath(
         date=date,
         hemisphere=hemisphere,

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -1,19 +1,4 @@
-"""Code to run NRT ECDR processing.
-
-TODO:
-
-* Think about a missing value. The nrt data will potentially contain missing
-  data since it can only look to the past for filling missing data. A user could
-  probably look at the QA field to find out that spatial/temporal interp hasn't
-  happened for a `np.nan` cell, but this would be extra work. Maybe a fine
-  trade-off for now.
-* Figure out how to leverage the temporal composite and finalization
-  code. Currently most of our code relies on hard-coded expectations about the
-  platform (based on date) and where the data live (base_output_dir). The data dir
-  is easy enough to change, but we may need to override the platform for NRT
-  processing. Some way to tell the code on a global level that it's dealing w/
-  NRT maybe?
-"""
+"""Code to run NRT ECDR processing."""
 
 import copy
 import datetime as dt
@@ -266,8 +251,6 @@ def nrt_ecdr_for_day(
                 is_nrt=True,
             )
 
-            # TODO: write_cde_netcdf needs updated to allow nrt checksums
-            # structure.
             written_cde_ncfile = write_cde_netcdf(
                 cde_ds=cde_ds,
                 output_filepath=cde_filepath,

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -226,10 +226,6 @@ def nrt_ecdr_for_day(
     overwrite: bool,
 ):
     """Create an initial daily ECDR NetCDF using NRT LANCE AMSR2 data."""
-    # The data should be organized by hemisphere.
-    base_output_dir = base_output_dir / hemisphere
-    base_output_dir.mkdir(exist_ok=True)
-
     cde_filepath = get_ecdr_filepath(
         date=date,
         hemisphere=hemisphere,
@@ -260,10 +256,13 @@ def nrt_ecdr_for_day(
                 is_nrt=True,
             )
 
+            # TODO: write_cde_netcdf needs updated to allow nrt checksums
+            # structure.
             written_cde_ncfile = write_cde_netcdf(
                 cde_ds=cde_ds,
                 output_filepath=cde_filepath,
                 base_output_dir=base_output_dir,
+                hemisphere=hemisphere,
             )
             logger.success(f"Wrote complete daily ncfile: {written_cde_ncfile}")
         except Exception as e:
@@ -336,7 +335,7 @@ def download_latest_nrt_data(*, output_dir: Path, overwrite: bool) -> None:
     type=click.Choice(get_args(Hemisphere)),
 )
 @click.option(
-    "--ecdr-data-dir",
+    "--base-output-dir",
     required=True,
     type=click.Path(
         exists=True,

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -959,6 +959,10 @@ def cli(
     if end_date is None:
         end_date = copy.copy(date)
 
+    # The data should be organized by hemisphere.
+    ecdr_data_dir = ecdr_data_dir / hemisphere
+    ecdr_data_dir.mkdir(exist_ok=True)
+
     create_tiecdr_for_date_range(
         hemisphere=hemisphere,
         start_date=date,

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -110,10 +110,10 @@ def temporally_interpolate_dataarray_using_flags(
 
 
 @cache
-def get_tie_dir(*, base_output_dir: Path) -> Path:
+def get_tie_dir(*, base_output_dir: Path, hemisphere: Hemisphere) -> Path:
     """Daily complete output dir for TIE processing"""
-    tie_dir = base_output_dir / "temporal_interp"
-    tie_dir.mkdir(exist_ok=True)
+    tie_dir = base_output_dir / "intermediate" / hemisphere / "temporal_interp"
+    tie_dir.mkdir(parents=True, exist_ok=True)
 
     return tie_dir
 
@@ -139,7 +139,7 @@ def get_tie_filepath(
     # Add `tiecdr` to the beginning of the standard name to distinguish it as a
     # WIP.
     tie_filename = "tiecdr_" + standard_fn
-    tie_dir = get_tie_dir(base_output_dir=base_output_dir)
+    tie_dir = get_tie_dir(base_output_dir=base_output_dir, hemisphere=hemisphere)
 
     tie_filepath = tie_dir / tie_filename
 
@@ -910,7 +910,7 @@ def create_tiecdr_for_date_range(
     type=click.Choice(get_args(Hemisphere)),
 )
 @click.option(
-    "--ecdr-data-dir",
+    "--base-output-dir",
     required=True,
     type=click.Path(
         exists=True,

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -110,9 +110,9 @@ def temporally_interpolate_dataarray_using_flags(
 
 
 @cache
-def get_tie_dir(*, ecdr_data_dir: Path) -> Path:
+def get_tie_dir(*, base_output_dir: Path) -> Path:
     """Daily complete output dir for TIE processing"""
-    tie_dir = ecdr_data_dir / "temporal_interp"
+    tie_dir = base_output_dir / "temporal_interp"
     tie_dir.mkdir(exist_ok=True)
 
     return tie_dir
@@ -123,7 +123,7 @@ def get_tie_filepath(
     date,
     hemisphere,
     resolution,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
 ) -> Path:
     """Return the complete daily tie file path."""
 
@@ -139,7 +139,7 @@ def get_tie_filepath(
     # Add `tiecdr` to the beginning of the standard name to distinguish it as a
     # WIP.
     tie_filename = "tiecdr_" + standard_fn
-    tie_dir = get_tie_dir(ecdr_data_dir=ecdr_data_dir)
+    tie_dir = get_tie_dir(base_output_dir=base_output_dir)
 
     tie_filepath = tie_dir / tie_filename
 
@@ -336,7 +336,7 @@ def read_or_create_and_read_idecdr_ds(
     date: dt.date,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
     overwrite_ide: bool = False,
 ) -> xr.Dataset:
     """Read an idecdr netCDF file, creating it if it doesn't exist."""
@@ -349,14 +349,14 @@ def read_or_create_and_read_idecdr_ds(
         platform=platform,
         hemisphere=hemisphere,
         resolution=resolution,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
     )
     if overwrite_ide or not ide_filepath.is_file():
         create_idecdr_for_date(
             date=date,
             hemisphere=hemisphere,
             resolution=resolution,
-            ecdr_data_dir=ecdr_data_dir,
+            base_output_dir=base_output_dir,
         )
     logger.debug(f"Reading ideCDR file from: {ide_filepath}")
     ide_ds = xr.load_dataset(ide_filepath)
@@ -723,7 +723,7 @@ def temporally_interpolated_ecdr_dataset(
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     interp_range: int = 5,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
     fill_the_pole_hole: bool = True,
 ) -> xr.Dataset:
     """Create xr dataset containing the second pass of daily enhanced CDR.
@@ -740,7 +740,7 @@ def temporally_interpolated_ecdr_dataset(
             date=iter_date,
             hemisphere=hemisphere,
             resolution=resolution,
-            ecdr_data_dir=ecdr_data_dir,
+            base_output_dir=base_output_dir,
         )
         init_datasets.append(init_dataset)
 
@@ -816,7 +816,7 @@ def make_tiecdr_netcdf(
     *,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
     interp_range: int = 5,
     fill_the_pole_hole: bool = True,
     overwrite_tie: bool = False,
@@ -825,7 +825,7 @@ def make_tiecdr_netcdf(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
     )
 
     if overwrite_tie or not output_path.is_file():
@@ -836,7 +836,7 @@ def make_tiecdr_netcdf(
                 hemisphere=hemisphere,
                 resolution=resolution,
                 interp_range=interp_range,
-                ecdr_data_dir=ecdr_data_dir,
+                base_output_dir=base_output_dir,
                 fill_the_pole_hole=fill_the_pole_hole,
             )
 
@@ -860,7 +860,7 @@ def create_tiecdr_for_date_range(
     start_date: dt.date,
     end_date: dt.date,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
     overwrite_tie: bool,
 ) -> None:
     """Generate the temporally composited daily ecdr files for a range of dates."""
@@ -869,7 +869,7 @@ def create_tiecdr_for_date_range(
             date=date,
             hemisphere=hemisphere,
             resolution=resolution,
-            ecdr_data_dir=ecdr_data_dir,
+            base_output_dir=base_output_dir,
             overwrite_tie=overwrite_tie,
         )
 
@@ -943,7 +943,7 @@ def cli(
     date: dt.date,
     end_date: dt.date | None,
     hemisphere: Hemisphere,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     overwrite: bool,
 ) -> None:
@@ -960,14 +960,14 @@ def cli(
         end_date = copy.copy(date)
 
     # The data should be organized by hemisphere.
-    ecdr_data_dir = ecdr_data_dir / hemisphere
-    ecdr_data_dir.mkdir(exist_ok=True)
+    base_output_dir = base_output_dir / hemisphere
+    base_output_dir.mkdir(exist_ok=True)
 
     create_tiecdr_for_date_range(
         hemisphere=hemisphere,
         start_date=date,
         end_date=end_date,
         resolution=resolution,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
         overwrite_tie=overwrite,
     )

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -19,7 +19,7 @@ from pm_tb_data._types import NORTH, Hemisphere
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS, SUPPORTED_SAT
 from seaice_ecdr.ancillary import get_non_ocean_mask, nh_polehole_mask
 from seaice_ecdr.cli.util import datetime_to_date
-from seaice_ecdr.constants import STANDARD_BASE_OUTPUT_DIR
+from seaice_ecdr.constants import BASE_OUTPUT_DIR
 from seaice_ecdr.initial_daily_ecdr import (
     create_idecdr_for_date,
     get_idecdr_filepath,
@@ -920,7 +920,7 @@ def create_tiecdr_for_date_range(
         resolve_path=True,
         path_type=Path,
     ),
-    default=STANDARD_BASE_OUTPUT_DIR,
+    default=BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -116,7 +116,7 @@ def temporally_interpolate_dataarray_using_flags(
 @cache
 def get_tie_dir(*, intermediate_output_dir: Path, hemisphere: Hemisphere) -> Path:
     """Daily complete output dir for TIE processing"""
-    tie_dir = intermediate_output_dir / hemisphere / "temporal_interp"
+    tie_dir = intermediate_output_dir / "temporal_interp"
     tie_dir.mkdir(parents=True, exist_ok=True)
 
     return tie_dir
@@ -969,6 +969,7 @@ def cli(
 
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=base_output_dir,
+        hemisphere=hemisphere,
         is_nrt=False,
     )
 

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -19,7 +19,7 @@ from pm_tb_data._types import NORTH, Hemisphere
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS, SUPPORTED_SAT
 from seaice_ecdr.ancillary import get_non_ocean_mask, nh_polehole_mask
 from seaice_ecdr.cli.util import datetime_to_date
-from seaice_ecdr.constants import BASE_OUTPUT_DIR
+from seaice_ecdr.constants import DEFAULT_BASE_OUTPUT_DIR
 from seaice_ecdr.initial_daily_ecdr import (
     create_idecdr_for_date,
     get_idecdr_filepath,
@@ -920,7 +920,7 @@ def create_tiecdr_for_date_range(
         resolve_path=True,
         path_type=Path,
     ),
-    default=BASE_OUTPUT_DIR,
+    default=DEFAULT_BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/tests/integration/__init__.py
+++ b/seaice_ecdr/tests/integration/__init__.py
@@ -13,7 +13,7 @@ def _get_cached_tmpdir():
 
 
 @pytest.fixture(scope="session")
-def ecdr_data_dir_test_path():
+def base_output_dir_test_path():
     """Session-scoped fixture providing temporary dir representing ECDR data dir."""
     tmpdir = _get_cached_tmpdir()
     tmppath = Path(tmpdir.name)

--- a/seaice_ecdr/tests/integration/test_complete_daily.py
+++ b/seaice_ecdr/tests/integration/test_complete_daily.py
@@ -2,7 +2,6 @@ import datetime as dt
 
 from pm_tb_data._types import NORTH
 
-from seaice_ecdr.checksum import get_checksum_filepath
 from seaice_ecdr.complete_daily_ecdr import make_standard_cdecdr_netcdf
 from seaice_ecdr.tests.integration import base_output_dir_test_path  # noqa
 
@@ -19,8 +18,13 @@ def test_make_standard_cdecdr_netcdf(base_output_dir_test_path):  # noqa
         assert output_path.is_file()
 
         # Assert that the checksums exist where we expect them to be.
-        checksum_filepath = get_checksum_filepath(
-            input_filepath=output_path,
-            base_output_dir=base_output_dir_test_path,
+        checksum_filepath = (
+            base_output_dir_test_path
+            / "complete"
+            / NORTH
+            / "checksums"
+            / "daily"
+            / "2022"
+            / (output_path.name + ".mnf")
         )
         assert checksum_filepath.is_file()

--- a/seaice_ecdr/tests/integration/test_complete_daily.py
+++ b/seaice_ecdr/tests/integration/test_complete_daily.py
@@ -22,6 +22,6 @@ def test_make_standard_cdecdr_netcdf(ecdr_data_dir_test_path):  # noqa
         checksum_filepath = get_checksum_filepath(
             input_filepath=output_path,
             ecdr_data_dir=ecdr_data_dir_test_path,
-            product_type="complete_daily",
+            product_type="daily",
         )
         assert checksum_filepath.is_file()

--- a/seaice_ecdr/tests/integration/test_complete_daily.py
+++ b/seaice_ecdr/tests/integration/test_complete_daily.py
@@ -4,16 +4,16 @@ from pm_tb_data._types import NORTH
 
 from seaice_ecdr.checksum import get_checksum_filepath
 from seaice_ecdr.complete_daily_ecdr import make_standard_cdecdr_netcdf
-from seaice_ecdr.tests.integration import ecdr_data_dir_test_path  # noqa
+from seaice_ecdr.tests.integration import base_output_dir_test_path  # noqa
 
 
-def test_make_standard_cdecdr_netcdf(ecdr_data_dir_test_path):  # noqa
+def test_make_standard_cdecdr_netcdf(base_output_dir_test_path):  # noqa
     for day in range(1, 5):
         output_path = make_standard_cdecdr_netcdf(
             date=dt.date(2022, 3, day),
             hemisphere=NORTH,
             resolution="12.5",
-            ecdr_data_dir=ecdr_data_dir_test_path,
+            base_output_dir=base_output_dir_test_path,
         )
 
         assert output_path.is_file()
@@ -21,6 +21,6 @@ def test_make_standard_cdecdr_netcdf(ecdr_data_dir_test_path):  # noqa
         # Assert that the checksums exist where we expect them to be.
         checksum_filepath = get_checksum_filepath(
             input_filepath=output_path,
-            ecdr_data_dir=ecdr_data_dir_test_path,
+            base_output_dir=base_output_dir_test_path,
         )
         assert checksum_filepath.is_file()

--- a/seaice_ecdr/tests/integration/test_complete_daily.py
+++ b/seaice_ecdr/tests/integration/test_complete_daily.py
@@ -22,6 +22,5 @@ def test_make_standard_cdecdr_netcdf(ecdr_data_dir_test_path):  # noqa
         checksum_filepath = get_checksum_filepath(
             input_filepath=output_path,
             ecdr_data_dir=ecdr_data_dir_test_path,
-            product_type="daily",
         )
         assert checksum_filepath.is_file()

--- a/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
+++ b/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
@@ -134,7 +134,7 @@ def test_cli_idecdr_ncfile_creation(tmpdir):
         date=test_date,
         hemisphere=test_hemisphere,
         resolution=test_resolution,
-        ecdr_data_dir=tmpdir_path,
+        base_output_dir=tmpdir_path,
         excluded_fields=[],
     )
     output_path = get_idecdr_filepath(
@@ -142,7 +142,7 @@ def test_cli_idecdr_ncfile_creation(tmpdir):
         date=test_date,
         platform=test_platform,
         resolution=test_resolution,
-        ecdr_data_dir=tmpdir_path,
+        base_output_dir=tmpdir_path,
     )
 
     assert output_path.is_file()
@@ -166,7 +166,7 @@ def test_can_drop_fields_from_idecdr_netcdf(
         date=test_date,
         hemisphere=test_hemisphere,
         resolution=test_resolution,
-        ecdr_data_dir=tmpdir_path,
+        base_output_dir=tmpdir_path,
         excluded_fields=(cdr_conc_fieldname,),
     )
     output_path = get_idecdr_filepath(
@@ -174,7 +174,7 @@ def test_can_drop_fields_from_idecdr_netcdf(
         date=test_date,
         platform=test_platform,
         resolution=test_resolution,
-        ecdr_data_dir=tmpdir_path,
+        base_output_dir=tmpdir_path,
     )
 
     assert output_path.is_file()

--- a/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
+++ b/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
@@ -134,7 +134,7 @@ def test_cli_idecdr_ncfile_creation(tmpdir):
         date=test_date,
         hemisphere=test_hemisphere,
         resolution=test_resolution,
-        base_output_dir=tmpdir_path,
+        intermediate_output_dir=tmpdir_path,
         excluded_fields=[],
     )
     output_path = get_idecdr_filepath(
@@ -142,7 +142,7 @@ def test_cli_idecdr_ncfile_creation(tmpdir):
         date=test_date,
         platform=test_platform,
         resolution=test_resolution,
-        base_output_dir=tmpdir_path,
+        intermediate_output_dir=tmpdir_path,
     )
 
     assert output_path.is_file()
@@ -166,7 +166,7 @@ def test_can_drop_fields_from_idecdr_netcdf(
         date=test_date,
         hemisphere=test_hemisphere,
         resolution=test_resolution,
-        base_output_dir=tmpdir_path,
+        intermediate_output_dir=tmpdir_path,
         excluded_fields=(cdr_conc_fieldname,),
     )
     output_path = get_idecdr_filepath(
@@ -174,7 +174,7 @@ def test_can_drop_fields_from_idecdr_netcdf(
         date=test_date,
         platform=test_platform,
         resolution=test_resolution,
-        base_output_dir=tmpdir_path,
+        intermediate_output_dir=tmpdir_path,
     )
 
     assert output_path.is_file()

--- a/seaice_ecdr/tests/integration/test_monthly.py
+++ b/seaice_ecdr/tests/integration/test_monthly.py
@@ -35,6 +35,5 @@ def test_make_monthly_nc(ecdr_data_dir_test_path, monkeypatch):  # noqa
     checksum_filepath = get_checksum_filepath(
         input_filepath=output_path,
         ecdr_data_dir=ecdr_data_dir_test_path,
-        product_type="monthly",
     )
     assert checksum_filepath.is_file()

--- a/seaice_ecdr/tests/integration/test_monthly.py
+++ b/seaice_ecdr/tests/integration/test_monthly.py
@@ -3,7 +3,6 @@ import xarray as xr
 from pm_tb_data._types import NORTH
 
 from seaice_ecdr import monthly
-from seaice_ecdr.checksum import get_checksum_filepath
 from seaice_ecdr.tests.integration import base_output_dir_test_path  # noqa
 
 
@@ -32,8 +31,12 @@ def test_make_monthly_nc(base_output_dir_test_path, monkeypatch):  # noqa
     assert ds is not None
 
     # Assert that the checksums exist where we expect them to be.
-    checksum_filepath = get_checksum_filepath(
-        input_filepath=output_path,
-        base_output_dir=base_output_dir_test_path,
+    checksum_filepath = (
+        base_output_dir_test_path
+        / "complete"
+        / NORTH
+        / "checksums"
+        / "monthly"
+        / (output_path.name + ".mnf")
     )
     assert checksum_filepath.is_file()

--- a/seaice_ecdr/tests/integration/test_monthly.py
+++ b/seaice_ecdr/tests/integration/test_monthly.py
@@ -18,6 +18,8 @@ def test_make_monthly_nc(base_output_dir_test_path, monkeypatch):  # noqa
 
     complete_output_dir = get_complete_output_dir(
         base_output_dir=base_output_dir_test_path,
+        hemisphere=NORTH,
+        is_nrt=False,
     )
 
     output_path = monthly.make_monthly_nc(

--- a/seaice_ecdr/tests/integration/test_monthly.py
+++ b/seaice_ecdr/tests/integration/test_monthly.py
@@ -4,11 +4,11 @@ from pm_tb_data._types import NORTH
 
 from seaice_ecdr import monthly
 from seaice_ecdr.checksum import get_checksum_filepath
-from seaice_ecdr.tests.integration import ecdr_data_dir_test_path  # noqa
+from seaice_ecdr.tests.integration import base_output_dir_test_path  # noqa
 
 
 @pytest.mark.order(after="test_complete_daily.py::test_make_cdecdr_netcdf")
-def test_make_monthly_nc(ecdr_data_dir_test_path, monkeypatch):  # noqa
+def test_make_monthly_nc(base_output_dir_test_path, monkeypatch):  # noqa
     # usually we require at least 20 days of data for a valid month. This mock
     # data is just 3 days in size, so we need to mock the
     # "check_min_days_for_valid_month" function.
@@ -21,7 +21,7 @@ def test_make_monthly_nc(ecdr_data_dir_test_path, monkeypatch):  # noqa
         month=3,
         hemisphere=NORTH,
         resolution="12.5",
-        ecdr_data_dir=ecdr_data_dir_test_path,
+        base_output_dir=base_output_dir_test_path,
     )
 
     assert output_path.is_file()
@@ -34,6 +34,6 @@ def test_make_monthly_nc(ecdr_data_dir_test_path, monkeypatch):  # noqa
     # Assert that the checksums exist where we expect them to be.
     checksum_filepath = get_checksum_filepath(
         input_filepath=output_path,
-        ecdr_data_dir=ecdr_data_dir_test_path,
+        base_output_dir=base_output_dir_test_path,
     )
     assert checksum_filepath.is_file()

--- a/seaice_ecdr/tests/integration/test_monthly.py
+++ b/seaice_ecdr/tests/integration/test_monthly.py
@@ -4,6 +4,7 @@ from pm_tb_data._types import NORTH
 
 from seaice_ecdr import monthly
 from seaice_ecdr.tests.integration import base_output_dir_test_path  # noqa
+from seaice_ecdr.util import get_complete_output_dir
 
 
 @pytest.mark.order(after="test_complete_daily.py::test_make_cdecdr_netcdf")
@@ -15,12 +16,16 @@ def test_make_monthly_nc(base_output_dir_test_path, monkeypatch):  # noqa
         monthly, "check_min_days_for_valid_month", lambda *_args, **_kwargs: True
     )
 
+    complete_output_dir = get_complete_output_dir(
+        base_output_dir=base_output_dir_test_path,
+    )
+
     output_path = monthly.make_monthly_nc(
         year=2022,
         month=3,
         hemisphere=NORTH,
         resolution="12.5",
-        base_output_dir=base_output_dir_test_path,
+        complete_output_dir=complete_output_dir,
     )
 
     assert output_path.is_file()

--- a/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
+++ b/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
@@ -30,14 +30,14 @@ def test_read_or_create_and_read_idecdr_ds(tmpdir):
         platform=platform,
         hemisphere=hemisphere,
         resolution=resolution,
-        ecdr_data_dir=Path(tmpdir),
+        base_output_dir=Path(tmpdir),
     )
 
     test_ide_ds_with_creation = read_or_create_and_read_idecdr_ds(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        ecdr_data_dir=Path(tmpdir),
+        base_output_dir=Path(tmpdir),
     )
 
     assert sample_ide_filepath.exists()
@@ -45,7 +45,7 @@ def test_read_or_create_and_read_idecdr_ds(tmpdir):
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        ecdr_data_dir=Path(tmpdir),
+        base_output_dir=Path(tmpdir),
     )
 
     assert test_ide_ds_with_creation == test_ide_ds_with_reading
@@ -67,6 +67,6 @@ def test_create_tiecdr_file(tmpdir):
         date=test_date,
         hemisphere=hemisphere,
         resolution=resolution,
-        ecdr_data_dir=Path(tmpdir),
+        base_output_dir=Path(tmpdir),
         interp_range=2,
     )

--- a/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
+++ b/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
@@ -30,14 +30,14 @@ def test_read_or_create_and_read_idecdr_ds(tmpdir):
         platform=platform,
         hemisphere=hemisphere,
         resolution=resolution,
-        base_output_dir=Path(tmpdir),
+        intermediate_output_dir=Path(tmpdir),
     )
 
     test_ide_ds_with_creation = read_or_create_and_read_idecdr_ds(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        base_output_dir=Path(tmpdir),
+        intermediate_output_dir=Path(tmpdir),
     )
 
     assert sample_ide_filepath.exists()
@@ -45,7 +45,7 @@ def test_read_or_create_and_read_idecdr_ds(tmpdir):
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        base_output_dir=Path(tmpdir),
+        intermediate_output_dir=Path(tmpdir),
     )
 
     assert test_ide_ds_with_creation == test_ide_ds_with_reading
@@ -63,10 +63,12 @@ def test_create_tiecdr_file(tmpdir):
     test_date = dt.date(2022, 3, 2)
 
     # For the test, only interpolate up to two days forward/back in time
-    make_tiecdr_netcdf(
+    fp = make_tiecdr_netcdf(
         date=test_date,
         hemisphere=hemisphere,
         resolution=resolution,
-        base_output_dir=Path(tmpdir),
+        intermediate_output_dir=Path(tmpdir),
         interp_range=2,
     )
+
+    assert fp.is_file()

--- a/seaice_ecdr/tests/integration/test_validation.py
+++ b/seaice_ecdr/tests/integration/test_validation.py
@@ -5,12 +5,12 @@ import itertools
 import pytest
 from pm_tb_data._types import NORTH
 
-from seaice_ecdr.tests.integration import ecdr_data_dir_test_path  # noqa
+from seaice_ecdr.tests.integration import base_output_dir_test_path  # noqa
 from seaice_ecdr.validation import validate_outputs
 
 
 @pytest.mark.order(after="test_monthly.py::test_make_monthly_nc")
-def test_validate_outputs(ecdr_data_dir_test_path):  # noqa
+def test_validate_outputs(base_output_dir_test_path):  # noqa
     for product_type, hemisphere in itertools.product(
         # TODO: currently just iterate over NORTH, because that's what data is
         # created for in the depdendent tests. We may consider creating monthly
@@ -23,7 +23,7 @@ def test_validate_outputs(ecdr_data_dir_test_path):  # noqa
             start_date=dt.date(2022, 3, 1),
             end_date=dt.date(2022, 3, 4),
             product=product_type,  # type: ignore[arg-type]
-            ecdr_data_dir=ecdr_data_dir_test_path,
+            base_output_dir=base_output_dir_test_path,
         )
 
         assert outputs["error_filepath"].is_file()

--- a/seaice_ecdr/tests/regression/test_daily_aggregate.py
+++ b/seaice_ecdr/tests/regression/test_daily_aggregate.py
@@ -5,15 +5,19 @@ from typing import Final
 import xarray as xr
 from pm_tb_data._types import NORTH
 
-from seaice_ecdr.complete_daily_ecdr import read_or_create_and_read_standard_cdecdr_ds
+from seaice_ecdr.complete_daily_ecdr import make_standard_cdecdr_netcdf, read_cdecdr_ds
 from seaice_ecdr.daily_aggregate import (
     get_daily_aggregate_filepath,
     make_daily_aggregate_netcdf_for_year,
 )
+from seaice_ecdr.util import get_complete_output_dir
 
 
 def test_daily_aggreagate_matches_daily_data(tmpdir):
-    tmpdir_path = Path(tmpdir)
+    base_output_dir = Path(tmpdir)
+    complete_output_dir = get_complete_output_dir(
+        base_output_dir=base_output_dir,
+    )
 
     year = 2022
     resolution: Final = "12.5"
@@ -22,11 +26,20 @@ def test_daily_aggreagate_matches_daily_data(tmpdir):
     # First, ensure some daily data is created.
     datasets = []
     for day in range(1, 3 + 1):
-        ds = read_or_create_and_read_standard_cdecdr_ds(
-            date=dt.date(year, 3, day),
+        date = dt.date(year, 3, day)
+        make_standard_cdecdr_netcdf(
+            date=date,
             hemisphere=hemisphere,
             resolution=resolution,
-            base_output_dir=tmpdir_path,
+            base_output_dir=base_output_dir,
+        )
+
+        ds = read_cdecdr_ds(
+            date=date,
+            hemisphere=hemisphere,
+            resolution=resolution,
+            complete_output_dir=complete_output_dir,
+            is_nrt=False,
         )
         datasets.append(ds)
 
@@ -35,14 +48,14 @@ def test_daily_aggreagate_matches_daily_data(tmpdir):
         year=year,
         hemisphere=hemisphere,
         resolution=resolution,
-        base_output_dir=tmpdir_path,
+        complete_output_dir=complete_output_dir,
     )
 
     # Read back in the data.
     aggregate_filepath = get_daily_aggregate_filepath(
         hemisphere=hemisphere,
         resolution=resolution,
-        base_output_dir=tmpdir_path,
+        complete_output_dir=complete_output_dir,
         start_date=dt.date(year, 3, 1),
         end_date=dt.date(year, 3, 3),
     )
@@ -52,8 +65,7 @@ def test_daily_aggreagate_matches_daily_data(tmpdir):
     agg_ds = xr.open_dataset(aggregate_filepath)
 
     checksum_filepath = (
-        tmpdir_path
-        / "complete"
+        complete_output_dir
         / hemisphere
         / "checksums"
         / "aggregate"

--- a/seaice_ecdr/tests/regression/test_daily_aggregate.py
+++ b/seaice_ecdr/tests/regression/test_daily_aggregate.py
@@ -27,7 +27,7 @@ def test_daily_aggreagate_matches_daily_data(tmpdir):
             date=dt.date(year, 3, day),
             hemisphere=hemisphere,
             resolution=resolution,
-            ecdr_data_dir=tmpdir_path,
+            base_output_dir=tmpdir_path,
         )
         datasets.append(ds)
 
@@ -36,14 +36,14 @@ def test_daily_aggreagate_matches_daily_data(tmpdir):
         year=year,
         hemisphere=hemisphere,
         resolution=resolution,
-        ecdr_data_dir=tmpdir_path,
+        base_output_dir=tmpdir_path,
     )
 
     # Read back in the data.
     aggregate_filepath = get_daily_aggregate_filepath(
         hemisphere=hemisphere,
         resolution=resolution,
-        ecdr_data_dir=tmpdir_path,
+        base_output_dir=tmpdir_path,
         start_date=dt.date(year, 3, 1),
         end_date=dt.date(year, 3, 3),
     )
@@ -55,7 +55,7 @@ def test_daily_aggreagate_matches_daily_data(tmpdir):
     # Assert that the checksums exist where we expect them to be.
     checksum_filepath = get_checksum_filepath(
         input_filepath=aggregate_filepath,
-        ecdr_data_dir=tmpdir_path,
+        base_output_dir=tmpdir_path,
     )
     assert checksum_filepath.is_file()
 

--- a/seaice_ecdr/tests/regression/test_daily_aggregate.py
+++ b/seaice_ecdr/tests/regression/test_daily_aggregate.py
@@ -5,7 +5,6 @@ from typing import Final
 import xarray as xr
 from pm_tb_data._types import NORTH
 
-from seaice_ecdr.checksum import get_checksum_filepath
 from seaice_ecdr.complete_daily_ecdr import read_or_create_and_read_standard_cdecdr_ds
 from seaice_ecdr.daily_aggregate import (
     get_daily_aggregate_filepath,
@@ -52,10 +51,13 @@ def test_daily_aggreagate_matches_daily_data(tmpdir):
     # they match the daily final datasets.
     agg_ds = xr.open_dataset(aggregate_filepath)
 
-    # Assert that the checksums exist where we expect them to be.
-    checksum_filepath = get_checksum_filepath(
-        input_filepath=aggregate_filepath,
-        base_output_dir=tmpdir_path,
+    checksum_filepath = (
+        tmpdir_path
+        / "complete"
+        / hemisphere
+        / "checksums"
+        / "aggregate"
+        / (aggregate_filepath.name + ".mnf")
     )
     assert checksum_filepath.is_file()
 

--- a/seaice_ecdr/tests/regression/test_daily_aggregate.py
+++ b/seaice_ecdr/tests/regression/test_daily_aggregate.py
@@ -15,13 +15,15 @@ from seaice_ecdr.util import get_complete_output_dir
 
 def test_daily_aggreagate_matches_daily_data(tmpdir):
     base_output_dir = Path(tmpdir)
+    hemisphere: Final = NORTH
     complete_output_dir = get_complete_output_dir(
         base_output_dir=base_output_dir,
+        hemisphere=hemisphere,
+        is_nrt=False,
     )
 
     year = 2022
     resolution: Final = "12.5"
-    hemisphere: Final = NORTH
 
     # First, ensure some daily data is created.
     datasets = []
@@ -66,7 +68,6 @@ def test_daily_aggreagate_matches_daily_data(tmpdir):
 
     checksum_filepath = (
         complete_output_dir
-        / hemisphere
         / "checksums"
         / "aggregate"
         / (aggregate_filepath.name + ".mnf")

--- a/seaice_ecdr/tests/regression/test_daily_aggregate.py
+++ b/seaice_ecdr/tests/regression/test_daily_aggregate.py
@@ -56,7 +56,6 @@ def test_daily_aggreagate_matches_daily_data(tmpdir):
     checksum_filepath = get_checksum_filepath(
         input_filepath=aggregate_filepath,
         ecdr_data_dir=tmpdir_path,
-        product_type="aggregate",
     )
     assert checksum_filepath.is_file()
 

--- a/seaice_ecdr/tests/unit/test_checksum.py
+++ b/seaice_ecdr/tests/unit/test_checksum.py
@@ -15,7 +15,7 @@ def test_write_checksum_file(tmp_path):
     checksum_file = write_checksum_file(
         input_filepath=example_file,
         ecdr_data_dir=tmp_path,
-        product_type="complete_daily",
+        product_type="daily",
     )
 
     # Assert that it was written.

--- a/seaice_ecdr/tests/unit/test_checksum.py
+++ b/seaice_ecdr/tests/unit/test_checksum.py
@@ -14,7 +14,7 @@ def test_write_checksum_file(tmp_path):
     # Use the function being tested to create a checksum file.
     checksum_file = write_checksum_file(
         input_filepath=example_file,
-        base_output_dir=tmp_path,
+        output_dir=tmp_path,
     )
 
     # Assert that it was written.

--- a/seaice_ecdr/tests/unit/test_checksum.py
+++ b/seaice_ecdr/tests/unit/test_checksum.py
@@ -14,7 +14,7 @@ def test_write_checksum_file(tmp_path):
     # Use the function being tested to create a checksum file.
     checksum_file = write_checksum_file(
         input_filepath=example_file,
-        ecdr_data_dir=tmp_path,
+        base_output_dir=tmp_path,
     )
 
     # Assert that it was written.

--- a/seaice_ecdr/tests/unit/test_checksum.py
+++ b/seaice_ecdr/tests/unit/test_checksum.py
@@ -15,7 +15,6 @@ def test_write_checksum_file(tmp_path):
     checksum_file = write_checksum_file(
         input_filepath=example_file,
         ecdr_data_dir=tmp_path,
-        product_type="daily",
     )
 
     # Assert that it was written.

--- a/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
+++ b/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
@@ -20,6 +20,7 @@ def test_no_melt_onset_for_southern_hemisphere(tmpdir):
                 hemisphere=SOUTH,
                 resolution="12.5",
                 ecdr_data_dir=Path(tmpdir),
+                is_nrt=False,
             )
 
 
@@ -33,5 +34,6 @@ def test_melt_onset_field_outside_melt_season(tmpdir):
             hemisphere=hemisphere,
             resolution="12.5",
             ecdr_data_dir=Path(tmpdir),
+            is_nrt=False,
         )
         assert np.all(melt_onset_field == MELT_ONSET_FILL_VALUE)

--- a/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
+++ b/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
@@ -9,17 +9,26 @@ from pm_tb_data._types import NORTH, SOUTH
 
 from seaice_ecdr import complete_daily_ecdr as cdecdr
 from seaice_ecdr.melt import MELT_ONSET_FILL_VALUE
+from seaice_ecdr.util import get_complete_output_dir, get_intermediate_output_dir
 
 
 def test_no_melt_onset_for_southern_hemisphere(tmpdir):
     """Verify that attempting to create a melt onset field for the SH raises an error"""
+    complete_output_dir = get_complete_output_dir(
+        base_output_dir=Path(tmpdir),
+    )
+    intermediate_output_dir = get_intermediate_output_dir(
+        base_output_dir=Path(tmpdir),
+        is_nrt=False,
+    )
     for date in (dt.date(2020, 2, 1), dt.date(2021, 6, 2), dt.date(2020, 10, 3)):
         with pytest.raises(RuntimeError):
             cdecdr.create_melt_onset_field(
                 date=date,
                 hemisphere=SOUTH,
                 resolution="12.5",
-                base_output_dir=Path(tmpdir),
+                complete_output_dir=complete_output_dir,
+                intermediate_output_dir=intermediate_output_dir,
                 is_nrt=False,
             )
 
@@ -28,12 +37,20 @@ def test_melt_onset_field_outside_melt_season(tmpdir):
     """Verify that melt onset is all fill value when not in melt season."""
     hemisphere = NORTH
 
+    complete_output_dir = get_complete_output_dir(
+        base_output_dir=Path(tmpdir),
+    )
+    intermediate_output_dir = get_intermediate_output_dir(
+        base_output_dir=Path(tmpdir),
+        is_nrt=False,
+    )
     for date in (dt.date(2020, 2, 1), dt.date(2020, 10, 3)):
         melt_onset_field = cdecdr.create_melt_onset_field(
             date=date,
             hemisphere=hemisphere,
             resolution="12.5",
-            base_output_dir=Path(tmpdir),
+            complete_output_dir=complete_output_dir,
+            intermediate_output_dir=intermediate_output_dir,
             is_nrt=False,
         )
         assert np.all(melt_onset_field == MELT_ONSET_FILL_VALUE)

--- a/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
+++ b/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
@@ -16,9 +16,12 @@ def test_no_melt_onset_for_southern_hemisphere(tmpdir):
     """Verify that attempting to create a melt onset field for the SH raises an error"""
     complete_output_dir = get_complete_output_dir(
         base_output_dir=Path(tmpdir),
+        hemisphere=SOUTH,
+        is_nrt=False,
     )
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=Path(tmpdir),
+        hemisphere=SOUTH,
         is_nrt=False,
     )
     for date in (dt.date(2020, 2, 1), dt.date(2021, 6, 2), dt.date(2020, 10, 3)):
@@ -39,9 +42,12 @@ def test_melt_onset_field_outside_melt_season(tmpdir):
 
     complete_output_dir = get_complete_output_dir(
         base_output_dir=Path(tmpdir),
+        hemisphere=hemisphere,
+        is_nrt=False,
     )
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=Path(tmpdir),
+        hemisphere=hemisphere,
         is_nrt=False,
     )
     for date in (dt.date(2020, 2, 1), dt.date(2020, 10, 3)):

--- a/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
+++ b/seaice_ecdr/tests/unit/test_complete_daily_ecdr.py
@@ -19,7 +19,7 @@ def test_no_melt_onset_for_southern_hemisphere(tmpdir):
                 date=date,
                 hemisphere=SOUTH,
                 resolution="12.5",
-                ecdr_data_dir=Path(tmpdir),
+                base_output_dir=Path(tmpdir),
                 is_nrt=False,
             )
 
@@ -33,7 +33,7 @@ def test_melt_onset_field_outside_melt_season(tmpdir):
             date=date,
             hemisphere=hemisphere,
             resolution="12.5",
-            ecdr_data_dir=Path(tmpdir),
+            base_output_dir=Path(tmpdir),
             is_nrt=False,
         )
         assert np.all(melt_onset_field == MELT_ONSET_FILL_VALUE)

--- a/seaice_ecdr/tests/unit/test_daily_aggregate.py
+++ b/seaice_ecdr/tests/unit/test_daily_aggregate.py
@@ -22,6 +22,7 @@ def test_get_daily_complete_filepaths_for_year(fs):
             hemisphere="north",
             resolution="12.5",
             ecdr_data_dir=ecdr_data_dir,
+            is_nrt=False,
         )
 
         fs.create_file(fp)
@@ -36,6 +37,7 @@ def test_get_daily_complete_filepaths_for_year(fs):
             hemisphere="north",
             resolution="12.5",
             ecdr_data_dir=ecdr_data_dir,
+            is_nrt=False,
         )
 
         fs.create_file(fp)

--- a/seaice_ecdr/tests/unit/test_daily_aggregate.py
+++ b/seaice_ecdr/tests/unit/test_daily_aggregate.py
@@ -2,7 +2,9 @@ import datetime as dt
 from pathlib import Path
 
 from seaice_ecdr.complete_daily_ecdr import get_ecdr_filepath
-from seaice_ecdr.daily_aggregate import _get_daily_complete_filepaths_for_year
+from seaice_ecdr.daily_aggregate import (
+    _get_daily_complete_filepaths_for_year,
+)
 from seaice_ecdr.util import date_range
 
 

--- a/seaice_ecdr/tests/unit/test_daily_aggregate.py
+++ b/seaice_ecdr/tests/unit/test_daily_aggregate.py
@@ -9,8 +9,8 @@ from seaice_ecdr.util import date_range
 
 
 def test_get_daily_complete_filepaths_for_year(fs):
-    base_output_dir = Path("/path/to/data/dir")
-    fs.create_dir(base_output_dir)
+    complete_output_dir = Path("/path/to/data/dir/complete")
+    fs.create_dir(complete_output_dir)
 
     # target year
     year = 2021
@@ -23,7 +23,7 @@ def test_get_daily_complete_filepaths_for_year(fs):
             date=date,
             hemisphere="north",
             resolution="12.5",
-            base_output_dir=base_output_dir,
+            complete_output_dir=complete_output_dir,
             is_nrt=False,
         )
 
@@ -38,7 +38,7 @@ def test_get_daily_complete_filepaths_for_year(fs):
             date=date,
             hemisphere="north",
             resolution="12.5",
-            base_output_dir=base_output_dir,
+            complete_output_dir=complete_output_dir,
             is_nrt=False,
         )
 
@@ -47,7 +47,7 @@ def test_get_daily_complete_filepaths_for_year(fs):
 
     actual = _get_daily_complete_filepaths_for_year(
         year=year,
-        base_output_dir=base_output_dir,
+        complete_output_dir=complete_output_dir,
         hemisphere="north",
         resolution="12.5",
     )

--- a/seaice_ecdr/tests/unit/test_daily_aggregate.py
+++ b/seaice_ecdr/tests/unit/test_daily_aggregate.py
@@ -7,8 +7,8 @@ from seaice_ecdr.util import date_range
 
 
 def test_get_daily_complete_filepaths_for_year(fs):
-    ecdr_data_dir = Path("/path/to/data/dir")
-    fs.create_dir(ecdr_data_dir)
+    base_output_dir = Path("/path/to/data/dir")
+    fs.create_dir(base_output_dir)
 
     # target year
     year = 2021
@@ -21,7 +21,7 @@ def test_get_daily_complete_filepaths_for_year(fs):
             date=date,
             hemisphere="north",
             resolution="12.5",
-            ecdr_data_dir=ecdr_data_dir,
+            base_output_dir=base_output_dir,
             is_nrt=False,
         )
 
@@ -36,7 +36,7 @@ def test_get_daily_complete_filepaths_for_year(fs):
             date=date,
             hemisphere="north",
             resolution="12.5",
-            ecdr_data_dir=ecdr_data_dir,
+            base_output_dir=base_output_dir,
             is_nrt=False,
         )
 
@@ -45,7 +45,7 @@ def test_get_daily_complete_filepaths_for_year(fs):
 
     actual = _get_daily_complete_filepaths_for_year(
         year=year,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
         hemisphere="north",
         resolution="12.5",
     )

--- a/seaice_ecdr/tests/unit/test_monthly.py
+++ b/seaice_ecdr/tests/unit/test_monthly.py
@@ -28,36 +28,31 @@ from seaice_ecdr.monthly import (
 def test__get_daily_complete_filepaths_for_month(fs):
     ecdr_data_dir = Path("/path/to/data/dir")
     fs.create_dir(ecdr_data_dir)
-    nh_complete_dir = get_ecdr_dir(
-        ecdr_data_dir=ecdr_data_dir, hemisphere="north", year=2022
-    )
-    sh_complete_dir = get_ecdr_dir(
-        ecdr_data_dir=ecdr_data_dir, hemisphere="south", year=2022
-    )
+    complete_dir = get_ecdr_dir(ecdr_data_dir=ecdr_data_dir, year=2022)
     year = 2022
     month = 3
     _fake_files_for_test_year_month_and_hemisphere = [
-        nh_complete_dir / "sic_psn12.5_20220301_am2_v05r01.nc",
-        nh_complete_dir / "sic_psn12.5_20220302_am2_v05r01.nc",
-        nh_complete_dir / "sic_psn12.5_20220303_am2_v05r01.nc",
+        complete_dir / "sic_psn12.5_20220301_am2_v05r01.nc",
+        complete_dir / "sic_psn12.5_20220302_am2_v05r01.nc",
+        complete_dir / "sic_psn12.5_20220303_am2_v05r01.nc",
     ]
     _fake_files = [
-        nh_complete_dir / "sic_psn12.5_20220201_am2_v05r01.nc",
-        sh_complete_dir / "sic_pss12.5_20220201_am2_v05r01.nc",
-        nh_complete_dir / "sic_psn12.5_20220202_am2_v05r01.nc",
-        sh_complete_dir / "sic_pss12.5_20220202_am2_v05r01.nc",
-        nh_complete_dir / "sic_psn12.5_20220203_am2_v05r01.nc",
-        sh_complete_dir / "sic_pss12.5_20220203_am2_v05r01.nc",
-        sh_complete_dir / "sic_pss12.5_20220301_am2_v05r01.nc",
-        sh_complete_dir / "sic_pss12.5_20220302_am2_v05r01.nc",
-        sh_complete_dir / "sic_pss12.5_20220303_am2_v05r01.nc",
+        complete_dir / "sic_psn12.5_20220201_am2_v05r01.nc",
+        complete_dir / "sic_pss12.5_20220201_am2_v05r01.nc",
+        complete_dir / "sic_psn12.5_20220202_am2_v05r01.nc",
+        complete_dir / "sic_pss12.5_20220202_am2_v05r01.nc",
+        complete_dir / "sic_psn12.5_20220203_am2_v05r01.nc",
+        complete_dir / "sic_pss12.5_20220203_am2_v05r01.nc",
+        complete_dir / "sic_pss12.5_20220301_am2_v05r01.nc",
+        complete_dir / "sic_pss12.5_20220302_am2_v05r01.nc",
+        complete_dir / "sic_pss12.5_20220303_am2_v05r01.nc",
         *_fake_files_for_test_year_month_and_hemisphere,
-        nh_complete_dir / "sic_psn12.5_20220401_am2_v05r01.nc",
-        sh_complete_dir / "sic_pss12.5_20220401_am2_v05r01.nc",
-        nh_complete_dir / "sic_psn12.5_20220402_am2_v05r01.nc",
-        sh_complete_dir / "sic_pss12.5_20220402_am2_v05r01.nc",
-        nh_complete_dir / "sic_psn12.5_20220403_am2_v05r01.nc",
-        sh_complete_dir / "sic_pss12.5_20220403_am2_v05r01.nc",
+        complete_dir / "sic_psn12.5_20220401_am2_v05r01.nc",
+        complete_dir / "sic_pss12.5_20220401_am2_v05r01.nc",
+        complete_dir / "sic_psn12.5_20220402_am2_v05r01.nc",
+        complete_dir / "sic_pss12.5_20220402_am2_v05r01.nc",
+        complete_dir / "sic_psn12.5_20220403_am2_v05r01.nc",
+        complete_dir / "sic_pss12.5_20220403_am2_v05r01.nc",
     ]
     for _file in _fake_files:
         fs.create_file(_file)

--- a/seaice_ecdr/tests/unit/test_monthly.py
+++ b/seaice_ecdr/tests/unit/test_monthly.py
@@ -28,31 +28,36 @@ from seaice_ecdr.monthly import (
 def test__get_daily_complete_filepaths_for_month(fs):
     ecdr_data_dir = Path("/path/to/data/dir")
     fs.create_dir(ecdr_data_dir)
-    complete_dir = get_ecdr_dir(ecdr_data_dir=ecdr_data_dir, year=2022)
+    nh_complete_dir = get_ecdr_dir(
+        ecdr_data_dir=ecdr_data_dir, hemisphere="north", year=2022
+    )
+    sh_complete_dir = get_ecdr_dir(
+        ecdr_data_dir=ecdr_data_dir, hemisphere="south", year=2022
+    )
     year = 2022
     month = 3
     _fake_files_for_test_year_month_and_hemisphere = [
-        complete_dir / "sic_psn12.5_20220301_am2_v05r01.nc",
-        complete_dir / "sic_psn12.5_20220302_am2_v05r01.nc",
-        complete_dir / "sic_psn12.5_20220303_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220301_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220302_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220303_am2_v05r01.nc",
     ]
     _fake_files = [
-        complete_dir / "sic_psn12.5_20220201_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220201_am2_v05r01.nc",
-        complete_dir / "sic_psn12.5_20220202_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220202_am2_v05r01.nc",
-        complete_dir / "sic_psn12.5_20220203_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220203_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220301_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220302_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220303_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220201_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220201_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220202_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220202_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220203_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220203_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220301_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220302_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220303_am2_v05r01.nc",
         *_fake_files_for_test_year_month_and_hemisphere,
-        complete_dir / "sic_psn12.5_20220401_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220401_am2_v05r01.nc",
-        complete_dir / "sic_psn12.5_20220402_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220402_am2_v05r01.nc",
-        complete_dir / "sic_psn12.5_20220403_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220403_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220401_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220401_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220402_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220402_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220403_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220403_am2_v05r01.nc",
     ]
     for _file in _fake_files:
         fs.create_file(_file)

--- a/seaice_ecdr/tests/unit/test_monthly.py
+++ b/seaice_ecdr/tests/unit/test_monthly.py
@@ -26,9 +26,9 @@ from seaice_ecdr.monthly import (
 
 
 def test__get_daily_complete_filepaths_for_month(fs):
-    ecdr_data_dir = Path("/path/to/data/dir")
-    fs.create_dir(ecdr_data_dir)
-    complete_dir = get_ecdr_dir(ecdr_data_dir=ecdr_data_dir, year=2022)
+    base_output_dir = Path("/path/to/data/dir")
+    fs.create_dir(base_output_dir)
+    complete_dir = get_ecdr_dir(base_output_dir=base_output_dir, year=2022)
     year = 2022
     month = 3
     _fake_files_for_test_year_month_and_hemisphere = [
@@ -60,7 +60,7 @@ def test__get_daily_complete_filepaths_for_month(fs):
     actual = _get_daily_complete_filepaths_for_month(
         year=year,
         month=month,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
         resolution="12.5",
         hemisphere=NORTH,
     )

--- a/seaice_ecdr/tests/unit/test_monthly.py
+++ b/seaice_ecdr/tests/unit/test_monthly.py
@@ -29,15 +29,13 @@ def test__get_daily_complete_filepaths_for_month(fs):
     complete_output_dir = Path("/path/to/data/dir/complete")
     fs.create_dir(complete_output_dir)
     nh_complete_dir = get_ecdr_dir(
-        complete_output_dir=complete_output_dir,
+        complete_output_dir=complete_output_dir / "north",
         year=2022,
-        hemisphere="north",
         is_nrt=False,
     )
     sh_complete_dir = get_ecdr_dir(
-        complete_output_dir=complete_output_dir,
+        complete_output_dir=complete_output_dir / "south",
         year=2022,
-        hemisphere="south",
         is_nrt=False,
     )
     year = 2022
@@ -71,7 +69,7 @@ def test__get_daily_complete_filepaths_for_month(fs):
     actual = _get_daily_complete_filepaths_for_month(
         year=year,
         month=month,
-        complete_output_dir=complete_output_dir,
+        complete_output_dir=complete_output_dir / NORTH,
         resolution="12.5",
         hemisphere=NORTH,
     )

--- a/seaice_ecdr/tests/unit/test_monthly.py
+++ b/seaice_ecdr/tests/unit/test_monthly.py
@@ -28,7 +28,7 @@ from seaice_ecdr.monthly import (
 def test__get_daily_complete_filepaths_for_month(fs):
     ecdr_data_dir = Path("/path/to/data/dir")
     fs.create_dir(ecdr_data_dir)
-    complete_dir = get_ecdr_dir(ecdr_data_dir=ecdr_data_dir)
+    complete_dir = get_ecdr_dir(ecdr_data_dir=ecdr_data_dir, year=2022)
     year = 2022
     month = 3
     _fake_files_for_test_year_month_and_hemisphere = [

--- a/seaice_ecdr/tests/unit/test_monthly.py
+++ b/seaice_ecdr/tests/unit/test_monthly.py
@@ -28,31 +28,42 @@ from seaice_ecdr.monthly import (
 def test__get_daily_complete_filepaths_for_month(fs):
     base_output_dir = Path("/path/to/data/dir")
     fs.create_dir(base_output_dir)
-    complete_dir = get_ecdr_dir(base_output_dir=base_output_dir, year=2022)
+    nh_complete_dir = get_ecdr_dir(
+        base_output_dir=base_output_dir,
+        year=2022,
+        hemisphere="north",
+        is_nrt=False,
+    )
+    sh_complete_dir = get_ecdr_dir(
+        base_output_dir=base_output_dir,
+        year=2022,
+        hemisphere="south",
+        is_nrt=False,
+    )
     year = 2022
     month = 3
     _fake_files_for_test_year_month_and_hemisphere = [
-        complete_dir / "sic_psn12.5_20220301_am2_v05r01.nc",
-        complete_dir / "sic_psn12.5_20220302_am2_v05r01.nc",
-        complete_dir / "sic_psn12.5_20220303_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220301_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220302_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220303_am2_v05r01.nc",
     ]
     _fake_files = [
-        complete_dir / "sic_psn12.5_20220201_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220201_am2_v05r01.nc",
-        complete_dir / "sic_psn12.5_20220202_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220202_am2_v05r01.nc",
-        complete_dir / "sic_psn12.5_20220203_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220203_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220301_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220302_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220303_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220201_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220201_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220202_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220202_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220203_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220203_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220301_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220302_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220303_am2_v05r01.nc",
         *_fake_files_for_test_year_month_and_hemisphere,
-        complete_dir / "sic_psn12.5_20220401_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220401_am2_v05r01.nc",
-        complete_dir / "sic_psn12.5_20220402_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220402_am2_v05r01.nc",
-        complete_dir / "sic_psn12.5_20220403_am2_v05r01.nc",
-        complete_dir / "sic_pss12.5_20220403_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220401_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220401_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220402_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220402_am2_v05r01.nc",
+        nh_complete_dir / "sic_psn12.5_20220403_am2_v05r01.nc",
+        sh_complete_dir / "sic_pss12.5_20220403_am2_v05r01.nc",
     ]
     for _file in _fake_files:
         fs.create_file(_file)

--- a/seaice_ecdr/tests/unit/test_monthly.py
+++ b/seaice_ecdr/tests/unit/test_monthly.py
@@ -26,16 +26,16 @@ from seaice_ecdr.monthly import (
 
 
 def test__get_daily_complete_filepaths_for_month(fs):
-    base_output_dir = Path("/path/to/data/dir")
-    fs.create_dir(base_output_dir)
+    complete_output_dir = Path("/path/to/data/dir/complete")
+    fs.create_dir(complete_output_dir)
     nh_complete_dir = get_ecdr_dir(
-        base_output_dir=base_output_dir,
+        complete_output_dir=complete_output_dir,
         year=2022,
         hemisphere="north",
         is_nrt=False,
     )
     sh_complete_dir = get_ecdr_dir(
-        base_output_dir=base_output_dir,
+        complete_output_dir=complete_output_dir,
         year=2022,
         hemisphere="south",
         is_nrt=False,
@@ -71,7 +71,7 @@ def test__get_daily_complete_filepaths_for_month(fs):
     actual = _get_daily_complete_filepaths_for_month(
         year=year,
         month=month,
-        base_output_dir=base_output_dir,
+        complete_output_dir=complete_output_dir,
         resolution="12.5",
         hemisphere=NORTH,
     )

--- a/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
+++ b/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
@@ -83,16 +83,16 @@ def test_access_to_standard_output_filename(tmpdir):
     resolution: Final = "12.5"
     sat = "am2"
 
-    ecdr_data_dir = Path(tmpdir)
+    base_output_dir = Path(tmpdir)
     sample_ide_filepath = get_idecdr_filepath(
         date=date,
         platform=sat,
         hemisphere=NORTH,
         resolution=resolution,
-        ecdr_data_dir=ecdr_data_dir,
+        base_output_dir=base_output_dir,
     )
     expected_filepath = (
-        get_idecdr_dir(ecdr_data_dir=ecdr_data_dir)
+        get_idecdr_dir(base_output_dir=base_output_dir)
         / f"idecdr_sic_psn12.5_20210219_am2_{ECDR_PRODUCT_VERSION}.nc"
     )
 

--- a/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
+++ b/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
@@ -83,16 +83,19 @@ def test_access_to_standard_output_filename(tmpdir):
     resolution: Final = "12.5"
     sat = "am2"
 
-    base_output_dir = Path(tmpdir)
+    intermediate_output_dir = Path(tmpdir)
     sample_ide_filepath = get_idecdr_filepath(
         date=date,
         platform=sat,
         hemisphere=NORTH,
         resolution=resolution,
-        base_output_dir=base_output_dir,
+        intermediate_output_dir=intermediate_output_dir,
     )
     expected_filepath = (
-        get_idecdr_dir(base_output_dir=base_output_dir, hemisphere=NORTH)
+        get_idecdr_dir(
+            intermediate_output_dir=intermediate_output_dir,
+            hemisphere=NORTH,
+        )
         / f"idecdr_sic_psn12.5_20210219_am2_{ECDR_PRODUCT_VERSION}.nc"
     )
 

--- a/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
+++ b/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
@@ -94,7 +94,6 @@ def test_access_to_standard_output_filename(tmpdir):
     expected_filepath = (
         get_idecdr_dir(
             intermediate_output_dir=intermediate_output_dir,
-            hemisphere=NORTH,
         )
         / f"idecdr_sic_psn12.5_20210219_am2_{ECDR_PRODUCT_VERSION}.nc"
     )

--- a/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
+++ b/seaice_ecdr/tests/unit/test_temporal_composite_daily.py
@@ -92,7 +92,7 @@ def test_access_to_standard_output_filename(tmpdir):
         base_output_dir=base_output_dir,
     )
     expected_filepath = (
-        get_idecdr_dir(base_output_dir=base_output_dir)
+        get_idecdr_dir(base_output_dir=base_output_dir, hemisphere=NORTH)
         / f"idecdr_sic_psn12.5_20210219_am2_{ECDR_PRODUCT_VERSION}.nc"
     )
 

--- a/seaice_ecdr/tests/unit/test_util.py
+++ b/seaice_ecdr/tests/unit/test_util.py
@@ -12,6 +12,7 @@ from seaice_ecdr.multiprocess_daily import get_dates_by_year
 from seaice_ecdr.util import (
     date_range,
     get_num_missing_pixels,
+    nrt_daily_filename,
     raise_error_for_dates,
     sat_from_filename,
     standard_daily_aggregate_filename,
@@ -36,6 +37,16 @@ def test_daily_filename_south():
 
     actual = standard_daily_filename(
         hemisphere=SOUTH, resolution="12.5", sat="am2", date=dt.date(2021, 1, 1)
+    )
+
+    assert actual == expected
+
+
+def test_nrt_daily_filename():
+    expected = f"sic_psn12.5_20210101_am2_{ECDR_PRODUCT_VERSION}_P.nc"
+
+    actual = nrt_daily_filename(
+        hemisphere=NORTH, resolution="12.5", sat="am2", date=dt.date(2021, 1, 1)
     )
 
     assert actual == expected

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import re
+from pathlib import Path
 from typing import Iterator, cast, get_args
 
 import numpy as np
@@ -32,6 +33,28 @@ def standard_daily_filename(
     fn = f"sic_{grid_id}_{date:%Y%m%d}_{sat}_{ECDR_PRODUCT_VERSION}.nc"
 
     return fn
+
+
+def nrt_daily_filename(
+    *,
+    hemisphere: Hemisphere,
+    resolution: ECDR_SUPPORTED_RESOLUTIONS,
+    sat: SUPPORTED_SAT,
+    date: dt.date,
+) -> str:
+    standard_fn = standard_daily_filename(
+        hemisphere=hemisphere,
+        resolution=resolution,
+        sat=sat,
+        date=date,
+    )
+    standard_fn_path = Path(standard_fn)
+
+    fn_base = standard_fn_path.stem
+    ext = standard_fn_path.suffix
+    nrt_fn = fn_base + "_P" + ext
+
+    return nrt_fn
 
 
 def standard_daily_aggregate_filename(

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -10,6 +10,7 @@ from pm_tb_data._types import Hemisphere
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS, SUPPORTED_SAT
 from seaice_ecdr.ancillary import get_ocean_mask
 from seaice_ecdr.constants import ECDR_PRODUCT_VERSION
+from seaice_ecdr.grid_id import get_grid_id
 
 
 def standard_daily_filename(
@@ -24,7 +25,11 @@ def standard_daily_filename(
     North Daily files: sic_psn12.5_YYYYMMDD_sat_v05r01.nc
     South Daily files: sic_pss12.5_YYYYMMDD_sat_v05r01.nc
     """
-    fn = f"sic_ps{hemisphere[0]}{resolution}_{date:%Y%m%d}_{sat}_{ECDR_PRODUCT_VERSION}.nc"
+    grid_id = get_grid_id(
+        hemisphere=hemisphere,
+        resolution=resolution,
+    )
+    fn = f"sic_{grid_id}_{date:%Y%m%d}_{sat}_{ECDR_PRODUCT_VERSION}.nc"
 
     return fn
 
@@ -41,7 +46,13 @@ def standard_daily_aggregate_filename(
     North Daily aggregate files: sic_psn12.5_YYYYMMDD-YYYYMMDD_v05r01.nc
     South Daily aggregate files: sic_pss12.5_YYYYMMDD-YYYYMMDD_v05r01.nc
     """
-    fn = f"sic_ps{hemisphere[0]}{resolution}_{start_date:%Y%m%d}-{end_date:%Y%m%d}_{ECDR_PRODUCT_VERSION}.nc"
+    grid_id = get_grid_id(
+        hemisphere=hemisphere,
+        resolution=resolution,
+    )
+    fn = (
+        f"sic_{grid_id}_{start_date:%Y%m%d}-{end_date:%Y%m%d}_{ECDR_PRODUCT_VERSION}.nc"
+    )
 
     return fn
 
@@ -59,7 +70,11 @@ def standard_monthly_filename(
     North Monthly files: sic_psn12.5_YYYYMM_sat_v05r01.nc
     South Monthly files: sic_pss12.5_YYYYMM_sat_v05r01.nc
     """
-    fn = f"sic_ps{hemisphere[0]}{resolution}_{year}{month:02}_{sat}_{ECDR_PRODUCT_VERSION}.nc"
+    grid_id = get_grid_id(
+        hemisphere=hemisphere,
+        resolution=resolution,
+    )
+    fn = f"sic_{grid_id}_{year}{month:02}_{sat}_{ECDR_PRODUCT_VERSION}.nc"
 
     return fn
 
@@ -80,7 +95,12 @@ def standard_monthly_aggregate_filename(
     """
     date_str = f"{start_year}{start_month:02}-{end_year}{end_month:02}"
 
-    fn = f"sic_ps{hemisphere[0]}{resolution}_{date_str}_{ECDR_PRODUCT_VERSION}.nc"
+    grid_id = get_grid_id(
+        hemisphere=hemisphere,
+        resolution=resolution,
+    )
+
+    fn = f"sic_{grid_id}_{date_str}_{ECDR_PRODUCT_VERSION}.nc"
 
     return fn
 

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -207,3 +207,21 @@ def raise_error_for_dates(*, error_dates: list[dt.date]) -> None:
             f"Encountered {len(error_dates)} failures."
             f" Data for the following dates were not created:\n{str_formatted_dates}"
         )
+
+
+def get_intermediate_output_dir(*, base_output_dir: Path, is_nrt: bool) -> Path:
+    intermediate_dir = base_output_dir / "intermediate"
+    if is_nrt:
+        intermediate_dir = intermediate_dir / "nrt"
+
+    intermediate_dir.mkdir(exist_ok=True, parents=True)
+
+    return intermediate_dir
+
+
+def get_complete_output_dir(*, base_output_dir: Path) -> Path:
+    complete_dir = base_output_dir / "complete"
+
+    complete_dir.mkdir(exist_ok=True)
+
+    return complete_dir

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -1,7 +1,7 @@
 import datetime as dt
 import re
 from pathlib import Path
-from typing import Iterator, cast, get_args
+from typing import Iterator, Literal, cast, get_args
 
 import numpy as np
 import pandas as pd
@@ -209,19 +209,49 @@ def raise_error_for_dates(*, error_dates: list[dt.date]) -> None:
         )
 
 
-def get_intermediate_output_dir(*, base_output_dir: Path, is_nrt: bool) -> Path:
-    intermediate_dir = base_output_dir / "intermediate"
+def _get_output_dir(
+    *,
+    base_output_dir: Path,
+    hemisphere: Hemisphere,
+    is_nrt: bool,
+    data_type: Literal["intermediate", "complete"],
+) -> Path:
+    out_dir = base_output_dir / data_type / hemisphere
     if is_nrt:
-        intermediate_dir = intermediate_dir / "nrt"
+        out_dir = out_dir / "nrt"
 
-    intermediate_dir.mkdir(exist_ok=True, parents=True)
+    out_dir.mkdir(exist_ok=True, parents=True)
+
+    return out_dir
+
+
+def get_intermediate_output_dir(
+    *,
+    base_output_dir: Path,
+    hemisphere: Hemisphere,
+    is_nrt: bool,
+) -> Path:
+    intermediate_dir = _get_output_dir(
+        base_output_dir=base_output_dir,
+        hemisphere=hemisphere,
+        is_nrt=is_nrt,
+        data_type="intermediate",
+    )
 
     return intermediate_dir
 
 
-def get_complete_output_dir(*, base_output_dir: Path) -> Path:
-    complete_dir = base_output_dir / "complete"
-
-    complete_dir.mkdir(exist_ok=True)
+def get_complete_output_dir(
+    *,
+    base_output_dir: Path,
+    hemisphere: Hemisphere,
+    is_nrt: bool,
+) -> Path:
+    complete_dir = _get_output_dir(
+        base_output_dir=base_output_dir,
+        hemisphere=hemisphere,
+        is_nrt=is_nrt,
+        data_type="complete",
+    )
 
     return complete_dir

--- a/seaice_ecdr/validation.py
+++ b/seaice_ecdr/validation.py
@@ -75,8 +75,8 @@ ERROR_FILE_BITMASK = dict(
 )
 
 
-def get_validation_dir(*, ecdr_data_dir: Path) -> Path:
-    validation_dir = ecdr_data_dir / "validation"
+def get_validation_dir(*, base_output_dir: Path) -> Path:
+    validation_dir = base_output_dir / "validation"
     validation_dir.mkdir(exist_ok=True)
 
     return validation_dir
@@ -349,7 +349,7 @@ def make_validation_dict(
 def validate_outputs(
     *,
     hemisphere: Hemisphere,
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
     start_date: dt.date,
     end_date: dt.date,
     product: Product,
@@ -364,7 +364,7 @@ def validate_outputs(
     * error_seaice_{n|s}_daily_{start_year}_{end_year}.csv. Contains the
       following fields: [year, month, day, error_code]
     """
-    validation_dir = get_validation_dir(ecdr_data_dir=ecdr_data_dir)
+    validation_dir = get_validation_dir(base_output_dir=base_output_dir)
     log_filepath = (
         validation_dir
         / f"log_seaice_{hemisphere[0]}_{product}_{start_date.year}_{end_date.year}.csv"
@@ -389,7 +389,7 @@ def validate_outputs(
                     date=date,
                     hemisphere=hemisphere,
                     resolution=VALIDATION_RESOLUTION,
-                    ecdr_data_dir=ecdr_data_dir,
+                    base_output_dir=base_output_dir,
                     is_nrt=False,
                 )
 
@@ -428,7 +428,7 @@ def validate_outputs(
             years = range(start_date.year, end_date.year + 1)
             months = range(start_date.month, end_date.month + 1)
             for year, month in itertools.product(years, months):
-                monthly_dir = get_monthly_dir(ecdr_data_dir=ecdr_data_dir)
+                monthly_dir = get_monthly_dir(base_output_dir=base_output_dir)
 
                 # monthly filepaths should have the form
                 # "sic_ps{n|s}12.5_{YYYYMM}_{sat}_v05r00.nc"
@@ -534,15 +534,15 @@ def validate_outputs(
     callback=datetime_to_date,
 )
 def cli(
-    ecdr_data_dir: Path,
+    base_output_dir: Path,
     hemisphere: Hemisphere | Literal["both"],
     product_type: Literal["daily", "monthly", "both"],
     start_date: dt.date,
     end_date: dt.date,
 ):
     # The data should be organized by hemisphere.
-    ecdr_data_dir = ecdr_data_dir / hemisphere
-    ecdr_data_dir.mkdir(exist_ok=True)
+    base_output_dir = base_output_dir / hemisphere
+    base_output_dir.mkdir(exist_ok=True)
 
     daily = False
     if product_type == "daily" or product_type == "both":
@@ -559,7 +559,7 @@ def cli(
         if daily:
             validate_outputs(
                 hemisphere=hemisphere,
-                ecdr_data_dir=ecdr_data_dir,
+                base_output_dir=base_output_dir,
                 start_date=start_date,
                 end_date=end_date,
                 product="daily",
@@ -567,7 +567,7 @@ def cli(
         if monthly:
             validate_outputs(
                 hemisphere=hemisphere,
-                ecdr_data_dir=ecdr_data_dir,
+                base_output_dir=base_output_dir,
                 start_date=start_date,
                 end_date=end_date,
                 product="monthly",

--- a/seaice_ecdr/validation.py
+++ b/seaice_ecdr/validation.py
@@ -58,7 +58,7 @@ from seaice_ecdr.ancillary import (
 )
 from seaice_ecdr.cli.util import datetime_to_date
 from seaice_ecdr.complete_daily_ecdr import get_ecdr_filepath
-from seaice_ecdr.constants import BASE_OUTPUT_DIR, ECDR_PRODUCT_VERSION
+from seaice_ecdr.constants import DEFAULT_BASE_OUTPUT_DIR, ECDR_PRODUCT_VERSION
 from seaice_ecdr.monthly import get_monthly_dir
 from seaice_ecdr.util import date_range, get_num_missing_pixels
 
@@ -486,7 +486,7 @@ def validate_outputs(
         resolve_path=True,
         path_type=Path,
     ),
-    default=BASE_OUTPUT_DIR,
+    default=DEFAULT_BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/validation.py
+++ b/seaice_ecdr/validation.py
@@ -366,6 +366,8 @@ def validate_outputs(
     """
     complete_output_dir = get_complete_output_dir(
         base_output_dir=base_output_dir,
+        hemisphere=hemisphere,
+        is_nrt=False,
     )
     validation_dir = get_validation_dir(base_output_dir=base_output_dir)
     log_filepath = (
@@ -433,7 +435,6 @@ def validate_outputs(
             for year, month in itertools.product(years, months):
                 monthly_dir = get_monthly_dir(
                     complete_output_dir=complete_output_dir,
-                    hemisphere=hemisphere,
                 )
 
                 # monthly filepaths should have the form

--- a/seaice_ecdr/validation.py
+++ b/seaice_ecdr/validation.py
@@ -390,6 +390,7 @@ def validate_outputs(
                     hemisphere=hemisphere,
                     resolution=VALIDATION_RESOLUTION,
                     ecdr_data_dir=ecdr_data_dir,
+                    is_nrt=False,
                 )
 
                 if not data_fp.is_file():

--- a/seaice_ecdr/validation.py
+++ b/seaice_ecdr/validation.py
@@ -60,7 +60,7 @@ from seaice_ecdr.cli.util import datetime_to_date
 from seaice_ecdr.complete_daily_ecdr import get_ecdr_filepath
 from seaice_ecdr.constants import DEFAULT_BASE_OUTPUT_DIR, ECDR_PRODUCT_VERSION
 from seaice_ecdr.monthly import get_monthly_dir
-from seaice_ecdr.util import date_range, get_num_missing_pixels
+from seaice_ecdr.util import date_range, get_complete_output_dir, get_num_missing_pixels
 
 VALIDATION_RESOLUTION: Final = "12.5"
 
@@ -364,6 +364,9 @@ def validate_outputs(
     * error_seaice_{n|s}_daily_{start_year}_{end_year}.csv. Contains the
       following fields: [year, month, day, error_code]
     """
+    complete_output_dir = get_complete_output_dir(
+        base_output_dir=base_output_dir,
+    )
     validation_dir = get_validation_dir(base_output_dir=base_output_dir)
     log_filepath = (
         validation_dir
@@ -389,7 +392,7 @@ def validate_outputs(
                     date=date,
                     hemisphere=hemisphere,
                     resolution=VALIDATION_RESOLUTION,
-                    base_output_dir=base_output_dir,
+                    complete_output_dir=complete_output_dir,
                     is_nrt=False,
                 )
 
@@ -429,7 +432,7 @@ def validate_outputs(
             months = range(start_date.month, end_date.month + 1)
             for year, month in itertools.product(years, months):
                 monthly_dir = get_monthly_dir(
-                    base_output_dir=base_output_dir,
+                    complete_output_dir=complete_output_dir,
                     hemisphere=hemisphere,
                 )
 

--- a/seaice_ecdr/validation.py
+++ b/seaice_ecdr/validation.py
@@ -58,7 +58,7 @@ from seaice_ecdr.ancillary import (
 )
 from seaice_ecdr.cli.util import datetime_to_date
 from seaice_ecdr.complete_daily_ecdr import get_ecdr_filepath
-from seaice_ecdr.constants import ECDR_PRODUCT_VERSION, STANDARD_BASE_OUTPUT_DIR
+from seaice_ecdr.constants import BASE_OUTPUT_DIR, ECDR_PRODUCT_VERSION
 from seaice_ecdr.monthly import get_monthly_dir
 from seaice_ecdr.util import date_range, get_num_missing_pixels
 
@@ -486,7 +486,7 @@ def validate_outputs(
         resolve_path=True,
         path_type=Path,
     ),
-    default=STANDARD_BASE_OUTPUT_DIR,
+    default=BASE_OUTPUT_DIR,
     help=(
         "Base output directory for standard ECDR outputs."
         " Subdirectories are created for outputs of"

--- a/seaice_ecdr/validation.py
+++ b/seaice_ecdr/validation.py
@@ -539,6 +539,10 @@ def cli(
     start_date: dt.date,
     end_date: dt.date,
 ):
+    # The data should be organized by hemisphere.
+    ecdr_data_dir = ecdr_data_dir / hemisphere
+    ecdr_data_dir.mkdir(exist_ok=True)
+
     daily = False
     if product_type == "daily" or product_type == "both":
         daily = True

--- a/seaice_ecdr/validation.py
+++ b/seaice_ecdr/validation.py
@@ -428,7 +428,10 @@ def validate_outputs(
             years = range(start_date.year, end_date.year + 1)
             months = range(start_date.month, end_date.month + 1)
             for year, month in itertools.product(years, months):
-                monthly_dir = get_monthly_dir(base_output_dir=base_output_dir)
+                monthly_dir = get_monthly_dir(
+                    base_output_dir=base_output_dir,
+                    hemisphere=hemisphere,
+                )
 
                 # monthly filepaths should have the form
                 # "sic_ps{n|s}12.5_{YYYYMM}_{sat}_v05r00.nc"
@@ -476,7 +479,7 @@ def validate_outputs(
     help="Create CSV files used to validate ECDR outputs.",
 )
 @click.option(
-    "--ecdr-data-dir",
+    "--base-output-dir",
     required=True,
     type=click.Path(
         exists=True,
@@ -540,10 +543,6 @@ def cli(
     start_date: dt.date,
     end_date: dt.date,
 ):
-    # The data should be organized by hemisphere.
-    base_output_dir = base_output_dir / hemisphere
-    base_output_dir.mkdir(exist_ok=True)
-
     daily = False
     if product_type == "daily" or product_type == "both":
         daily = True


### PR DESCRIPTION
* Rename `ecdr_data_dir` -> `base_output_dir`
* Explicitly create and separate outputs by intermediate and complete subdirs under `base_output_dir`
* Add date-range option to NRT CLI.

Creates a directory structure that looks like this:

```
/share/apps/G02202_V5/v05r01_outputs/
├── complete
│   ├── north
│   │   ├── aggregate
│   │   ├── checksums
│   │   │   ├── aggregate
│   │   │   ├── daily
│   │   │   │   └── 2012
│   │   │   └── monthly
│   │   ├── daily
│   │   │   └── 2012
│   │   ├── monthly
│   │   └── nrt
│   │       └── checksums
│   └── south
│       ├── aggregate
│       ├── checksums
│       │   ├── aggregate
│       │   ├── daily
│       │   │   └── 2012
│       │   └── monthly
│       ├── daily
│       │   └── 2012
│       ├── monthly
│       └── nrt
│           └── checksums
├── intermediate
│   ├── north
│   │   ├── initial_daily
│   │   ├── nrt
│   │   │   ├── initial_daily
│   │   │   └── temporal_interp
│   │   └── temporal_interp
│   └── south
│       ├── initial_daily
│       ├── nrt
│       │   ├── initial_daily
│       │   └── temporal_interp
│       └── temporal_interp
└── validation

```