### PR TITLE
do not use melt_onset QA flag mask for south

### DIFF
--- a/seaice_ecdr/intermediate_monthly.py
+++ b/seaice_ecdr/intermediate_monthly.py
@@ -217,8 +217,12 @@ CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS_NORTH = OrderedDict(
     }
 )
 
-CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS_SOUTH = CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS_NORTH.copy()
-CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS_SOUTH.pop("at_least_one_day_during_month_has_melt_detected")
+CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS_SOUTH = (
+    CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS_NORTH.copy()
+)
+CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS_SOUTH.pop(
+    "at_least_one_day_during_month_has_melt_detected"
+)
 
 
 def _qa_field_has_flag(*, qa_field: xr.DataArray, flag_value: int) -> xr.DataArray:
@@ -330,17 +334,16 @@ def calc_cdr_seaice_conc_monthly_qa_flag(
             cdr_seaice_conc_monthly_qa_flag
             + qa_flag_bitmasks["at_least_one_day_during_month_has_melt_detected"],
         )
-        monthly_qa_valid_range = (np.uint8(0), np.uint8(255))
-    else:
-        monthly_qa_valid_range = (np.uint8(0), np.uint8(127))
+
+    monthly_qa_values = [np.uint8(value) for value in qa_flag_bitmasks.values()]
 
     cdr_seaice_conc_monthly_qa_flag = cdr_seaice_conc_monthly_qa_flag.assign_attrs(
         long_name="NOAA/NSIDC CDR of Passive Microwave Monthly Northern Hemisphere Sea Ice Concentration QA flags",
         standard_name="status_flag",
         flag_meanings=" ".join(k for k in qa_flag_bitmasks.keys()),
-        flag_masks=[np.uint8(v) for v in qa_flag_bitmasks.values()],
+        flag_masks=monthly_qa_values,
         grid_mapping="crs",
-        valid_range=monthly_qa_valid_range,
+        valid_range=(np.uint8(0), np.uint8(sum(monthly_qa_values))),
     )
 
     cdr_seaice_conc_monthly_qa_flag.encoding = dict(

--- a/seaice_ecdr/intermediate_monthly.py
+++ b/seaice_ecdr/intermediate_monthly.py
@@ -217,17 +217,8 @@ CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS_NORTH = OrderedDict(
     }
 )
 
-CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS_SOUTH = OrderedDict(
-    {
-        "average_concentration_exceeds_0.15": 1,
-        "average_concentration_exceeds_0.30": 2,
-        "at_least_half_the_days_have_sea_ice_conc_exceeds_0.15": 4,
-        "at_least_half_the_days_have_sea_ice_conc_exceeds_0.30": 8,
-        "invalid_ice_mask_applied": 16,
-        "at_least_one_day_during_month_has_spatial_interpolation": 32,
-        "at_least_one_day_during_month_has_temporal_interpolation": 64,
-    }
-)
+CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS_SOUTH = CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS_NORTH.copy()
+CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS_SOUTH.pop("at_least_one_day_during_month_has_melt_detected")
 
 
 def _qa_field_has_flag(*, qa_field: xr.DataArray, flag_value: int) -> xr.DataArray:

--- a/seaice_ecdr/tests/unit/test_monthly.py
+++ b/seaice_ecdr/tests/unit/test_monthly.py
@@ -12,7 +12,7 @@ from seaice_ecdr import util
 from seaice_ecdr.constants import ECDR_PRODUCT_VERSION
 from seaice_ecdr.intermediate_daily import get_ecdr_dir
 from seaice_ecdr.intermediate_monthly import (
-    CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS,
+    CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS_NORTH,
     CDR_SEAICE_CONC_QA_FLAG_DAILY_BITMASKS,
     _get_daily_complete_filepaths_for_month,
     _platform_id_for_month,
@@ -301,6 +301,9 @@ def _mock_daily_ds_for_month():
 
 def test_calc_cdr_seaice_conc_monthly_qa_flag():
     _mock_daily_ds = _mock_daily_ds_for_month()
+    CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS = (
+        CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS_NORTH
+    )
     expected_flags = np.array(
         [
             CDR_SEAICE_CONC_MONTHLY_QA_FLAG_BITMASKS[
@@ -357,6 +360,7 @@ def test_calc_cdr_seaice_conc_monthly_qa_flag():
     actual = calc_cdr_seaice_conc_monthly_qa_flag(
         daily_ds_for_month=_mock_daily_ds,
         cdr_seaice_conc_monthly=_mean_daily_conc,
+        hemisphere="north",
     )
 
     nptesting.assert_array_equal(expected_flags, actual.values)


### PR DESCRIPTION
This PR fixes the inclusion of a "melt_onset" bitmask in the southern hemisphere monthly files.