### PR TITLE
Support both hemis ops cli

### DIFF
--- a/doc/operation.md
+++ b/doc/operation.md
@@ -110,7 +110,7 @@ There will be one daily aggregate file per year per hemisphere.
 When a month's worth of daily data is available, monthly data files can be produced:
 
 ```
-monthly --year YYYY --month mm --hemisphere {north|south}
+monthly --year YYYY --month mm --hemisphere both
 ```
 
 A range of years/months can also be specified:

--- a/doc/operation.md
+++ b/doc/operation.md
@@ -133,10 +133,9 @@ Each time finalized data is produced, the validation CLI should be run:
 
 
 ```
-validate-outputs --hemisphere {north|south} --start-date YYYY-MM-DD --end-date YYYY-MM-DD
+validate-outputs --hemisphere both --start-date YYYY-MM-DD --end-date YYYY-MM-DD
 ```
 
 This produces log files in
 `/share/apps/G02202_V5/v05r00_outputs/production/validation/` that should be
-published to the production location. TODO: confirm this is accurate. Does not
-look like v4 does this.
+reviewed by the NOAA@NSIDC project manager responsible for the sea ice CDR.

--- a/doc/operation.md
+++ b/doc/operation.md
@@ -93,7 +93,7 @@ as an example.
 To create daily data:
 
 ```
-daily --start-date YYYY-MM-DD --end-date YYYY-MM-DD --hemisphere {north|south}
+daily --start-date YYYY-MM-DD --end-date YYYY-MM-DD --hemisphere both
 ```
 
 Once daily data for a year is available, this data should be aggregated with the

--- a/seaice_ecdr/cli/daily.py
+++ b/seaice_ecdr/cli/daily.py
@@ -1,7 +1,7 @@
 import copy
 import datetime as dt
 from pathlib import Path
-from typing import get_args
+from typing import Literal, get_args
 
 import click
 from pm_tb_data._types import Hemisphere
@@ -112,7 +112,7 @@ def make_25km_ecdr(
     "-h",
     "--hemisphere",
     required=True,
-    type=click.Choice(get_args(Hemisphere)),
+    type=click.Choice([*get_args(Hemisphere), "both"]),
 )
 @click.option(
     "--base-output-dir",
@@ -161,7 +161,7 @@ def cli(
     *,
     date: dt.date,
     end_date: dt.date | None,
-    hemisphere: Hemisphere,
+    hemisphere: Hemisphere | Literal["both"],
     base_output_dir: Path,
     no_multiprocessing: bool,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
@@ -171,16 +171,22 @@ def cli(
     if end_date is None:
         end_date = copy.copy(date)
 
-    make_25km_ecdr(
-        start_date=date,
-        end_date=end_date,
-        hemisphere=hemisphere,
-        base_output_dir=base_output_dir,
-        no_multiprocessing=no_multiprocessing,
-        resolution=resolution,
-        land_spillover_alg=land_spillover_alg,
-        ancillary_source=ancillary_source,
-    )
+    if hemisphere == "both":
+        hemispheres: list[Hemisphere] = ["north", "south"]
+    else:
+        hemispheres = [hemisphere]
+
+    for hemisphere in hemispheres:
+        make_25km_ecdr(
+            start_date=date,
+            end_date=end_date,
+            hemisphere=hemisphere,
+            base_output_dir=base_output_dir,
+            no_multiprocessing=no_multiprocessing,
+            resolution=resolution,
+            land_spillover_alg=land_spillover_alg,
+            ancillary_source=ancillary_source,
+        )
 
 
 if __name__ == "__main__":

--- a/seaice_ecdr/cli/monthly.py
+++ b/seaice_ecdr/cli/monthly.py
@@ -1,6 +1,6 @@
 import datetime as dt
 from pathlib import Path
-from typing import get_args
+from typing import Literal, get_args
 
 import click
 import pandas as pd
@@ -122,7 +122,7 @@ def make_monthly_25km_ecdr(
     "-h",
     "--hemisphere",
     required=True,
-    type=click.Choice(get_args(Hemisphere)),
+    type=click.Choice([*get_args(Hemisphere), "both"]),
 )
 @click.option(
     "--base-output-dir",
@@ -167,7 +167,7 @@ def cli(
     month: int,
     end_year: int | None,
     end_month: int | None,
-    hemisphere: Hemisphere,
+    hemisphere: Hemisphere | Literal["both"],
     base_output_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     land_spillover_alg: LAND_SPILL_ALGS,
@@ -180,17 +180,23 @@ def cli(
     if end_month is None:
         end_month = month
 
-    make_monthly_25km_ecdr(
-        year=year,
-        month=month,
-        end_year=end_year,
-        end_month=end_month,
-        hemisphere=hemisphere,
-        base_output_dir=base_output_dir,
-        resolution=resolution,
-        land_spillover_alg=land_spillover_alg,
-        ancillary_source=ancillary_source,
-    )
+    if hemisphere == "both":
+        hemispheres: list[Hemisphere] = ["north", "south"]
+    else:
+        hemispheres = [hemisphere]
+
+    for hemisphere in hemispheres:
+        make_monthly_25km_ecdr(
+            year=year,
+            month=month,
+            end_year=end_year,
+            end_month=end_month,
+            hemisphere=hemisphere,
+            base_output_dir=base_output_dir,
+            resolution=resolution,
+            land_spillover_alg=land_spillover_alg,
+            ancillary_source=ancillary_source,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Support `--hemisphere both` for more CLIs. Now only the daily/monthly aggregate CLIs require `--hemisphere {north|south}`. May revisit that in the future!

Also updates the `operations.md` doc with the latest info.