### PR TITLE
Remove unused/OBE kwargs related to ancillary sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   for sea ice concentration based on day of year for data from DMSP
   platforms. This implements the "Seki" method approach to aligning DMSP-derived
   concentrations with AMSR2.
+* Remove concept of "ancillary sources", which was set with `--ancillary-source`
+  from CLI. This feature was not working as intended, and with the move to
+  v2.0.0 (which includes updates to ancillary data), it does not make sense to
+  backport those updates to ancillary files to previous versions.
 
 # v1.0.2
 

--- a/seaice_ecdr/cli/daily.py
+++ b/seaice_ecdr/cli/daily.py
@@ -7,10 +7,8 @@ import click
 from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
-from seaice_ecdr.ancillary import ANCILLARY_SOURCES
 from seaice_ecdr.cli.util import CLI_EXE_PATH, datetime_to_date, run_cmd
 from seaice_ecdr.constants import (
-    DEFAULT_ANCILLARY_SOURCE,
     DEFAULT_BASE_OUTPUT_DIR,
     DEFAULT_CDR_RESOLUTION,
     DEFAULT_SPILLOVER_ALG,
@@ -38,7 +36,6 @@ def make_25km_ecdr(
     no_multiprocessing: bool,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     land_spillover_alg: LAND_SPILL_ALGS,
-    ancillary_source: ANCILLARY_SOURCES,
 ):
     # Use the default platform dates, which excludes AMSR2
     if no_multiprocessing:
@@ -52,7 +49,6 @@ def make_25km_ecdr(
         f" --base-output-dir {base_output_dir}"
         f" --land-spillover-alg {land_spillover_alg}"
         f" --resolution {resolution}"
-        f" --ancillary-source {ancillary_source}"
     )
 
     # If the given start & end date intersect with the prototype period, run that
@@ -70,7 +66,6 @@ def make_25km_ecdr(
                 f" --base-output-dir {base_output_dir}"
                 f" --land-spillover-alg {land_spillover_alg}"
                 f" --resolution {resolution}"
-                f" --ancillary-source {ancillary_source}"
             )
 
     # Prepare the daily data for publication
@@ -156,12 +151,6 @@ def make_25km_ecdr(
     type=click.Choice(get_args(LAND_SPILL_ALGS)),
     default=DEFAULT_SPILLOVER_ALG,
 )
-@click.option(
-    "--ancillary-source",
-    required=True,
-    type=click.Choice(get_args(ANCILLARY_SOURCES)),
-    default=DEFAULT_ANCILLARY_SOURCE,
-)
 def cli(
     *,
     date: dt.date,
@@ -171,7 +160,6 @@ def cli(
     no_multiprocessing: bool,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     land_spillover_alg: LAND_SPILL_ALGS,
-    ancillary_source: ANCILLARY_SOURCES,
 ):
     if end_date is None:
         end_date = copy.copy(date)
@@ -190,7 +178,6 @@ def cli(
             no_multiprocessing=no_multiprocessing,
             resolution=resolution,
             land_spillover_alg=land_spillover_alg,
-            ancillary_source=ancillary_source,
         )
 
 

--- a/seaice_ecdr/cli/monthly.py
+++ b/seaice_ecdr/cli/monthly.py
@@ -7,10 +7,8 @@ import pandas as pd
 from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
-from seaice_ecdr.ancillary import ANCILLARY_SOURCES
 from seaice_ecdr.cli.util import CLI_EXE_PATH, run_cmd
 from seaice_ecdr.constants import (
-    DEFAULT_ANCILLARY_SOURCE,
     DEFAULT_BASE_OUTPUT_DIR,
     DEFAULT_CDR_RESOLUTION,
     DEFAULT_SPILLOVER_ALG,
@@ -47,7 +45,6 @@ def make_monthly_25km_ecdr(
     base_output_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     land_spillover_alg: LAND_SPILL_ALGS,
-    ancillary_source: ANCILLARY_SOURCES,
 ):
 
     # Use the default platform dates, which excludes AMSR2
@@ -59,7 +56,6 @@ def make_monthly_25km_ecdr(
         f" --hemisphere {hemisphere}"
         f" --base-output-dir {base_output_dir}"
         f" --resolution {resolution}"
-        f" --ancillary-source {ancillary_source}"
     )
 
     # If the given start & end date intersect with the AMSR2 period,
@@ -84,7 +80,6 @@ def make_monthly_25km_ecdr(
             f" --hemisphere {hemisphere}"
             f" --base-output-dir {base_output_dir}"
             f" --resolution {resolution}"
-            f" --ancillary-source {ancillary_source}"
         )
 
     # Prepare the monthly data for publication
@@ -167,12 +162,6 @@ def make_monthly_25km_ecdr(
     type=click.Choice(get_args(LAND_SPILL_ALGS)),
     default=DEFAULT_SPILLOVER_ALG,
 )
-@click.option(
-    "--ancillary-source",
-    required=True,
-    type=click.Choice(get_args(ANCILLARY_SOURCES)),
-    default=DEFAULT_ANCILLARY_SOURCE,
-)
 def cli(
     *,
     year: int,
@@ -183,7 +172,6 @@ def cli(
     base_output_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     land_spillover_alg: LAND_SPILL_ALGS,
-    ancillary_source: ANCILLARY_SOURCES,
 ) -> None:
     # Note: It appears that click cannot set one argument based on another.
     #       For clarity, we handle the "None" arg condition here for end_<vars>
@@ -207,7 +195,6 @@ def cli(
             base_output_dir=base_output_dir,
             resolution=resolution,
             land_spillover_alg=land_spillover_alg,
-            ancillary_source=ancillary_source,
         )
 
 

--- a/seaice_ecdr/cli/monthly_nrt.py
+++ b/seaice_ecdr/cli/monthly_nrt.py
@@ -7,7 +7,6 @@ from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr.cli.util import CLI_EXE_PATH, run_cmd
 from seaice_ecdr.constants import (
-    DEFAULT_ANCILLARY_SOURCE,
     DEFAULT_BASE_NRT_OUTPUT_DIR,
     DEFAULT_CDR_RESOLUTION,
 )
@@ -45,7 +44,6 @@ def make_monthly_25km_ecdr(
         f" --hemisphere {hemisphere}"
         f" --base-output-dir {base_output_dir}"
         f" --resolution {DEFAULT_CDR_RESOLUTION}"
-        f" --ancillary-source {DEFAULT_ANCILLARY_SOURCE}"
         " --is-nrt"
     )
 

--- a/seaice_ecdr/constants.py
+++ b/seaice_ecdr/constants.py
@@ -93,7 +93,6 @@ CDRv4_ANCILLARY_DIR = NSIDC_NFS_SHARE_DIR / "cdrv4_equiv_ancillary"
 
 # Defaults for CDR runs
 DEFAULT_CDR_RESOLUTION: Final = "25"
-DEFAULT_ANCILLARY_SOURCE: Final = "CDRv5"
 DEFAULT_SPILLOVER_ALG: Final = "NT2_BT"
 
 # NRT (G10016) outputs

--- a/seaice_ecdr/daily_aggregate.py
+++ b/seaice_ecdr/daily_aggregate.py
@@ -21,7 +21,6 @@ from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import (
-    ANCILLARY_SOURCES,
     get_ancillary_ds,
     remove_FillValue_from_coordinate_vars,
 )
@@ -101,7 +100,6 @@ def _update_ncrcat_daily_ds(
     daily_filepaths: list[Path],
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ancillary_source: ANCILLARY_SOURCES = "CDRv5",
 ):
     """Update the aggregate dataset created by `ncrcat`.
 
@@ -110,7 +108,6 @@ def _update_ncrcat_daily_ds(
     surf_geo_ds = get_ancillary_ds(
         hemisphere=hemisphere,
         resolution=resolution,
-        ancillary_source=ancillary_source,
     )
     # Lat and lon fields are placed under the "cdr_supplementary" group.
     for sup_var in ("latitude", "longitude"):
@@ -163,7 +160,6 @@ def _update_ncrcat_daily_ds(
         platform_ids=[platform_id_from_filename(fp.name) for fp in daily_filepaths],
         resolution=resolution,
         hemisphere=hemisphere,
-        ancillary_source=ancillary_source,
     )
     ds.attrs = daily_aggregate_ds_global_attrs  # type: ignore[assignment]
 

--- a/seaice_ecdr/intermediate_monthly.py
+++ b/seaice_ecdr/intermediate_monthly.py
@@ -37,7 +37,6 @@ from pm_tb_data._types import NORTH, Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import (
-    ANCILLARY_SOURCES,
     flag_value_for_meaning,
     get_monthly_cdr_conc_threshold,
     remove_FillValue_from_coordinate_vars,
@@ -372,7 +371,6 @@ def calc_cdr_seaice_conc_monthly(
     daily_ds_for_month: xr.Dataset,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ancillary_source: ANCILLARY_SOURCES,
 ) -> xr.DataArray:
     """Create the `cdr_seaice_conc_monthly` variable."""
     daily_conc_for_month = daily_ds_for_month.cdr_seaice_conc
@@ -582,7 +580,6 @@ def make_intermediate_monthly_ds(
     platform_id: SUPPORTED_PLATFORM_ID,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ancillary_source: ANCILLARY_SOURCES,
 ) -> xr.Dataset:
     """Create a monthly dataset from daily data.
 
@@ -601,7 +598,6 @@ def make_intermediate_monthly_ds(
         daily_ds_for_month=daily_ds_for_month,
         hemisphere=hemisphere,
         resolution=resolution,
-        ancillary_source=ancillary_source,
     )
 
     # Create `cdr_seaice_conc_monthly_stdev`, the standard deviation of the
@@ -673,7 +669,6 @@ def make_intermediate_monthly_ds(
         platform_ids=[platform_id],
         resolution=resolution,
         hemisphere=hemisphere,
-        ancillary_source=ancillary_source,
     )
     monthly_ds.attrs.update(monthly_ds_global_attrs)
 
@@ -720,7 +715,6 @@ def make_intermediate_monthly_nc(
     hemisphere: Hemisphere,
     intermediate_output_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ancillary_source: ANCILLARY_SOURCES,
     is_nrt: bool,
 ) -> Path:
     daily_ds_for_month = get_daily_ds_for_month(
@@ -748,7 +742,6 @@ def make_intermediate_monthly_nc(
         platform_id=platform_id,
         hemisphere=hemisphere,
         resolution=resolution,
-        ancillary_source=ancillary_source,
     )
 
     monthly_ds = remove_FillValue_from_coordinate_vars(monthly_ds)
@@ -824,11 +817,6 @@ def make_intermediate_monthly_nc(
     type=click.Choice(get_args(ECDR_SUPPORTED_RESOLUTIONS)),
 )
 @click.option(
-    "--ancillary-source",
-    required=True,
-    type=click.Choice(get_args(ANCILLARY_SOURCES)),
-)
-@click.option(
     "--is-nrt",
     required=False,
     is_flag=True,
@@ -843,7 +831,6 @@ def cli(
     hemisphere: Hemisphere,
     base_output_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ancillary_source: ANCILLARY_SOURCES,
     is_nrt: bool,
 ):
     if end_year is None:
@@ -868,7 +855,6 @@ def cli(
                 intermediate_output_dir=intermediate_output_dir,
                 hemisphere=hemisphere,
                 resolution=resolution,
-                ancillary_source=ancillary_source,
                 is_nrt=is_nrt,
             )
         except Exception:

--- a/seaice_ecdr/monthly_aggregate.py
+++ b/seaice_ecdr/monthly_aggregate.py
@@ -13,12 +13,11 @@ from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import (
-    ANCILLARY_SOURCES,
     get_ancillary_ds,
     remove_FillValue_from_coordinate_vars,
 )
 from seaice_ecdr.checksum import write_checksum_file
-from seaice_ecdr.constants import DEFAULT_ANCILLARY_SOURCE, DEFAULT_BASE_OUTPUT_DIR
+from seaice_ecdr.constants import DEFAULT_BASE_OUTPUT_DIR
 from seaice_ecdr.nc_attrs import get_global_attrs
 from seaice_ecdr.nc_util import (
     add_ncgroup,
@@ -91,13 +90,11 @@ def _update_ncrcat_monthly_ds(
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     monthly_filepaths: list[Path],
-    ancillary_source: ANCILLARY_SOURCES,
 ) -> datatree.DataTree:
     # Add latitude and longitude fields
     surf_geo_ds = get_ancillary_ds(
         hemisphere=hemisphere,
         resolution=resolution,
-        ancillary_source=ancillary_source,
     )
 
     # Lat and lon fields are placed under the "cdr_supplementary" group.
@@ -127,7 +124,6 @@ def _update_ncrcat_monthly_ds(
         platform_ids=[platform_id_from_filename(fp.name) for fp in monthly_filepaths],
         resolution=resolution,
         hemisphere=hemisphere,
-        ancillary_source=ancillary_source,
     )
     agg_ds.attrs = monthly_aggregate_ds_global_attrs  # type: ignore[assignment]
 
@@ -167,18 +163,11 @@ def _update_ncrcat_monthly_ds(
     type=click.Choice(get_args(ECDR_SUPPORTED_RESOLUTIONS)),
     default="25",
 )
-@click.option(
-    "--ancillary-source",
-    required=True,
-    type=click.Choice(get_args(ANCILLARY_SOURCES)),
-    default=DEFAULT_ANCILLARY_SOURCE,
-)
 def cli(
     *,
     hemisphere: Hemisphere,
     base_output_dir: Path,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ancillary_source: ANCILLARY_SOURCES,
 ) -> None:
     try:
         complete_output_dir = get_complete_output_dir(
@@ -220,7 +209,6 @@ def cli(
                 hemisphere=hemisphere,
                 resolution=resolution,
                 monthly_filepaths=monthly_filepaths,
-                ancillary_source=ancillary_source,
             )
 
             start_date = pd.Timestamp(ds.time.min().values).date()

--- a/seaice_ecdr/multiprocess_intermediate_daily.py
+++ b/seaice_ecdr/multiprocess_intermediate_daily.py
@@ -10,7 +10,6 @@ import click
 from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
-from seaice_ecdr.ancillary import ANCILLARY_SOURCES
 from seaice_ecdr.cli.util import datetime_to_date
 from seaice_ecdr.constants import DEFAULT_BASE_OUTPUT_DIR
 from seaice_ecdr.initial_daily_ecdr import create_idecdr_for_date
@@ -25,10 +24,6 @@ from seaice_ecdr.util import (
     raise_error_for_dates,
 )
 
-# TODO:
-#  ancillary sources are given in seaice_ecdr.ancillary.ANCILLARY_SOURCES
-#    but are manually spelled out in the click options here
-
 
 def multiprocess_intermediate_daily(
     start_date: dt.date,
@@ -38,7 +33,6 @@ def multiprocess_intermediate_daily(
     overwrite: bool,
     land_spillover_alg: LAND_SPILL_ALGS,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ancillary_source: ANCILLARY_SOURCES,
 ):
     dates = list(date_range(start_date=start_date, end_date=end_date))
     dates_by_year = get_dates_by_year(dates)
@@ -72,7 +66,6 @@ def multiprocess_intermediate_daily(
         intermediate_output_dir=intermediate_output_dir,
         overwrite_ide=overwrite,
         land_spillover_alg=land_spillover_alg,
-        ancillary_source=ancillary_source,
     )
 
     _create_tiecdr_wrapper = partial(
@@ -82,7 +75,6 @@ def multiprocess_intermediate_daily(
         intermediate_output_dir=intermediate_output_dir,
         overwrite_tie=overwrite,
         land_spillover_alg=land_spillover_alg,
-        ancillary_source=ancillary_source,
     )
 
     _complete_daily_wrapper = partial(
@@ -92,7 +84,6 @@ def multiprocess_intermediate_daily(
         base_output_dir=base_output_dir,
         overwrite_cde=overwrite,
         land_spillover_alg=land_spillover_alg,
-        ancillary_source=ancillary_source,
     )
 
     # Use two less than the available number of cores by default. E.g., on an
@@ -182,13 +173,6 @@ def multiprocess_intermediate_daily(
     default="NT2_BT",
 )
 @click.option(
-    "--ancillary-source",
-    required=True,
-    # type=click.Choice(["CDRv4", "CDRv5"]),
-    type=click.Choice(get_args(ANCILLARY_SOURCES)),
-    default="CDRv5",
-)
-@click.option(
     "--resolution",
     required=True,
     type=click.Choice(get_args(ECDR_SUPPORTED_RESOLUTIONS)),
@@ -201,7 +185,6 @@ def cli(
     overwrite: bool,
     land_spillover_alg: LAND_SPILL_ALGS,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ancillary_source: ANCILLARY_SOURCES,
 ):
     multiprocess_intermediate_daily(
         start_date=start_date,
@@ -211,5 +194,4 @@ def cli(
         overwrite=overwrite,
         land_spillover_alg=land_spillover_alg,
         resolution=resolution,
-        ancillary_source=ancillary_source,
     )

--- a/seaice_ecdr/nc_attrs.py
+++ b/seaice_ecdr/nc_attrs.py
@@ -13,7 +13,6 @@ from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import (
-    ANCILLARY_SOURCES,
     get_ancillary_ds,
 )
 from seaice_ecdr.constants import ECDR_PRODUCT_VERSION
@@ -153,7 +152,6 @@ def get_global_attrs(
     platform_ids: list[SUPPORTED_PLATFORM_ID],
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     hemisphere: Hemisphere,
-    ancillary_source: ANCILLARY_SOURCES,
 ) -> dict[str, Any]:
     """Return a dictionary containing the global attributes for a standard ECDR NetCDF file.
 
@@ -221,7 +219,6 @@ def get_global_attrs(
     ancillary_ds = get_ancillary_ds(
         hemisphere=hemisphere,
         resolution=resolution,
-        ancillary_source=ancillary_source,
     )
     attrs_from_ancillary = (
         "geospatial_bounds",

--- a/seaice_ecdr/nrt.py
+++ b/seaice_ecdr/nrt.py
@@ -21,7 +21,6 @@ from loguru import logger
 from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
-from seaice_ecdr.ancillary import ANCILLARY_SOURCES
 from seaice_ecdr.checksum import write_checksum_file
 from seaice_ecdr.cli.util import datetime_to_date
 from seaice_ecdr.constants import DEFAULT_BASE_NRT_OUTPUT_DIR, ECDR_NRT_PRODUCT_VERSION
@@ -88,7 +87,6 @@ def compute_nrt_initial_daily_ecdr_dataset(
     *,
     date: dt.date,
     hemisphere: Hemisphere,
-    ancillary_source: ANCILLARY_SOURCES = "CDRv5",
 ):
     """Create an initial daily ECDR NetCDF using NRT data"""
     platform_id = _get_nrt_platform_id()
@@ -108,7 +106,6 @@ def compute_nrt_initial_daily_ecdr_dataset(
         hemisphere=hemisphere,
         tb_data=tb_data,
         land_spillover_alg=NRT_LAND_SPILLOVER_ALG,
-        ancillary_source=ancillary_source,
     )
 
     return nrt_initial_ecdr_ds
@@ -169,7 +166,6 @@ def temporally_interpolated_nrt_ecdr_dataset(
     date: dt.date,
     intermediate_output_dir: Path,
     overwrite: bool,
-    ancillary_source: ANCILLARY_SOURCES = "CDRv5",
 ) -> xr.Dataset:
     init_datasets = []
     for date in date_range(
@@ -192,7 +188,6 @@ def temporally_interpolated_nrt_ecdr_dataset(
         data_stack=data_stack,
         interp_range=NRT_DAYS_TO_LOOK_PREVIOUSLY,
         one_sided_limit=NRT_DAYS_TO_LOOK_PREVIOUSLY,
-        ancillary_source=ancillary_source,
     )
 
     return temporally_interpolated_ds
@@ -325,7 +320,6 @@ def nrt_ecdr_for_day(
     hemisphere: Hemisphere,
     base_output_dir: Path,
     overwrite: bool,
-    ancillary_source: ANCILLARY_SOURCES = "CDRv5",
 ):
     """Create an initial daily ECDR NetCDF using NRT NSIDC-0802 AMSR2 data."""
     nrt_output_filepath = get_nrt_complete_daily_filepath(
@@ -357,7 +351,6 @@ def nrt_ecdr_for_day(
                 resolution=NRT_RESOLUTION,
                 intermediate_output_dir=intermediate_output_dir,
                 is_nrt=True,
-                ancillary_source=ancillary_source,
             )
             # Write the daily intermediate file. This is used by the monthly NRT
             # processing to produce the monthly fields.

--- a/seaice_ecdr/regrid_25to12.py
+++ b/seaice_ecdr/regrid_25to12.py
@@ -19,7 +19,6 @@ from scipy.signal import convolve2d
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import (
-    ANCILLARY_SOURCES,
     get_adj123_field,
     get_empty_ds_with_time,
     get_non_ocean_mask,
@@ -37,7 +36,6 @@ def _setup_ecdr_ds_replacement(
     xr_tbs: xr.Dataset,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ancillary_source: ANCILLARY_SOURCES = "CDRv5",
 ) -> xr.Dataset:
     # Initialize geo-referenced xarray Dataset
     grid_id = get_grid_id(
@@ -49,7 +47,6 @@ def _setup_ecdr_ds_replacement(
         hemisphere=hemisphere,
         resolution=resolution,
         date=date,
-        ancillary_source=ancillary_source,
     )
 
     # Set initial global attributes
@@ -77,7 +74,6 @@ def _setup_ecdr_ds_replacement(
 
 def get_reprojection_da_psn25to12(
     hemisphere: Hemisphere,
-    ancillary_source: ANCILLARY_SOURCES = "CDRv5",
 ) -> xr.DataArray:
     """Returns a mask with:
     0: No values will be interpolated
@@ -86,10 +82,12 @@ def get_reprojection_da_psn25to12(
     3: nearest neighbor interpolation should be applied
     """
     is_ocean_25 = get_ocean_mask(
-        hemisphere=hemisphere, resolution="25", ancillary_source=ancillary_source
+        hemisphere=hemisphere,
+        resolution="25",
     )
     is_ocean_12 = get_ocean_mask(
-        hemisphere=hemisphere, resolution="12.5", ancillary_source=ancillary_source
+        hemisphere=hemisphere,
+        resolution="12.5",
     )
 
     # Calculate where bilinear interpolation will compute properly
@@ -251,7 +249,6 @@ def adjust_reprojected_siconc_field(
     siconc_da: xr.DataArray,
     hemisphere: Hemisphere,
     adjustment_array: npt.NDArray,
-    ancillary_source: ANCILLARY_SOURCES = "CDRv5",
     min_siext: float = 0.10,
     n_adj: int = 3,
 ) -> xr.DataArray:
@@ -261,7 +258,6 @@ def adjust_reprojected_siconc_field(
     coast_adj = get_adj123_field(
         hemisphere=hemisphere,
         resolution="12.5",
-        ancillary_source=ancillary_source,
     ).to_numpy()
 
     # Initialize ice_edge_adjacency to 255
@@ -311,7 +307,6 @@ def reproject_ideds_25to12(
     date,
     hemisphere,
     resolution,
-    ancillary_source: ANCILLARY_SOURCES = "CDRv5",
 ):
     # Determine reprojection_masks
     reprojection_da = get_reprojection_da_psn25to12(hemisphere=hemisphere)
@@ -338,7 +333,6 @@ def reproject_ideds_25to12(
         xr_tbs=reprojected_tbs_ds,
         resolution=resolution,
         hemisphere=hemisphere,
-        ancillary_source=ancillary_source,
     )
     # add data_source and platform to the dataset attrs.
     reprojected_ideds.attrs["data_source"] = initial_ecdr_ds.data_source
@@ -348,7 +342,6 @@ def reproject_ideds_25to12(
     reprojected_ideds["non_ocean_mask"] = get_non_ocean_mask(
         hemisphere=hemisphere,
         resolution=resolution,
-        ancillary_source=ancillary_source,
     )
 
     # Block-replace (=nearest-neighbor interp)

--- a/seaice_ecdr/set_daily_ncattrs.py
+++ b/seaice_ecdr/set_daily_ncattrs.py
@@ -6,7 +6,6 @@ from pm_tb_data._types import NORTH, Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import (
-    ANCILLARY_SOURCES,
     remove_FillValue_from_coordinate_vars,
 )
 from seaice_ecdr.nc_attrs import get_global_attrs
@@ -34,7 +33,6 @@ def finalize_cdecdr_ds(
     ds_in: xr.Dataset,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ancillary_source: ANCILLARY_SOURCES,
     fields_to_drop: list = CDECDR_FIELDS_TO_DROP,
     fields_to_rename: dict = CDECDR_FIELDS_TO_RENAME,
 ) -> xr.Dataset:
@@ -357,7 +355,6 @@ def finalize_cdecdr_ds(
         platform_ids=[ds_in.platform],
         resolution=resolution,
         hemisphere=hemisphere,
-        ancillary_source=ancillary_source,
     )
     ds.attrs = new_global_attrs
 

--- a/seaice_ecdr/spillover.py
+++ b/seaice_ecdr/spillover.py
@@ -9,7 +9,6 @@ from pm_tb_data._types import Hemisphere
 from scipy.ndimage import binary_dilation, generate_binary_structure, shift
 
 from seaice_ecdr.ancillary import (
-    ANCILLARY_SOURCES,
     get_adj123_field,
     get_land90_conc_field,
     get_non_ocean_mask,
@@ -234,7 +233,6 @@ def land_spillover(
     tb_data: EcdrTbData,
     algorithm: LAND_SPILL_ALGS,
     land_mask: npt.NDArray,
-    ancillary_source: ANCILLARY_SOURCES,
     fix_goddard_bt_error: bool = False,  # By default, don't fix Goddard bug
 ) -> npt.NDArray:
     """Apply the land spillover technique to the CDR concentration field."""
@@ -244,12 +242,10 @@ def land_spillover(
         l90c = get_land90_conc_field(
             hemisphere=hemisphere,
             resolution=tb_data.resolution,
-            ancillary_source=ancillary_source,
         )
         adj123 = get_adj123_field(
             hemisphere=hemisphere,
             resolution=tb_data.resolution,
-            ancillary_source=ancillary_source,
         )
         spillover_applied_nt2 = apply_nt2_land_spillover(
             conc=cdr_conc,
@@ -266,12 +262,10 @@ def land_spillover(
         l90c = get_land90_conc_field(
             hemisphere=hemisphere,
             resolution=tb_data.resolution,
-            ancillary_source=ancillary_source,
         )
         adj123 = get_adj123_field(
             hemisphere=hemisphere,
             resolution=tb_data.resolution,
-            ancillary_source=ancillary_source,
         )
         spillover_applied_nt2 = apply_nt2_land_spillover(
             conc=cdr_conc,
@@ -285,7 +279,6 @@ def land_spillover(
         non_ocean_mask = get_non_ocean_mask(
             hemisphere=hemisphere,
             resolution=tb_data.resolution,
-            ancillary_source=ancillary_source,
         )
 
         spillover_applied_nt2_bt = coastal_fix(
@@ -307,7 +300,6 @@ def land_spillover(
         adj123 = get_adj123_field(
             hemisphere=hemisphere,
             resolution=tb_data.resolution,
-            ancillary_source=ancillary_source,
         )
         ils_arr[adj123 == 0] = 1  # land -> land
         ils_arr[adj123 == 1] = 2  # dist1 -> removable
@@ -336,14 +328,12 @@ def land_spillover(
         shoremap = get_nt_shoremap(
             hemisphere=hemisphere,
             resolution=tb_data.resolution,
-            ancillary_source=ancillary_source,
         )
 
         # Need to use adj123 to get rid of shoremap's lakes
         adj123 = get_adj123_field(
             hemisphere=hemisphere,
             resolution=tb_data.resolution,
-            ancillary_source=ancillary_source,
         )
         shoremap[(shoremap == 2) & (adj123 == 0)] = 1  # lakeshore -> land
         shoremap[(shoremap == 3) & (adj123 == 0)] = 1  # lake -> land

--- a/seaice_ecdr/temporal_composite_daily.py
+++ b/seaice_ecdr/temporal_composite_daily.py
@@ -18,7 +18,6 @@ from scipy.ndimage import shift
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import (
-    ANCILLARY_SOURCES,
     get_daily_climatology_mask,
     get_non_ocean_mask,
     nh_polehole_mask,
@@ -561,7 +560,6 @@ def temporal_interpolation(
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     data_stack: xr.Dataset,
-    ancillary_source: ANCILLARY_SOURCES,
     fill_the_pole_hole: bool = True,
     interp_range: int = 5,
     one_sided_limit: int = 3,
@@ -581,7 +579,6 @@ def temporal_interpolation(
     non_ocean_mask = get_non_ocean_mask(
         hemisphere=hemisphere,
         resolution=resolution,
-        ancillary_source=ancillary_source,
     )
     # daily_climatology_mask is True where historically no sea ice.
     #   It can be None if no daily_climatology mask is to be used
@@ -589,7 +586,6 @@ def temporal_interpolation(
         date=date,
         hemisphere=hemisphere,
         resolution=resolution,
-        ancillary_source=ancillary_source,
     )
 
     # Actually compute the cdr_conc temporal composite
@@ -655,7 +651,6 @@ def temporal_interpolation(
         near_pole_hole_mask = nh_polehole_mask(
             date=date,
             resolution=resolution,
-            ancillary_source=ancillary_source,
         )
         cdr_conc_pole_filled = fill_pole_hole(
             conc=cdr_conc,
@@ -728,7 +723,6 @@ def temporal_interpolation(
         near_pole_hole_mask = nh_polehole_mask(
             date=date,
             resolution=resolution,
-            ancillary_source=ancillary_source,
         )
         bt_conc_pole_filled = fill_pole_hole(
             conc=bt_conc_2d,
@@ -851,7 +845,6 @@ def temporally_interpolated_ecdr_dataset(
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     intermediate_output_dir: Path,
     land_spillover_alg: LAND_SPILL_ALGS,
-    ancillary_source: ANCILLARY_SOURCES,
     interp_range: int = 5,
     fill_the_pole_hole: bool = True,
 ) -> xr.Dataset:
@@ -871,7 +864,6 @@ def temporally_interpolated_ecdr_dataset(
             resolution=resolution,
             intermediate_output_dir=intermediate_output_dir,
             land_spillover_alg=land_spillover_alg,
-            ancillary_source=ancillary_source,
         )
         init_datasets.append(init_dataset)
 
@@ -883,7 +875,6 @@ def temporally_interpolated_ecdr_dataset(
         date=date,
         data_stack=data_stack,
         fill_the_pole_hole=fill_the_pole_hole,
-        ancillary_source=ancillary_source,
     )
 
     return tie_ds
@@ -953,7 +944,6 @@ def make_tiecdr_netcdf(
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     intermediate_output_dir: Path,
     land_spillover_alg: LAND_SPILL_ALGS,
-    ancillary_source: ANCILLARY_SOURCES,
     interp_range: int = 5,
     fill_the_pole_hole: bool = True,
     overwrite_tie: bool = False,
@@ -976,7 +966,6 @@ def make_tiecdr_netcdf(
                 intermediate_output_dir=intermediate_output_dir,
                 fill_the_pole_hole=fill_the_pole_hole,
                 land_spillover_alg=land_spillover_alg,
-                ancillary_source=ancillary_source,
             )
 
             written_tie_ncfile = write_tie_netcdf(
@@ -1020,7 +1009,6 @@ def read_or_create_and_read_standard_tiecdr_ds(
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     intermediate_output_dir: Path,
     land_spillover_alg: LAND_SPILL_ALGS,
-    ancillary_source: ANCILLARY_SOURCES,
     overwrite_tie: bool = False,
 ) -> xr.Dataset:
     """Read an tiecdr netCDF file, creating it if it doesn't exist.
@@ -1034,7 +1022,6 @@ def read_or_create_and_read_standard_tiecdr_ds(
         intermediate_output_dir=intermediate_output_dir,
         overwrite_tie=overwrite_tie,
         land_spillover_alg=land_spillover_alg,
-        ancillary_source=ancillary_source,
     )
 
     tie_ds = read_tiecdr_ds(
@@ -1055,7 +1042,6 @@ def create_tiecdr_for_date_range(
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     intermediate_output_dir: Path,
     land_spillover_alg: LAND_SPILL_ALGS,
-    ancillary_source: ANCILLARY_SOURCES,
     overwrite_tie: bool,
 ) -> None:
     """Generate the temporally composited daily ecdr files for a range of dates."""
@@ -1067,7 +1053,6 @@ def create_tiecdr_for_date_range(
             intermediate_output_dir=intermediate_output_dir,
             overwrite_tie=overwrite_tie,
             land_spillover_alg=land_spillover_alg,
-            ancillary_source=ancillary_source,
         )
 
 
@@ -1144,7 +1129,6 @@ def cli(
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
     overwrite: bool,
     land_spillover_alg: LAND_SPILL_ALGS,
-    ancillary_source: ANCILLARY_SOURCES,
 ) -> None:
     """Run the temporal composite daily ECDR algorithm with AMSR2 data.
 
@@ -1171,5 +1155,4 @@ def cli(
         intermediate_output_dir=intermediate_output_dir,
         overwrite_tie=overwrite,
         land_spillover_alg=land_spillover_alg,
-        ancillary_source=ancillary_source,
     )

--- a/seaice_ecdr/tests/integration/test_ancillary.py
+++ b/seaice_ecdr/tests/integration/test_ancillary.py
@@ -10,7 +10,6 @@ from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
 from seaice_ecdr.ancillary import (
-    ANCILLARY_SOURCES,
     get_adj123_field,
     get_ancillary_daily_clim_filepath,
     get_ancillary_filepath,
@@ -20,7 +19,6 @@ from seaice_ecdr.ancillary import (
     get_smmr_invalid_ice_mask,
 )
 from seaice_ecdr.constants import (
-    DEFAULT_ANCILLARY_SOURCE,
     DEFAULT_CDR_RESOLUTION,
     ECDR_PRODUCT_VERSION,
     NSIDC_NFS_SHARE_DIR,
@@ -29,22 +27,16 @@ from seaice_ecdr.grid_id import get_grid_id
 from seaice_ecdr.platforms.config import AM2_PLATFORM, F11_PLATFORM
 
 
-def test_default_ancillary_source_is_valid():
-    assert DEFAULT_ANCILLARY_SOURCE in get_args(ANCILLARY_SOURCES)
-
-
 def test_get_smmr_invalid_ice_masks():
-    for ancillary_source in get_args(ANCILLARY_SOURCES):
-        for hemisphere in get_args(Hemisphere):
-            icemask = get_smmr_invalid_ice_mask(
-                date=dt.date(2023, 1, 29),
-                hemisphere=hemisphere,
-                resolution="25",
-                ancillary_source=ancillary_source,
-            )
+    for hemisphere in get_args(Hemisphere):
+        icemask = get_smmr_invalid_ice_mask(
+            date=dt.date(2023, 1, 29),
+            hemisphere=hemisphere,
+            resolution="25",
+        )
 
-            assert icemask.dtype == bool
-            assert icemask.any()
+        assert icemask.dtype == bool
+        assert icemask.any()
 
 
 def test_adj123_does_not_overlap_land():
@@ -54,13 +46,11 @@ def test_adj123_does_not_overlap_land():
         non_ocean_mask = get_non_ocean_mask(
             hemisphere=hemisphere,
             resolution=test_resolution,
-            ancillary_source=DEFAULT_ANCILLARY_SOURCE,
         )
 
         adj123_mask = get_adj123_field(
             hemisphere=hemisphere,
             resolution=test_resolution,
-            ancillary_source=DEFAULT_ANCILLARY_SOURCE,
         )
 
         is_land = non_ocean_mask.data
@@ -73,7 +63,6 @@ def test_adj123_does_not_overlap_land():
             assert not np.any(is_land & is_adj1)
         except AssertionError as e:
             print('adj123 value of 1 overlaps with land:')
-            print(f'   ancillary_source: {DEFAULT_ANCILLARY_SOURCE}')
             print(f'         hemisphere: {hemisphere}')
             print(f'         resolution: {test_resolution}')
             breakpoint()
@@ -87,7 +76,6 @@ def test_adj123_does_not_overlap_land():
 def test_ancillary_filepaths():
     """test that the directory/names of the ancillary files
     for publication are as expected"""
-    ancillary_source = cast(ANCILLARY_SOURCES, DEFAULT_ANCILLARY_SOURCE)
     resolution = cast(ECDR_SUPPORTED_RESOLUTIONS, DEFAULT_CDR_RESOLUTION)
     hemispheres = get_args(Hemisphere)
     product_version = ECDR_PRODUCT_VERSION
@@ -115,7 +103,6 @@ def test_ancillary_filepaths():
         actual_ancillary_filepath = get_ancillary_filepath(
             hemisphere=hemisphere,
             resolution=resolution,
-            ancillary_source=ancillary_source,
         )
 
         expected_fn = expected_fp_template.safe_substitute(filename_info)
@@ -126,7 +113,6 @@ def test_ancillary_filepaths():
         actual_daily_ancillary_filepath = get_ancillary_daily_clim_filepath(
             hemisphere=hemisphere,
             resolution=resolution,
-            ancillary_source=ancillary_source,
         )
         expected_daily_fn = expected_daily_fp_template.safe_substitute(filename_info)
         expected_daily_ancillary_filepath = Path(expected_dir) / Path(expected_daily_fn)

--- a/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
+++ b/seaice_ecdr/tests/integration/test_initial_daily_ecdr_generation.py
@@ -28,14 +28,12 @@ def sample_idecdr_dataset_nh():
     test_date = dt.datetime(2021, 4, 5).date()
     test_hemisphere = NORTH
     test_resolution: Final = "25"
-    ancillary_source: Final = "CDRv5"
 
     ide_conc_ds = initial_daily_ecdr_dataset(
         date=test_date,
         hemisphere=test_hemisphere,
         resolution=test_resolution,
         land_spillover_alg="NT2",
-        ancillary_source=ancillary_source,
     )
     return ide_conc_ds
 
@@ -48,14 +46,12 @@ def sample_idecdr_dataset_sh():
     test_date = dt.datetime(2021, 4, 5).date()
     test_hemisphere = NORTH
     test_resolution: Final = "25"
-    ancillary_source: Final = "CDRv5"
 
     ide_conc_ds = initial_daily_ecdr_dataset(
         date=test_date,
         hemisphere=test_hemisphere,
         resolution=test_resolution,
         land_spillover_alg="NT2",
-        ancillary_source=ancillary_source,
     )
     return ide_conc_ds
 
@@ -136,7 +132,6 @@ def test_cli_idecdr_ncfile_creation(tmpdir):
     test_hemisphere = NORTH
     test_resolution: Final = "25"
     test_platform_id: SUPPORTED_PLATFORM_ID = "F17"
-    ancillary_source: Final = "CDRv5"
 
     make_idecdr_netcdf(
         date=test_date,
@@ -145,7 +140,6 @@ def test_cli_idecdr_ncfile_creation(tmpdir):
         intermediate_output_dir=tmpdir_path,
         excluded_fields=[],
         land_spillover_alg="NT2",
-        ancillary_source=ancillary_source,
         platform_id=test_platform_id,
     )
     output_path = get_idecdr_filepath(
@@ -172,7 +166,6 @@ def test_can_drop_fields_from_idecdr_netcdf(
     test_hemisphere = NORTH
     test_resolution: Final = "25"
     test_platform_id: SUPPORTED_PLATFORM_ID = "F17"
-    ancillary_source: Final = "CDRv5"
 
     make_idecdr_netcdf(
         date=test_date,
@@ -181,7 +174,6 @@ def test_can_drop_fields_from_idecdr_netcdf(
         intermediate_output_dir=tmpdir_path,
         excluded_fields=(cdr_conc_fieldname,),
         land_spillover_alg="NT2",
-        ancillary_source=ancillary_source,
         platform_id=test_platform_id,
     )
     output_path = get_idecdr_filepath(

--- a/seaice_ecdr/tests/integration/test_intermediate_daily.py
+++ b/seaice_ecdr/tests/integration/test_intermediate_daily.py
@@ -1,12 +1,9 @@
 import datetime as dt
-from typing import Final
 
 from pm_tb_data._types import NORTH
 
 from seaice_ecdr.intermediate_daily import make_standard_cdecdr_netcdf
 from seaice_ecdr.tests.integration import base_output_dir_test_path  # noqa
-
-ancillary_source: Final = "CDRv5"
 
 
 def test_make_standard_cdecdr_netcdf(base_output_dir_test_path):  # noqa
@@ -17,7 +14,6 @@ def test_make_standard_cdecdr_netcdf(base_output_dir_test_path):  # noqa
             resolution="25",
             base_output_dir=base_output_dir_test_path,
             land_spillover_alg="NT2",
-            ancillary_source=ancillary_source,
         )
 
         assert output_path.is_file()

--- a/seaice_ecdr/tests/integration/test_intermediate_monthly.py
+++ b/seaice_ecdr/tests/integration/test_intermediate_monthly.py
@@ -1,5 +1,3 @@
-from typing import Final
-
 import pytest
 import xarray as xr
 from pm_tb_data._types import NORTH
@@ -7,8 +5,6 @@ from pm_tb_data._types import NORTH
 from seaice_ecdr import intermediate_monthly
 from seaice_ecdr.tests.integration import base_output_dir_test_path  # noqa
 from seaice_ecdr.util import get_intermediate_output_dir
-
-ancillary_source: Final = "CDRv5"
 
 
 @pytest.mark.order(after="test_intermediate_daily.py::test_make_cdecdr_netcdf")
@@ -33,7 +29,6 @@ def test_make_intermediate_monthly_nc(base_output_dir_test_path, monkeypatch):  
         hemisphere=NORTH,
         resolution="25",
         intermediate_output_dir=intermediate_output_dir,
-        ancillary_source=ancillary_source,
         is_nrt=False,
     )
 

--- a/seaice_ecdr/tests/integration/test_monthly.py
+++ b/seaice_ecdr/tests/integration/test_monthly.py
@@ -191,7 +191,6 @@ def test_monthly_ds(monkeypatch, tmpdir):
         platform_id="am2",
         hemisphere=NORTH,
         resolution="25",
-        ancillary_source="CDRv5",
     )
 
     # Test that the dataset only contains the variables we expect.

--- a/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
+++ b/seaice_ecdr/tests/integration/test_temporal_composite_daily_integration.py
@@ -22,7 +22,6 @@ hemisphere = NORTH
 resolution: Final = "25"
 platform_id: SUPPORTED_PLATFORM_ID = "F17"
 land_spillover_alg: Final = "NT2"
-ancillary_source: Final = "CDRv5"
 
 
 def test_read_or_create_and_read_idecdr_ds(tmpdir):
@@ -42,7 +41,6 @@ def test_read_or_create_and_read_idecdr_ds(tmpdir):
         resolution=resolution,
         intermediate_output_dir=Path(tmpdir),
         land_spillover_alg=land_spillover_alg,
-        ancillary_source=ancillary_source,
     )
 
     assert sample_ide_filepath.exists()
@@ -52,7 +50,6 @@ def test_read_or_create_and_read_idecdr_ds(tmpdir):
         resolution=resolution,
         intermediate_output_dir=Path(tmpdir),
         land_spillover_alg=land_spillover_alg,
-        ancillary_source=ancillary_source,
     )
 
     assert test_ide_ds_with_creation == test_ide_ds_with_reading
@@ -77,7 +74,6 @@ def test_create_tiecdr_file(tmpdir):
         intermediate_output_dir=Path(tmpdir),
         interp_range=2,
         land_spillover_alg=land_spillover_alg,
-        ancillary_source=ancillary_source,
     )
 
     assert fp.is_file()

--- a/seaice_ecdr/tests/regression/test_daily_aggregate.py
+++ b/seaice_ecdr/tests/regression/test_daily_aggregate.py
@@ -26,7 +26,6 @@ def test_daily_aggregate_matches_daily_data(tmpdir):
     year = 2022
     resolution: Final = "25"
     land_spillover_alg: Final = "NT2"
-    ancillary_source: Final = "CDRv5"
 
     # First, ensure some daily data is created.
     datasets = []
@@ -38,7 +37,6 @@ def test_daily_aggregate_matches_daily_data(tmpdir):
             resolution=resolution,
             base_output_dir=base_output_dir,
             land_spillover_alg=land_spillover_alg,
-            ancillary_source=ancillary_source,
         )
         daily_output_fp = publish_daily_nc(
             base_output_dir=base_output_dir,

--- a/seaice_ecdr/tests/unit/test_intermediate_daily.py
+++ b/seaice_ecdr/tests/unit/test_intermediate_daily.py
@@ -24,7 +24,6 @@ def test_no_melt_onset_for_southern_hemisphere(tmpdir):
                 date=date,
                 hemisphere=SOUTH,
                 resolution="12.5",
-                ancillary_source="CDRv5",
                 intermediate_output_dir=intermediate_output_dir,
                 is_nrt=False,
             )
@@ -43,7 +42,6 @@ def test_melt_onset_field_outside_melt_season(tmpdir):
             date=date,
             hemisphere=hemisphere,
             resolution="12.5",
-            ancillary_source="CDRv5",
             intermediate_output_dir=intermediate_output_dir,
             is_nrt=False,
         )

--- a/seaice_ecdr/tests/unit/test_monthly.py
+++ b/seaice_ecdr/tests/unit/test_monthly.py
@@ -426,7 +426,6 @@ def test__calc_conc_monthly(monkeypatch):
         daily_ds_for_month=mock_daily_ds,
         hemisphere="north",
         resolution="25",
-        ancillary_source="CDRv5",
     )
 
     nptesting.assert_array_equal(

--- a/seaice_ecdr/tests/unit/test_util.py
+++ b/seaice_ecdr/tests/unit/test_util.py
@@ -311,7 +311,6 @@ def test_get_num_missing_pixels(monkeypatch):
         seaice_conc_var=_mock_sic,
         hemisphere="north",
         resolution="12.5",
-        ancillary_source="CDRv5",
     )
 
     assert detected_missing == 1

--- a/seaice_ecdr/util.py
+++ b/seaice_ecdr/util.py
@@ -9,7 +9,7 @@ import xarray as xr
 from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr._types import ECDR_SUPPORTED_RESOLUTIONS
-from seaice_ecdr.ancillary import ANCILLARY_SOURCES, get_ocean_mask
+from seaice_ecdr.ancillary import get_ocean_mask
 from seaice_ecdr.constants import ECDR_NRT_PRODUCT_VERSION, ECDR_PRODUCT_VERSION
 from seaice_ecdr.grid_id import get_grid_id
 from seaice_ecdr.platforms import SUPPORTED_PLATFORM_ID
@@ -297,13 +297,11 @@ def get_num_missing_pixels(
     seaice_conc_var: xr.DataArray,
     hemisphere: Hemisphere,
     resolution: ECDR_SUPPORTED_RESOLUTIONS,
-    ancillary_source: ANCILLARY_SOURCES,
 ) -> int:
     """The number of missing pixels is anywhere that there are nans over ocean."""
     ocean_mask = get_ocean_mask(
         hemisphere=hemisphere,
         resolution=resolution,
-        ancillary_source=ancillary_source,
     )
 
     num_missing_pixels = int((seaice_conc_var.isnull() & ocean_mask).astype(int).sum())

--- a/seaice_ecdr/validation.py
+++ b/seaice_ecdr/validation.py
@@ -53,7 +53,6 @@ from loguru import logger
 from pm_tb_data._types import Hemisphere
 
 from seaice_ecdr.ancillary import (
-    ANCILLARY_SOURCES,
     bitmask_value_for_meaning,
     flag_value_for_meaning,
 )
@@ -223,7 +222,6 @@ def get_pixel_counts(
     ds: datatree.DataTree,
     product: Product,
     hemisphere: Hemisphere,
-    ancillary_source: ANCILLARY_SOURCES = "CDRv5",
 ) -> dict[str, int]:
     """Return pixel counts from the daily or monthly ds.
 
@@ -280,7 +278,6 @@ def get_pixel_counts(
         seaice_conc_var=seaice_conc_var,  # type: ignore[arg-type]
         hemisphere=hemisphere,
         resolution=VALIDATION_RESOLUTION,
-        ancillary_source=ancillary_source,
     )
 
     # Per CDR v4, "bad" ice pixels are outside the expected range.


### PR DESCRIPTION
`ancillary_source` was a very common kwarg that was originally intended to be used to test differences between CDR v4 and 5. The code was never fully implemented, and did not work as intended.

For CDR v6, there will be updated and new ancillary data.

This major version change will remove the concept of ancillary sources, removing a broken feature and streamlining the code in the process.

If we need to add support for different ancillary sources in the future, we should promote it to a top-level configuration that does not need to be passed through so many pieces of code, and ensure it is well tested!