### PR TITLE
NRT Processing updates for G10016

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
       - name: "Install Conda environment"
         uses: "mamba-org/setup-micromamba@v1"
         with:
+          micromamba-version: '1.5.10-0' # any version from https://github.com/mamba-org/micromamba-releases
           environment-file: "conda-lock.yml"
           # When using a lock-file, we have to set an environment name.
           environment-name: "seaice_ecdr-ci"

--- a/environment.yml
+++ b/environment.yml
@@ -20,8 +20,8 @@ dependencies:
   - nco ~=5.1.9
   - pandas ~=1.4.4
   - opencv ~=4.8.0
-  - pm_tb_data ~=0.4.0
-  - pm_icecon ~=0.4.0
+  - pm_tb_data ~=0.5.0
+  - pm_icecon ~=0.5.0
   - leafmap
   - rioxarray
   - hvplot

--- a/seaice_ecdr/ancillary.py
+++ b/seaice_ecdr/ancillary.py
@@ -112,7 +112,12 @@ def get_surfacetype_da(
     if "polehole_bitmask" in ancillary_ds.data_vars.keys():
         polehole_bitmask = ancillary_ds.polehole_bitmask
         platform = PLATFORM_CONFIG.get_platform_by_date(date)
-        polehole_bitlabel = f"{platform.id}_polemask"
+        platform_id = platform.id
+        # TODO: Use F17 polemask if F18 is being used. There is currently no F18
+        # polemask defined in the ancilary file
+        if platform.id == "F18":
+            platform_id = "F17"
+        polehole_bitlabel = f"{platform_id}_polemask"
         polehole_bitvalue = bitmask_value_for_meaning(
             var=polehole_bitmask,
             meaning=polehole_bitlabel,
@@ -192,7 +197,12 @@ def nh_polehole_mask(
             date=date,
         )
 
-    polehole_bitlabel = f"{platform.id}_polemask"
+    platform_id = platform.id
+    # TODO: Use F17 polemask if F18 is being used. There is currently no F18
+    # polemask defined in the ancilary file
+    if platform.id == "F18":
+        platform_id = "F17"
+    polehole_bitlabel = f"{platform_id}_polemask"
     polehole_bitvalue = bitmask_value_for_meaning(
         var=polehole_bitmask,
         meaning=polehole_bitlabel,

--- a/seaice_ecdr/cli/entrypoint.py
+++ b/seaice_ecdr/cli/entrypoint.py
@@ -4,6 +4,7 @@ import click
 
 from seaice_ecdr.cli.daily import cli as daily_cli
 from seaice_ecdr.cli.monthly import cli as monthly_cli
+from seaice_ecdr.cli.nrt import cli as nrt_cli
 from seaice_ecdr.daily_aggregate import cli as daily_aggregate_cli
 from seaice_ecdr.initial_daily_ecdr import cli as ecdr_cli
 from seaice_ecdr.intermediate_daily import cli as intermediate_daily_cli
@@ -12,7 +13,7 @@ from seaice_ecdr.monthly_aggregate import cli as monthly_aggregate_cli
 from seaice_ecdr.multiprocess_intermediate_daily import (
     cli as multiprocess_intermediate_daily_cli,
 )
-from seaice_ecdr.nrt import nrt_cli
+from seaice_ecdr.nrt import nrt_ecdr_for_dates
 from seaice_ecdr.publish_daily import cli as publish_daily_cli
 from seaice_ecdr.temporal_composite_daily import cli as tiecdr_cli
 from seaice_ecdr.validation import cli as validation_cli
@@ -26,12 +27,12 @@ def cli():
 
 cli.add_command(ecdr_cli)
 cli.add_command(tiecdr_cli)
-cli.add_command(nrt_cli)
 cli.add_command(intermediate_daily_cli)
 cli.add_command(intermediate_monthly_cli)
 cli.add_command(validation_cli)
 cli.add_command(multiprocess_intermediate_daily_cli)
 cli.add_command(publish_daily_cli)
+cli.add_command(nrt_ecdr_for_dates)
 
 # CLIs that ops will use below:
 # Generate standard daily files ready for publication:
@@ -42,6 +43,9 @@ cli.add_command(daily_aggregate_cli)
 cli.add_command(monthly_cli)
 # Generate monthly aggregate file (one per hemisphere)
 cli.add_command(monthly_aggregate_cli)
+# Wraps the `nrt_ecdr_for_dates` CLI with the correct platform start date
+# configuration chosen.
+cli.add_command(nrt_cli)
 
 if __name__ == "__main__":
     cli()

--- a/seaice_ecdr/cli/nrt.py
+++ b/seaice_ecdr/cli/nrt.py
@@ -1,0 +1,93 @@
+"""Wrapper around the nrt CLI to override platform start dates config
+
+This is a hack, and should be unnecessary once the code is refactored to make it
+easier to configure the platform start dates.
+"""
+
+import copy
+import datetime as dt
+from pathlib import Path
+from typing import get_args
+
+import click
+from pm_tb_data._types import Hemisphere
+
+from seaice_ecdr.cli.util import CLI_EXE_PATH, datetime_to_date, run_cmd
+from seaice_ecdr.constants import DEFAULT_BASE_NRT_OUTPUT_DIR
+from seaice_ecdr.platforms.config import NRT_PLATFORM_START_DATES_CONFIG_FILEPATH
+
+
+@click.command(name="daily-nrt")
+@click.option(
+    "-d",
+    "--date",
+    required=True,
+    type=click.DateTime(formats=("%Y-%m-%d", "%Y%m%d", "%Y.%m.%d")),
+    callback=datetime_to_date,
+)
+@click.option(
+    "--end-date",
+    required=False,
+    type=click.DateTime(
+        formats=(
+            "%Y-%m-%d",
+            "%Y%m%d",
+            "%Y.%m.%d",
+        )
+    ),
+    # Like `datetime_to_date` but allows `None`.
+    callback=lambda _ctx, _param, value: value if value is None else value.date(),
+    default=None,
+    help="If given, run temporal composite for `--date` through this end date.",
+)
+@click.option(
+    "-h",
+    "--hemisphere",
+    required=True,
+    type=click.Choice(get_args(Hemisphere)),
+)
+@click.option(
+    "--base-output-dir",
+    required=True,
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        writable=True,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=DEFAULT_BASE_NRT_OUTPUT_DIR,
+    help=(
+        "Base output directory for NRT ECDR outputs."
+        " Subdirectories are created for outputs of"
+        " different stages of processing."
+    ),
+    show_default=True,
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    help=("Overwrite intermediate and final outputs."),
+)
+def cli(
+    *,
+    date: dt.date,
+    end_date: dt.date | None,
+    hemisphere: Hemisphere,
+    base_output_dir: Path,
+    overwrite: bool,
+):
+    if end_date is None:
+        end_date = copy.copy(date)
+
+    overwrite_str = " --overwrite" if overwrite else ""
+
+    run_cmd(
+        f"export PLATFORM_START_DATES_CONFIG_FILEPATH={NRT_PLATFORM_START_DATES_CONFIG_FILEPATH} &&"
+        f"{CLI_EXE_PATH} nrt"
+        f" --hemisphere {hemisphere}"
+        f" --base-output-dir {base_output_dir}"
+        f" --date {date:%Y-%m-%d}"
+        f" --end-date {end_date:%Y-%m-%d}" + overwrite_str
+    )

--- a/seaice_ecdr/config/nrt_platform_start_dates.yml
+++ b/seaice_ecdr/config/nrt_platform_start_dates.yml
@@ -1,0 +1,5 @@
+cdr_platform_start_dates:
+  # We only use F18 for NRT.
+  - platform_id: "F18"
+    # This appears to be the first date of data in NSIDC0080.
+    start_date: "2021-11-01"

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -84,6 +84,9 @@ LOGS_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_logs" / _env_subdir
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 
 # Location of surface mask & geo-information files.
+# TODO: we should consider moving the ancillary files to a different
+# location. Currently, ancillary files are stored in the G02202 V5 specific dir,
+# but the NRT product is G10016 and it uses the same ancillary data.
 CDR_ANCILLARY_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_ancillary"
 CDRv4_ANCILLARY_DIR = NSIDC_NFS_SHARE_DIR / "cdrv4_equiv_ancillary"
 

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -68,3 +68,13 @@ LOGS_DIR.mkdir(parents=True, exist_ok=True)
 # Location of surface mask & geo-information files.
 CDR_ANCILLARY_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_ancillary"
 CDRv4_ANCILLARY_DIR = NSIDC_NFS_SHARE_DIR / "cdrv4_equiv_ancillary"
+
+# NRT outputs
+ECDR_NRT_PRODUCT_VERSION = "v03r00"
+NSIDC_NFS_NRT_SHARE_DIR = Path("/share/apps/G10016_V3")
+if not NSIDC_NFS_SHARE_DIR.is_dir():
+    raise RuntimeError(f"Expected {NSIDC_NFS_NRT_SHARE_DIR} to exist, but it does not.")
+DEFAULT_BASE_NRT_OUTPUT_DIR = (
+    NSIDC_NFS_NRT_SHARE_DIR / ECDR_NRT_PRODUCT_VERSION / _env_subdir
+)
+DEFAULT_BASE_NRT_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -14,8 +14,26 @@ import os
 import subprocess
 from pathlib import Path
 
+from pydantic import BaseModel
+
+
+class ProductVersion(BaseModel):
+    major_version_number: int
+    revision_number: int
+
+    @property
+    def version_str(self) -> str:
+        return f"v{self.major_version_number:02}r{self.revision_number:02}"
+
+    def __str__(self) -> str:
+        return self.version_str
+
+
 # This is the version string for the ECDR product.
-ECDR_PRODUCT_VERSION = "v05r00"
+ECDR_PRODUCT_VERSION = ProductVersion(
+    major_version_number=5,
+    revision_number=0,
+)
 
 # NSIDC infrastructure-specific paths:
 NSIDC_NFS_SHARE_DIR = Path("/share/apps/G02202_V5")
@@ -70,11 +88,14 @@ CDR_ANCILLARY_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_ancillary"
 CDRv4_ANCILLARY_DIR = NSIDC_NFS_SHARE_DIR / "cdrv4_equiv_ancillary"
 
 # NRT outputs
-ECDR_NRT_PRODUCT_VERSION = "v03r00"
+ECDR_NRT_PRODUCT_VERSION = ProductVersion(
+    major_version_number=3,
+    revision_number=0,
+)
 NSIDC_NFS_NRT_SHARE_DIR = Path("/share/apps/G10016_V3")
 if not NSIDC_NFS_SHARE_DIR.is_dir():
     raise RuntimeError(f"Expected {NSIDC_NFS_NRT_SHARE_DIR} to exist, but it does not.")
 DEFAULT_BASE_NRT_OUTPUT_DIR = (
-    NSIDC_NFS_NRT_SHARE_DIR / ECDR_NRT_PRODUCT_VERSION / _env_subdir
+    NSIDC_NFS_NRT_SHARE_DIR / ECDR_NRT_PRODUCT_VERSION.version_str / _env_subdir
 )
 DEFAULT_BASE_NRT_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -65,10 +65,6 @@ DEFAULT_BASE_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 LOGS_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_logs" / _env_subdir
 LOGS_DIR.mkdir(parents=True, exist_ok=True)
 
-# Location of LANCE AMSR2 NRT data files:
-# TODO: nest the subdir under an `ecdr_inputs` or similar?
-LANCE_NRT_DATA_DIR = NSIDC_NFS_SHARE_DIR / "lance_amsr2_nrt_data"
-
 # Location of surface mask & geo-information files.
 CDR_ANCILLARY_DIR = NSIDC_NFS_SHARE_DIR / f"{ECDR_PRODUCT_VERSION}_ancillary"
 CDRv4_ANCILLARY_DIR = NSIDC_NFS_SHARE_DIR / "cdrv4_equiv_ancillary"

--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -48,12 +48,14 @@ def _get_daily_complete_filepaths_for_year(
         dt.date(year, 1, 1), PLATFORM_CONFIG.get_first_platform_start_date()
     )
     for period in pd.period_range(start=start_date, end=dt.date(year, 12, 31)):
+        platform = PLATFORM_CONFIG.get_platform_by_date(period.to_timestamp().date())
         expected_fp = get_complete_daily_filepath(
             date=period.to_timestamp().date(),
             hemisphere=hemisphere,
             resolution=resolution,
             complete_output_dir=complete_output_dir,
             is_nrt=False,
+            platform_id=platform.id,
         )
         if expected_fp.is_file():
             data_list.append(expected_fp)

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -585,11 +585,8 @@ def compute_initial_daily_ecdr_dataset(
             satellite="amsre",
             gridid=ecdr_ide_ds.grid_id,
         )
-    # F18 is used in NRT processing.
-    elif platform.id == "F18":
-        raise NotImplementedError("TODO")
-    # Note: F18 is included in NSIDC0001, but we're getting data from NSIDC0080
-    # for NRT.
+    # NOTE/TODO: we get F18 data from NSIDC-0080 for NRT processing, but we are
+    # using the NSIDC-0001 specific BT params for F18.
     elif platform.id in get_args(NSIDC_0001_SATS):
         bt_coefs_init = pmi_bt_params_0001.get_nsidc0001_bootstrap_params(
             date=date,

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -335,7 +335,7 @@ def get_flagmask(
     if ancillary_source == "CDRv4":
         version_string = "v04r00"
     elif ancillary_source == "CDRv5":
-        version_string = ECDR_PRODUCT_VERSION
+        version_string = ECDR_PRODUCT_VERSION.version_str
 
     flagmask_fn = CDR_ANCILLARY_DIR / f"flagmask_{gridid}_{version_string}.dat"
     try:

--- a/seaice_ecdr/nc_attrs.py
+++ b/seaice_ecdr/nc_attrs.py
@@ -167,12 +167,12 @@ def get_global_attrs(
         **time_coverage_attrs,
         title=(
             "NOAA-NSIDC Climate Data Record of Passive Microwave"
-            " Sea Ice Concentration Version 5"
+            f" Sea Ice Concentration Version {ECDR_PRODUCT_VERSION.major_version_number}"
         ),
         program="NOAA Climate Data Record Program",
         software_version_id=_get_software_version_id(),
-        metadata_link="https://nsidc.org/data/g02202/versions/5",
-        product_version=ECDR_PRODUCT_VERSION,
+        metadata_link=f"https://nsidc.org/data/g02202/versions/{ECDR_PRODUCT_VERSION.major_version_number}",
+        product_version=ECDR_PRODUCT_VERSION.version_str,
         spatial_resolution=f"{resolution}km",
         standard_name_vocabulary="CF Standard Name Table (v83, 17 October 2023)",
         id="https://doi.org/10.7265/rjzb-pf78",

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -43,6 +43,13 @@ from seaice_ecdr.util import (
 )
 
 NRT_RESOLUTION: Final = "25"
+# NOTE/TODO: note that the NRT_PLATFORM_ID is used but not the exclusive source
+# of platform information. The program must be run with the environment variable
+# `PLATFORM_START_DATES_CONFIG_FILEPATH` set to the NRT config file
+# (`nrt_platform_start_dates.yml`) for the code to run properly. Ideally in the
+# future we can refactor the code to support configuring the platform start
+# dates at any point rather than needing an at-import-time setup as we currently
+# do.
 NRT_PLATFORM_ID: Final = "F18"
 # Number of days to look previously for temporal interpolation (forward
 # gap-filling)

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -293,6 +293,9 @@ def nrt_ecdr_for_day(
                 f" Sea Ice Concentration Version {ECDR_NRT_PRODUCT_VERSION.major_version_number}"
             )
             daily_ds.attrs["product_version"] = ECDR_NRT_PRODUCT_VERSION.version_str
+            daily_ds.attrs["summary"] = (
+                f"This data set provides a near-real-time (NRT) passive microwave sea ice concentration climate data record (CDR) based on gridded brightness temperatures (TBs) from the Defense Meteorological Satellite Program (DMSP) passive microwave radiometer: the Special Sensor Microwave Imager/Sounder (SSMIS) F18. The sea ice concentration CDR is an estimate of sea ice concentration that is produced by combining concentration estimates from two algorithms developed at the NASA Goddard Space Flight Center (GSFC): the NASA Team algorithm and the Bootstrap algorithm. The individual algorithms are used to process and combine brightness temperature data at NSIDC. This product is designed to provide an NRT time series of sea ice concentrations (the fraction, or percentage, of ocean area covered by sea ice). The data are gridded on the NSIDC polar stereographic grid with {NRT_RESOLUTION} x {NRT_RESOLUTION} km grid cells and are available in NetCDF file format. Each file contains a variable with the CDR concentration values as well as variables that hold the NASA Team and Bootstrap processed concentrations for reference. Variables containing standard deviation, quality flags, and projection information are also included."
+            )
 
             daily_ds.to_netcdf(nrt_output_filepath)
             logger.success(f"Wrote complete daily NRT NC file: {nrt_output_filepath}")

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -114,6 +114,7 @@ def read_or_create_and_read_nrt_idecdr_ds(
     intermediate_output_dir: Path,
     overwrite: bool,
 ):
+    # TODO: this isn't correct. We always use F18
     platform = PLATFORM_CONFIG.get_platform_by_date(date)
     idecdr_filepath = get_idecdr_filepath(
         hemisphere=hemisphere,
@@ -317,7 +318,7 @@ def nrt_ecdr_for_day(
             raise e
 
 
-@click.command(name="daily-nrt")
+@click.command(name="nrt")
 @click.option(
     "-d",
     "--date",
@@ -388,12 +389,3 @@ def nrt_ecdr_for_dates(
             base_output_dir=base_output_dir,
             overwrite=overwrite,
         )
-
-
-@click.group(name="nrt")
-def nrt_cli():
-    """Run NRT Sea Ice ECDR."""
-    ...
-
-
-nrt_cli.add_command(nrt_ecdr_for_dates)

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -44,6 +44,9 @@ from seaice_ecdr.util import (
 
 NRT_RESOLUTION: Final = "25"
 NRT_PLATFORM_ID: Final = "F18"
+# Number of days to look previously for temporal interpolation (forward
+# gap-filling)
+NRT_DAYS_TO_LOOK_PREVIOUSLY: Final = 5
 
 
 def compute_nrt_initial_daily_ecdr_dataset(
@@ -152,12 +155,11 @@ def temporally_interpolated_nrt_ecdr_dataset(
     date: dt.date,
     intermediate_output_dir: Path,
     overwrite: bool,
-    days_to_look_previously: int = 5,
     ancillary_source: ANCILLARY_SOURCES = "CDRv5",
 ) -> xr.Dataset:
     init_datasets = []
     for date in date_range(
-        start_date=date - dt.timedelta(days=days_to_look_previously), end_date=date
+        start_date=date - dt.timedelta(days=NRT_DAYS_TO_LOOK_PREVIOUSLY), end_date=date
     ):
         init_dataset = read_or_create_and_read_nrt_idecdr_ds(
             date=date,
@@ -174,8 +176,8 @@ def temporally_interpolated_nrt_ecdr_dataset(
         hemisphere=hemisphere,
         resolution=NRT_RESOLUTION,
         data_stack=data_stack,
-        interp_range=days_to_look_previously,
-        one_sided_limit=days_to_look_previously,
+        interp_range=NRT_DAYS_TO_LOOK_PREVIOUSLY,
+        one_sided_limit=NRT_DAYS_TO_LOOK_PREVIOUSLY,
         ancillary_source=ancillary_source,
     )
 
@@ -188,9 +190,6 @@ def read_or_create_and_read_nrt_tiecdr_ds(
     date: dt.date,
     intermediate_output_dir: Path,
     overwrite: bool,
-    # TODO: is it 4 or 5 days? Here we use 4, but the default for the temporal
-    # interpolation itself is 5.
-    days_to_look_previously: int = 4,
 ) -> xr.Dataset:
     tie_filepath = get_tie_filepath(
         date=date,
@@ -205,7 +204,6 @@ def read_or_create_and_read_nrt_tiecdr_ds(
             date=date,
             intermediate_output_dir=intermediate_output_dir,
             overwrite=overwrite,
-            days_to_look_previously=days_to_look_previously,
         )
 
         write_tie_netcdf(

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -12,6 +12,7 @@ from pm_tb_data._types import Hemisphere
 from pm_tb_data.fetch.nsidc_0080 import get_nsidc_0080_tbs_from_disk
 
 from seaice_ecdr.ancillary import ANCILLARY_SOURCES
+from seaice_ecdr.checksum import write_checksum_file
 from seaice_ecdr.cli.util import datetime_to_date
 from seaice_ecdr.constants import DEFAULT_BASE_OUTPUT_DIR
 from seaice_ecdr.initial_daily_ecdr import (
@@ -274,7 +275,12 @@ def nrt_ecdr_for_day(
             daily_ds.to_netcdf(nrt_output_filepath)
             logger.success(f"Wrote complete daily NRT NC file: {nrt_output_filepath}")
 
-            # TODO: write checksum file for NRTs?
+            # write checksum file for NRTs
+            checksums_dir = nrt_output_filepath.parent / "checksums"
+            write_checksum_file(
+                input_filepath=nrt_output_filepath,
+                output_dir=checksums_dir,
+            )
         except Exception as e:
             logger.exception(f"Failed to create NRT ECDR for {date=} {hemisphere=}")
             raise e

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -47,6 +47,7 @@ NRT_PLATFORM_ID: Final = "F18"
 # Number of days to look previously for temporal interpolation (forward
 # gap-filling)
 NRT_DAYS_TO_LOOK_PREVIOUSLY: Final = 5
+NRT_LAND_SPILLOVER_ALG: Final = "NT2_BT"
 
 
 def compute_nrt_initial_daily_ecdr_dataset(
@@ -91,8 +92,7 @@ def compute_nrt_initial_daily_ecdr_dataset(
         date=date,
         hemisphere=hemisphere,
         tb_data=tb_data,
-        # TODO: this needs to be updated.
-        land_spillover_alg="NT2",
+        land_spillover_alg=NRT_LAND_SPILLOVER_ALG,
         ancillary_source=ancillary_source,
     )
 

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -235,6 +235,7 @@ def nrt_ecdr_for_day(
         hemisphere=hemisphere,
         resolution=NRT_RESOLUTION,
         complete_output_dir=complete_output_dir,
+        platform_id=NRT_PLATFORM_ID,
         is_nrt=True,
     )
 

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -224,7 +224,7 @@ def nrt_ecdr_for_day(
     overwrite: bool,
     ancillary_source: ANCILLARY_SOURCES = "CDRv5",
 ):
-    """Create an initial daily ECDR NetCDF using NRT LANCE AMSR2 data."""
+    """Create an initial daily ECDR NetCDF using NRT NSIDC-0080 F18 data."""
     complete_output_dir = get_complete_output_dir(
         base_output_dir=base_output_dir,
         hemisphere=hemisphere,
@@ -330,13 +330,7 @@ def nrt_ecdr_for_day(
 @click.option(
     "--overwrite",
     is_flag=True,
-    help=(
-        "Overwrite intermediate and final outputs. CAUTION: because lance data is temporary,"
-        " this action could be destructive in a permenant way. E.g,. if input data for a"
-        " day that this CLI is being run for was previously generated with available"
-        " lance data, but that data no longer exists, the resulting file may be empty or"
-        " have significant data gaps. Use this primarily in a development environment."
-    ),
+    help=("Overwrite intermediate and final outputs."),
 )
 def nrt_ecdr_for_dates(
     *,

--- a/seaice_ecdr/platforms/config.py
+++ b/seaice_ecdr/platforms/config.py
@@ -62,7 +62,6 @@ F18_PLATFORM = Platform(
     sensor="SSMIS > Special Sensor Microwave Imager/Sounder",
     id="F18",
     date_range=DateRange(
-        # TODO: is this accurate? This value from NSIDC-0001 docs.
         first_date=dt.date(2017, 1, 1),
         last_date=None,
     ),

--- a/seaice_ecdr/platforms/config.py
+++ b/seaice_ecdr/platforms/config.py
@@ -53,6 +53,18 @@ AME_PLATFORM = Platform(
     ),
 )
 
+
+F18_PLATFORM = Platform(
+    name="DMSP 5D-3/F18 > Defense Meteorological Satellite Program-F18",
+    sensor="SSMIS > Special Sensor Microwave Imager/Sounder",
+    id="F18",
+    date_range=DateRange(
+        # TODO: is this accurate? This value from NSIDC-0001 docs.
+        first_date=dt.date(2017, 1, 1),
+        last_date=None,
+    ),
+)
+
 F17_PLATFORM = Platform(
     name="DMSP 5D-3/F17 > Defense Meteorological Satellite Program-F17",
     sensor="SSMIS > Special Sensor Microwave Imager/Sounder",
@@ -105,6 +117,7 @@ SUPPORTED_PLATFORMS = [
     AM2_PLATFORM,
     AME_PLATFORM,
     F17_PLATFORM,
+    F18_PLATFORM,
     F13_PLATFORM,
     F11_PLATFORM,
     F08_PLATFORM,

--- a/seaice_ecdr/platforms/config.py
+++ b/seaice_ecdr/platforms/config.py
@@ -31,6 +31,9 @@ DEFAULT_PLATFORM_START_DATES_CONFIG_FILEPATH = Path(
 PROTOTYPE_PLATFORM_START_DATES_CONFIG_FILEPATH = Path(
     _this_dir / "../config/prototype_platform_start_dates.yml"
 ).resolve()
+NRT_PLATFORM_START_DATES_CONFIG_FILEPATH = Path(
+    _this_dir / "../config/nrt_platform_start_dates.yml"
+).resolve()
 
 
 AM2_PLATFORM = Platform(

--- a/seaice_ecdr/platforms/models.py
+++ b/seaice_ecdr/platforms/models.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, root_validator, validator
 SUPPORTED_PLATFORM_ID = Literal[
     "am2",  # AMSR2
     "ame",  # AMSRE
+    "F18",  # SSMIS F18 (NRT)
     "F17",  # SSMIS F17
     "F13",  # SSMI F13
     "F11",  # SSMI F11

--- a/seaice_ecdr/publish_daily.py
+++ b/seaice_ecdr/publish_daily.py
@@ -60,20 +60,20 @@ def get_complete_daily_filepath(
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     complete_output_dir: Path,
     is_nrt: bool,
+    platform_id: SUPPORTED_PLATFORM_ID,
 ):
-    platform = PLATFORM_CONFIG.get_platform_by_date(date)
     if is_nrt:
         ecdr_filename = nrt_daily_filename(
             hemisphere=hemisphere,
             date=date,
-            platform_id=platform.id,
+            platform_id=platform_id,
             resolution=resolution,
         )
     else:
         ecdr_filename = standard_daily_filename(
             hemisphere=hemisphere,
             date=date,
-            platform_id=platform.id,
+            platform_id=platform_id,
             resolution=resolution,
         )
 
@@ -234,12 +234,14 @@ def publish_daily_nc(
         hemisphere=hemisphere,
         is_nrt=False,
     )
+    platform = PLATFORM_CONFIG.get_platform_by_date(date)
     complete_daily_filepath = get_complete_daily_filepath(
         date=date,
         resolution=resolution,
         complete_output_dir=complete_output_dir,
         hemisphere=hemisphere,
         is_nrt=False,
+        platform_id=platform.id,
     )
     complete_daily_ds.to_netcdf(complete_daily_filepath)
     logger.success(f"Staged NC file for publication: {complete_daily_filepath}")

--- a/seaice_ecdr/publish_daily.py
+++ b/seaice_ecdr/publish_daily.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import get_args
 
 import click
+import xarray as xr
 from datatree import DataTree
 from loguru import logger
 from pm_tb_data._types import NORTH, Hemisphere
@@ -26,6 +27,11 @@ from seaice_ecdr.util import (
     nrt_daily_filename,
     standard_daily_filename,
 )
+
+# TODO: consider extracting to config or a kwarg of this function for more
+# flexible use with other platforms in the future.
+PROTOTYPE_PLATFORM_ID: SUPPORTED_PLATFORM_ID = "am2"
+PROTOTYPE_PLATFORM_DATA_GROUP_NAME = f"prototype_{PROTOTYPE_PLATFORM_ID}"
 
 
 # TODO: this and `get_complete_daily_filepath` are identical (aside from var
@@ -82,6 +88,54 @@ def get_complete_daily_filepath(
     return ecdr_filepath
 
 
+def make_publication_ready_ds(
+    intermediate_daily_ds: xr.Dataset,
+    hemisphere: Hemisphere,
+) -> DataTree:
+    """Take an intermediate daily dataset and prepare for publication.
+
+    * Moves supplementary fields into "cdr_supplementary" group
+    * Removes `valid_range` attr from coordinate vars
+    * Adds `coverage_content_type: coordinate` attr to coordinate vars
+    * Adds  `coordinates` attr to data variables
+    """
+    # publication-ready daily data are grouped using `DataTree`.
+    # Create a `cdr_supplementary` group for "supplemntary" fields
+    cdr_supplementary_fields = [
+        "raw_bt_seaice_conc",
+        "raw_nt_seaice_conc",
+        "surface_type_mask",
+    ]
+    # Melt onset only occurs in the NH.
+    if hemisphere == NORTH:
+        cdr_supplementary_fields.append("cdr_melt_onset_day")
+
+    # Drop x, y, time coordinate variables. These will be inherited from the
+    # root group.
+    cdr_supplementary_group = intermediate_daily_ds[cdr_supplementary_fields].drop_vars(
+        ["x", "y", "time"]
+    )
+    # remove attrs from supplementary group. These will be inherted from the
+    # root group.
+    cdr_supplementary_group.attrs = {}
+
+    complete_daily_ds: DataTree = DataTree.from_dict(
+        {
+            "/": intermediate_daily_ds[
+                [k for k in intermediate_daily_ds if k not in cdr_supplementary_fields]
+            ],
+            "cdr_supplementary": cdr_supplementary_group,
+        }
+    )
+
+    # Remove `valid_range` from coordinate attrs
+    remove_valid_range_from_coordinate_vars(complete_daily_ds)
+    add_coordinate_coverage_content_type(complete_daily_ds)
+    add_coordinates_attr(complete_daily_ds)
+
+    return complete_daily_ds
+
+
 # TODO: consider a better name. `publish` implies this function might actually
 # publish it to a publicly accessible archive. That's something ops will do
 # separately. This just generates the publication-ready nc file to it's expected
@@ -100,10 +154,6 @@ def publish_daily_nc(
     output NC file's root-group variables are all taken from the default
     platforms given by the platform start date configuration.
     """
-    # TODO: consider extracting to config or a kwarg of this function for more
-    # flexible use with other platforms in the future.
-    PROTOTYPE_PLATFORM_ID: SUPPORTED_PLATFORM_ID = "am2"
-    PROTOTYPE_PLATFORM_DATA_GROUP_NAME = f"prototype_{PROTOTYPE_PLATFORM_ID}"
 
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=base_output_dir,
@@ -120,35 +170,13 @@ def publish_daily_nc(
         is_nrt=False,
     )
 
-    # publication-ready daily data are grouped using `DataTree`.
-    # Create a `cdr_supplementary` group for "supplemntary" fields
-    cdr_supplementary_fields = [
-        "raw_bt_seaice_conc",
-        "raw_nt_seaice_conc",
-        "surface_type_mask",
-    ]
-    # Melt onset only occurs in the NH.
-    if hemisphere == NORTH:
-        cdr_supplementary_fields.append("cdr_melt_onset_day")
-
-    # Drop x, y, time coordinate variables. These will be inherited from the
-    # root group.
-    cdr_supplementary_group = default_daily_ds[cdr_supplementary_fields].drop_vars(
-        ["x", "y", "time"]
-    )
-    # remove attrs from supplementary group. These will be inherted from the
-    # root group.
-    cdr_supplementary_group.attrs = {}
-
-    complete_daily_ds: DataTree = DataTree.from_dict(
-        {
-            "/": default_daily_ds[
-                [k for k in default_daily_ds if k not in cdr_supplementary_fields]
-            ],
-            "cdr_supplementary": cdr_supplementary_group,
-        }
+    # Prepare a dataset that's ready for publication.
+    complete_daily_ds = make_publication_ready_ds(
+        intermediate_daily_ds=default_daily_ds,
+        hemisphere=hemisphere,
     )
 
+    # Add the prototype group if there's data.
     if PLATFORM_CONFIG.platform_available_for_date(
         platform_id=PROTOTYPE_PLATFORM_ID,
         date=date,
@@ -199,11 +227,6 @@ def publish_daily_nc(
             logger.warning(
                 f"Failed to find prototype daily file for {date=} {PROTOTYPE_PLATFORM_ID=}"
             )
-
-    # Remove `valid_range` from coordinate attrs
-    remove_valid_range_from_coordinate_vars(complete_daily_ds)
-    add_coordinate_coverage_content_type(complete_daily_ds)
-    add_coordinates_attr(complete_daily_ds)
 
     # write out finalized nc file.
     complete_output_dir = get_complete_output_dir(

--- a/seaice_ecdr/tb_data.py
+++ b/seaice_ecdr/tb_data.py
@@ -254,7 +254,7 @@ def _get_nsidc_0001_tbs(
         tbs=ecdr_tbs,
         resolution=tb_resolution,
         data_source=data_source,
-        platform_id=platform_id,  # type: ignore[arg-type]
+        platform_id=platform_id,
     )
 
     return ecdr_tb_data

--- a/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
+++ b/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
@@ -146,6 +146,7 @@ def test_cli_idecdr_ncfile_creation(tmpdir):
         excluded_fields=[],
         land_spillover_alg="NT2",
         ancillary_source=ancillary_source,
+        platform_id=test_platform_id,
     )
     output_path = get_idecdr_filepath(
         hemisphere=test_hemisphere,
@@ -181,6 +182,7 @@ def test_can_drop_fields_from_idecdr_netcdf(
         excluded_fields=(cdr_conc_fieldname,),
         land_spillover_alg="NT2",
         ancillary_source=ancillary_source,
+        platform_id=test_platform_id,
     )
     output_path = get_idecdr_filepath(
         hemisphere=test_hemisphere,

--- a/seaice_ecdr/tests/unit/test_util.py
+++ b/seaice_ecdr/tests/unit/test_util.py
@@ -8,7 +8,7 @@ import xarray as xr
 from pm_tb_data._types import NORTH, SOUTH
 
 from seaice_ecdr import util
-from seaice_ecdr.constants import ECDR_PRODUCT_VERSION
+from seaice_ecdr.constants import ECDR_NRT_PRODUCT_VERSION, ECDR_PRODUCT_VERSION
 from seaice_ecdr.multiprocess_intermediate_daily import get_dates_by_year
 from seaice_ecdr.platforms.models import SUPPORTED_PLATFORM_ID
 from seaice_ecdr.util import (
@@ -46,7 +46,7 @@ def test_daily_filename_south():
 
 
 def test_nrt_daily_filename():
-    expected = f"sic_psn12.5_20210101_am2_{ECDR_PRODUCT_VERSION}_P.nc"
+    expected = f"sic_psn12.5_20210101_am2_{ECDR_NRT_PRODUCT_VERSION}_P.nc"
 
     actual = nrt_daily_filename(
         hemisphere=NORTH, resolution="12.5", platform_id="am2", date=dt.date(2021, 1, 1)

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -10,7 +10,7 @@ from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import ANCILLARY_SOURCES, get_ocean_mask
-from seaice_ecdr.constants import ECDR_PRODUCT_VERSION
+from seaice_ecdr.constants import ECDR_NRT_PRODUCT_VERSION, ECDR_PRODUCT_VERSION
 from seaice_ecdr.grid_id import get_grid_id
 from seaice_ecdr.platforms import SUPPORTED_PLATFORM_ID
 
@@ -54,6 +54,9 @@ def nrt_daily_filename(
     fn_base = standard_fn_path.stem
     ext = standard_fn_path.suffix
     nrt_fn = fn_base + "_P" + ext
+
+    # Replace the standard G02202 version number with the NRT version.
+    nrt_fn = nrt_fn.replace(ECDR_PRODUCT_VERSION, ECDR_NRT_PRODUCT_VERSION)
 
     return nrt_fn
 

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -56,7 +56,9 @@ def nrt_daily_filename(
     nrt_fn = fn_base + "_P" + ext
 
     # Replace the standard G02202 version number with the NRT version.
-    nrt_fn = nrt_fn.replace(ECDR_PRODUCT_VERSION, ECDR_NRT_PRODUCT_VERSION)
+    nrt_fn = nrt_fn.replace(
+        ECDR_PRODUCT_VERSION.version_str, ECDR_NRT_PRODUCT_VERSION.version_str
+    )
 
     return nrt_fn
 


### PR DESCRIPTION
* Adds support for  the `cdr_supplementary` NC group
* Changes the output location for NRT data to `/share/apps/G10016_V3` and updates associated dataset attrs to reflect G10016 instead of G02202
* Update `ECDR_PRODUCT_VERSION` type from string to pydantic model. 