### PR TITLE
Rename `prototype_amsr2` -> `prototype_am2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v0.3.0
 
 * Add new `daily` cli that produces daily NC files ready for publication. During
-  the AMSR2 period, a `prototype_amsr2` group is added to the final output files
+  the AMSR2 period, a `prototype_am2` group is added to the final output files
   with AMSR2-derived fields.
 
 # match-cdrv4 (commit 87271ec)

--- a/seaice_ecdr/publish_daily.py
+++ b/seaice_ecdr/publish_daily.py
@@ -137,7 +137,7 @@ def publish_daily_nc(
     # TODO: consider extracting to config or a kwarg of this function for more
     # flexible use with other platforms in the future.
     PROTOTYPE_PLATFORM_ID: SUPPORTED_PLATFORM_ID = "am2"
-    PROTOTYPE_PLATFORM_DATA_GROUP_NAME = "prototype_amsr2"
+    PROTOTYPE_PLATFORM_DATA_GROUP_NAME = f"prototype_{PROTOTYPE_PLATFORM_ID}"
 
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=base_output_dir,

--- a/seaice_ecdr/tests/integration/test_publish_daily.py
+++ b/seaice_ecdr/tests/integration/test_publish_daily.py
@@ -22,8 +22,8 @@ def test_publish_daily_nc(base_output_dir_test_path):  # noqa
 
         # TODO: we would expect this date to contain the amsr2 prototype group,
         # but the integration tests do not currently run with the AMSR2 platform
-        # config, so the `prototype_amsr2` group is not present.
-        # assert "prototype_amsr2" in ds.groups
+        # config, so the `prototype_am2` group is not present.
+        # assert "prototype_am2" in ds.groups
         assert "/cdr_supplementary" in ds.groups
 
         assert "valid_range" not in ds.time.attrs.keys()

--- a/seaice_ecdr/tests/regression/test_daily_aggregate.py
+++ b/seaice_ecdr/tests/regression/test_daily_aggregate.py
@@ -74,9 +74,9 @@ def test_daily_aggregate_matches_daily_data(tmpdir):
     agg_cdr_supplementary_ds = xr.open_dataset(
         aggregate_filepath, group="cdr_supplementary"
     )
-    # TODO: prototype_amsr2 does not currently exist in this regression test
+    # TODO: prototype_am2 does not currently exist in this regression test
     # because only data for the default platforms are being generated
-    # agg_prototype_amsr2_ds = xr.open_dataset(aggregate_filepath, group="prototype_amsr2")
+    # agg_prototype_am2_ds = xr.open_dataset(aggregate_filepath, group="prototype_am2")
 
     checksum_filepath = (
         complete_output_dir


### PR DESCRIPTION
Use the platform ID as an identifier like we do for the variable names themselves. This is more consistent and allows the code to be more flexible, which we want for the future as new platforms are developed and put into operations.