### PR TITLE
Remove nrt-specific output dir code

### DIFF
--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -286,7 +286,6 @@ def cli(
     complete_output_dir = get_complete_output_dir(
         base_output_dir=base_output_dir,
         hemisphere=hemisphere,
-        is_nrt=False,
     )
     failed_years = []
     for year_to_process in range(year, end_year + 1):

--- a/seaice_ecdr/initial_daily_ecdr.py
+++ b/seaice_ecdr/initial_daily_ecdr.py
@@ -1472,7 +1472,6 @@ def cli(
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=base_output_dir,
         hemisphere=hemisphere,
-        is_nrt=False,
     )
     create_idecdr_for_date(
         hemisphere=hemisphere,

--- a/seaice_ecdr/intermediate_daily.py
+++ b/seaice_ecdr/intermediate_daily.py
@@ -554,7 +554,6 @@ def make_standard_cdecdr_netcdf(
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=base_output_dir,
         hemisphere=hemisphere,
-        is_nrt=False,
     )
     platform = PLATFORM_CONFIG.get_platform_by_date(date)
     cde_filepath = get_ecdr_filepath(
@@ -578,7 +577,6 @@ def make_standard_cdecdr_netcdf(
         intermediate_output_dir = get_intermediate_output_dir(
             base_output_dir=base_output_dir,
             hemisphere=hemisphere,
-            is_nrt=False,
         )
         tie_ds = read_or_create_and_read_standard_tiecdr_ds(
             date=date,

--- a/seaice_ecdr/intermediate_monthly.py
+++ b/seaice_ecdr/intermediate_monthly.py
@@ -764,7 +764,6 @@ def cli(
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=base_output_dir,
         hemisphere=hemisphere,
-        is_nrt=False,
     )
     error_periods = []
     for period in pd.period_range(

--- a/seaice_ecdr/monthly_aggregate.py
+++ b/seaice_ecdr/monthly_aggregate.py
@@ -170,7 +170,6 @@ def cli(
         complete_output_dir = get_complete_output_dir(
             base_output_dir=base_output_dir,
             hemisphere=hemisphere,
-            is_nrt=False,
         )
         monthly_filepaths = _get_monthly_complete_filepaths(
             hemisphere=hemisphere,

--- a/seaice_ecdr/multiprocess_intermediate_daily.py
+++ b/seaice_ecdr/multiprocess_intermediate_daily.py
@@ -63,7 +63,6 @@ def multiprocess_intermediate_daily(
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=base_output_dir,
         hemisphere=hemisphere,
-        is_nrt=False,
     )
 
     _create_idecdr_wrapper = partial(

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -238,7 +238,6 @@ def get_nrt_complete_daily_filepath(
     complete_output_dir = get_complete_output_dir(
         base_output_dir=base_output_dir,
         hemisphere=hemisphere,
-        is_nrt=True,
     )
     nrt_output_filepath = get_complete_daily_filepath(
         date=date,
@@ -274,7 +273,6 @@ def nrt_ecdr_for_day(
         intermediate_output_dir = get_intermediate_output_dir(
             base_output_dir=base_output_dir,
             hemisphere=hemisphere,
-            is_nrt=True,
         )
         try:
             tiecdr_ds = read_or_create_and_read_nrt_tiecdr_ds(
@@ -316,7 +314,15 @@ def nrt_ecdr_for_day(
             logger.success(f"Wrote complete daily NRT NC file: {nrt_output_filepath}")
 
             # write checksum file for NRTs
-            checksums_dir = nrt_output_filepath.parent / "checksums"
+            complete_output_dir = get_complete_output_dir(
+                base_output_dir=base_output_dir,
+                hemisphere=hemisphere,
+            )
+            checksums_dir = (
+                complete_output_dir
+                / nrt_output_filepath.relative_to(complete_output_dir).parent
+                / "checksums"
+            )
             write_checksum_file(
                 input_filepath=nrt_output_filepath,
                 output_dir=checksums_dir,

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -320,8 +320,8 @@ def nrt_ecdr_for_day(
             )
             checksums_dir = (
                 complete_output_dir
-                / nrt_output_filepath.relative_to(complete_output_dir).parent
                 / "checksums"
+                / nrt_output_filepath.relative_to(complete_output_dir).parent
             )
             write_checksum_file(
                 input_filepath=nrt_output_filepath,

--- a/seaice_ecdr/publish_daily.py
+++ b/seaice_ecdr/publish_daily.py
@@ -40,15 +40,8 @@ def get_complete_daily_dir(
     *,
     complete_output_dir: Path,
     year: int,
-    # TODO: extract nrt handling and make responsiblity for defining the output
-    # dir a higher-level concern.
-    is_nrt: bool,
 ) -> Path:
-    if is_nrt:
-        # NRT daily data just lives under the complete output dir.
-        ecdr_dir = complete_output_dir
-    else:
-        ecdr_dir = complete_output_dir / "daily" / str(year)
+    ecdr_dir = complete_output_dir / "daily" / str(year)
     ecdr_dir.mkdir(parents=True, exist_ok=True)
 
     return ecdr_dir
@@ -80,7 +73,6 @@ def get_complete_daily_filepath(
     ecdr_dir = get_complete_daily_dir(
         complete_output_dir=complete_output_dir,
         year=date.year,
-        is_nrt=is_nrt,
     )
 
     ecdr_filepath = ecdr_dir / ecdr_filename
@@ -158,7 +150,6 @@ def publish_daily_nc(
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=base_output_dir,
         hemisphere=hemisphere,
-        is_nrt=False,
     )
     default_platform = PLATFORM_CONFIG.get_platform_by_date(date)
     default_daily_ds = read_cdecdr_ds(
@@ -232,7 +223,6 @@ def publish_daily_nc(
     complete_output_dir = get_complete_output_dir(
         base_output_dir=base_output_dir,
         hemisphere=hemisphere,
-        is_nrt=False,
     )
     platform = PLATFORM_CONFIG.get_platform_by_date(date)
     complete_daily_filepath = get_complete_daily_filepath(

--- a/seaice_ecdr/publish_monthly.py
+++ b/seaice_ecdr/publish_monthly.py
@@ -84,7 +84,8 @@ def prepare_monthly_nc_for_publication(
 
     # Get the intermediate monthly data
     intermediate_output_dir = get_intermediate_output_dir(
-        base_output_dir=base_output_dir, hemisphere=hemisphere, is_nrt=False
+        base_output_dir=base_output_dir,
+        hemisphere=hemisphere,
     )
     intermediate_monthly_dir = get_intermediate_monthly_dir(
         intermediate_output_dir=intermediate_output_dir,
@@ -208,7 +209,6 @@ def prepare_monthly_nc_for_publication(
     complete_output_dir = get_complete_output_dir(
         base_output_dir=base_output_dir,
         hemisphere=hemisphere,
-        is_nrt=False,
     )
 
     complete_monthly_filepath = get_complete_monthly_filepath(

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -1098,7 +1098,6 @@ def cli(
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=base_output_dir,
         hemisphere=hemisphere,
-        is_nrt=False,
     )
 
     create_tiecdr_for_date_range(

--- a/seaice_ecdr/tests/integration/test_intermediate_monthly.py
+++ b/seaice_ecdr/tests/integration/test_intermediate_monthly.py
@@ -25,7 +25,6 @@ def test_make_intermediate_monthly_nc(base_output_dir_test_path, monkeypatch):  
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=base_output_dir_test_path,
         hemisphere=NORTH,
-        is_nrt=False,
     )
 
     output_path = intermediate_monthly.make_intermediate_monthly_nc(

--- a/seaice_ecdr/tests/regression/test_daily_aggregate.py
+++ b/seaice_ecdr/tests/regression/test_daily_aggregate.py
@@ -21,7 +21,6 @@ def test_daily_aggregate_matches_daily_data(tmpdir):
     complete_output_dir = get_complete_output_dir(
         base_output_dir=base_output_dir,
         hemisphere=hemisphere,
-        is_nrt=False,
     )
 
     year = 2022

--- a/seaice_ecdr/tests/unit/test_intermediate_daily.py
+++ b/seaice_ecdr/tests/unit/test_intermediate_daily.py
@@ -17,7 +17,6 @@ def test_no_melt_onset_for_southern_hemisphere(tmpdir):
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=Path(tmpdir),
         hemisphere=SOUTH,
-        is_nrt=False,
     )
     for date in (dt.date(2020, 2, 1), dt.date(2021, 6, 2), dt.date(2020, 10, 3)):
         with pytest.raises(RuntimeError):
@@ -38,7 +37,6 @@ def test_melt_onset_field_outside_melt_season(tmpdir):
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=Path(tmpdir),
         hemisphere=hemisphere,
-        is_nrt=False,
     )
     for date in (dt.date(2020, 2, 1), dt.date(2020, 10, 3)):
         melt_onset_field = cdecdr.create_melt_onset_field(

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -280,12 +280,9 @@ def _get_output_dir(
     *,
     base_output_dir: Path,
     hemisphere: Hemisphere,
-    is_nrt: bool,
     data_type: Literal["intermediate", "complete"],
 ) -> Path:
     out_dir = base_output_dir / data_type / hemisphere
-    if is_nrt:
-        out_dir = out_dir / "nrt"
 
     out_dir.mkdir(exist_ok=True, parents=True)
 
@@ -296,12 +293,10 @@ def get_intermediate_output_dir(
     *,
     base_output_dir: Path,
     hemisphere: Hemisphere,
-    is_nrt: bool,
 ) -> Path:
     intermediate_dir = _get_output_dir(
         base_output_dir=base_output_dir,
         hemisphere=hemisphere,
-        is_nrt=is_nrt,
         data_type="intermediate",
     )
 
@@ -312,12 +307,10 @@ def get_complete_output_dir(
     *,
     base_output_dir: Path,
     hemisphere: Hemisphere,
-    is_nrt: bool,
 ) -> Path:
     complete_dir = _get_output_dir(
         base_output_dir=base_output_dir,
         hemisphere=hemisphere,
-        is_nrt=is_nrt,
         data_type="complete",
     )
 

--- a/seaice_ecdr/validation.py
+++ b/seaice_ecdr/validation.py
@@ -381,7 +381,6 @@ def validate_outputs(
     intermediate_output_dir = get_intermediate_output_dir(
         base_output_dir=base_output_dir,
         hemisphere=hemisphere,
-        is_nrt=False,
     )
     validation_dir = get_validation_dir(base_output_dir=base_output_dir)
     log_filepath = (


### PR DESCRIPTION
Originally we were only going to produce daily nrt files and they were going to be a part of G02202. Now they'll ne a new version of G10016 and the directory structure for nrt files should reflect this.