### PR TITLE
minor tweaks to validation CLI

### DIFF
--- a/seaice_ecdr/validation.py
+++ b/seaice_ecdr/validation.py
@@ -235,6 +235,9 @@ def get_pixel_counts(
     seaice_conc_var = ds[conc_var_name]
 
     qa_var_name = "cdr_seaice_conc_qa_flag"
+    if product == "monthly":
+        qa_var_name = "cdr_seaice_conc_monthly_qa_flag"
+
     qa_var = ds[qa_var_name]
 
     # Handle the log file first. It contains information on the # of
@@ -453,7 +456,7 @@ def validate_outputs(
                 results = find_standard_monthly_netcdf_files(
                     search_dir=monthly_dir,
                     hemisphere=hemisphere,
-                    resolution="25",
+                    resolution=VALIDATION_RESOLUTION,
                     year=year,
                     month=month,
                     platform_id="*",


### PR DESCRIPTION
This code is currently flagging the fact that values of 2.55 are getting through in the concentration fields. We need to make sure that only SIC values (0-1) are present in the conc fields. This should be handled in https://trello.com/c/Powpns6G/465-clean-up-cdr-values-below-10-or-above-100-for-daily