### PR TITLE
Add support for producing monthly NRT from 0802

### DIFF
--- a/seaice_ecdr/cli/monthly.py
+++ b/seaice_ecdr/cli/monthly.py
@@ -22,6 +22,21 @@ from seaice_ecdr.platforms.config import (
 from seaice_ecdr.publish_monthly import prepare_monthly_nc_for_publication
 from seaice_ecdr.spillover import LAND_SPILL_ALGS
 
+# TODO: the prototype config should ideally be read from the platform start date
+# config.
+# TODO: this config is duplicated in the `publish_monthly` and `cli.daily`
+# module! If this is updated, those need to be updated there too!
+PROTOTYPE_PLATFORM_START_YEAR: int | None = None
+PROTOTYPE_PLATFORM_START_MONTH: int | None = None
+
+PROTOTYPE_PLATFORM_START_DATE: dt.date | None = None
+if PROTOTYPE_PLATFORM_START_DATE:
+    assert PROTOTYPE_PLATFORM_START_YEAR is not None
+    assert PROTOTYPE_PLATFORM_START_MONTH is not None
+    PROTOTYPE_PLATFORM_START_DATE = dt.date(
+        PROTOTYPE_PLATFORM_START_YEAR, PROTOTYPE_PLATFORM_START_MONTH, 1
+    )
+
 
 def make_monthly_25km_ecdr(
     year: int,
@@ -34,14 +49,6 @@ def make_monthly_25km_ecdr(
     land_spillover_alg: LAND_SPILL_ALGS,
     ancillary_source: ANCILLARY_SOURCES,
 ):
-    # TODO: the amsr2 start date should ideally be read from the platform start
-    # date config.
-    PROTOTYPE_PLATFORM_START_YEAR = 2013
-    PROTOTYPE_PLATFORM_START_MONTH = 1
-
-    PROTOTYPE_PLATFORM_START_DATE = dt.date(
-        PROTOTYPE_PLATFORM_START_YEAR, PROTOTYPE_PLATFORM_START_MONTH, 1
-    )
 
     # Use the default platform dates, which excludes AMSR2
     run_cmd(
@@ -57,10 +64,15 @@ def make_monthly_25km_ecdr(
 
     # If the given start & end date intersect with the AMSR2 period,
     # run that separately:
-    if dt.date(end_year, end_month, 1) >= PROTOTYPE_PLATFORM_START_DATE:
+    if (
+        PROTOTYPE_PLATFORM_START_DATE
+        and dt.date(end_year, end_month, 1) >= PROTOTYPE_PLATFORM_START_DATE
+    ):
         proto_year = year
         proto_month = month
         if dt.date(year, month, 1) < PROTOTYPE_PLATFORM_START_DATE:
+            assert PROTOTYPE_PLATFORM_START_YEAR is not None
+            assert PROTOTYPE_PLATFORM_START_MONTH is not None
             proto_year = PROTOTYPE_PLATFORM_START_YEAR
             proto_month = PROTOTYPE_PLATFORM_START_MONTH
 

--- a/seaice_ecdr/cli/monthly_nrt.py
+++ b/seaice_ecdr/cli/monthly_nrt.py
@@ -13,7 +13,6 @@ from seaice_ecdr.constants import (
 )
 from seaice_ecdr.platforms.config import (
     NRT_AM2_PLATFORM_START_DATES_CONFIG_FILEPATH,
-    NRT_F17_PLATFORM_START_DATES_CONFIG_FILEPATH,
 )
 
 
@@ -24,19 +23,13 @@ def make_monthly_25km_ecdr(
     end_month: int | None,
     hemisphere: Hemisphere,
     base_output_dir: Path,
-    nrt_platform_id: Literal["F17", "am2"],
 ):
     if end_year is None:
         end_year = year
     if end_month is None:
         end_month = month
 
-    if nrt_platform_id == "F17":
-        nrt_platform_start_dates_filepath = NRT_F17_PLATFORM_START_DATES_CONFIG_FILEPATH
-    elif nrt_platform_id == "am2":
-        nrt_platform_start_dates_filepath = NRT_AM2_PLATFORM_START_DATES_CONFIG_FILEPATH
-    else:
-        raise RuntimeError(f"NRT processing is not defined for {nrt_platform_id}")
+    nrt_platform_start_dates_filepath = NRT_AM2_PLATFORM_START_DATES_CONFIG_FILEPATH
     run_cmd(
         f"export PLATFORM_START_DATES_CONFIG_FILEPATH={nrt_platform_start_dates_filepath} &&"
         f" {CLI_EXE_PATH} intermediate-monthly"
@@ -117,15 +110,6 @@ def make_monthly_25km_ecdr(
     ),
     show_default=True,
 )
-@click.option(
-    "--nrt-platform-id",
-    # TODO: eventually we want to support AM2 as a separate monthly file. This
-    # does not currently work: the code instead places the AMSR2 monthly data
-    # into a `am2_prototype` group like the non-nrt files, and that's not what
-    # we want because the lag on data for F17 is different from AM2.
-    type=click.Choice(["F17"]),
-    default="F17",
-)
 def cli(
     *,
     year: int,
@@ -134,7 +118,6 @@ def cli(
     end_month: int | None,
     hemisphere: Hemisphere | Literal["both"],
     base_output_dir: Path,
-    nrt_platform_id: Literal["F17"],
 ) -> None:
     base_output_dir = base_output_dir / "CDR"
     base_output_dir.mkdir(exist_ok=True)
@@ -152,7 +135,6 @@ def cli(
             end_month=end_month,
             hemisphere=hemisphere,
             base_output_dir=base_output_dir,
-            nrt_platform_id=nrt_platform_id,
         )
 
 

--- a/seaice_ecdr/cli/monthly_nrt.py
+++ b/seaice_ecdr/cli/monthly_nrt.py
@@ -23,13 +23,20 @@ def make_monthly_25km_ecdr(
     end_month: int | None,
     hemisphere: Hemisphere,
     base_output_dir: Path,
+    # TODO: only am2 is currently supported, but in the future we may want to
+    # support am3 as a prototype platform.
+    nrt_platform_id: Literal["am2"] = "am2",
 ):
     if end_year is None:
         end_year = year
     if end_month is None:
         end_month = month
 
-    nrt_platform_start_dates_filepath = NRT_AM2_PLATFORM_START_DATES_CONFIG_FILEPATH
+    if nrt_platform_id == "am2":
+        nrt_platform_start_dates_filepath = NRT_AM2_PLATFORM_START_DATES_CONFIG_FILEPATH
+    else:
+        raise NotImplementedError(f"{nrt_platform_id=} is not supported.")
+
     run_cmd(
         f"export PLATFORM_START_DATES_CONFIG_FILEPATH={nrt_platform_start_dates_filepath} &&"
         f" {CLI_EXE_PATH} intermediate-monthly"
@@ -110,6 +117,15 @@ def make_monthly_25km_ecdr(
     ),
     show_default=True,
 )
+@click.option(
+    "--nrt-platform-id",
+    # TODO: eventually we want to support a prototype platform as a separate
+    # monthly file. This does not currently work: the code instead places the
+    # prototype monthly data into a `{prototype_platform_id}_prototype` group
+    # like the non-nrt files, and that's not what we want.
+    type=click.Choice(["am2"]),
+    default="am2",
+)
 def cli(
     *,
     year: int,
@@ -118,6 +134,7 @@ def cli(
     end_month: int | None,
     hemisphere: Hemisphere | Literal["both"],
     base_output_dir: Path,
+    nrt_platform_id: Literal["am2"],
 ) -> None:
     base_output_dir = base_output_dir / "CDR"
     base_output_dir.mkdir(exist_ok=True)
@@ -135,6 +152,7 @@ def cli(
             end_month=end_month,
             hemisphere=hemisphere,
             base_output_dir=base_output_dir,
+            nrt_platform_id=nrt_platform_id,
         )
 
 

--- a/seaice_ecdr/config/nrt_f17_platform_start_dates.yml
+++ b/seaice_ecdr/config/nrt_f17_platform_start_dates.yml
@@ -1,3 +1,0 @@
-cdr_platform_start_dates:
-  - platform_id: "F17"
-    start_date: "2008-01-01"

--- a/seaice_ecdr/platforms/config.py
+++ b/seaice_ecdr/platforms/config.py
@@ -31,9 +31,6 @@ DEFAULT_PLATFORM_START_DATES_CONFIG_FILEPATH = Path(
 PROTOTYPE_PLATFORM_START_DATES_CONFIG_FILEPATH = Path(
     _this_dir / "../config/prototype_platform_start_dates.yml"
 ).resolve()
-NRT_F17_PLATFORM_START_DATES_CONFIG_FILEPATH = Path(
-    _this_dir / "../config/nrt_f17_platform_start_dates.yml"
-).resolve()
 NRT_AM2_PLATFORM_START_DATES_CONFIG_FILEPATH = Path(
     _this_dir / "../config/nrt_am2_platform_start_dates.yml"
 ).resolve()


### PR DESCRIPTION
Resolves #181 

Retains the code to produce a prototype group, but makes it optional. This still feels a little hacky, and might be nice to just remove the code to support the "prototype" group altogether, but it may yet come in handy w/ e.g., AMSR3