### PR TITLE
Seaice ecdrv1 g02202v5 g10016v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.1.0
+
+* Update NRT daily processing code to fetch NSIDC-0080 (F17) via
+  `earthaccess`. This will allow G10016 v3 to continue processing F17 data after
+  the NSIDC on-prem ECS system is shut down.
+
 # v1.0.2
 
 * Fix for subprocess calls for `git` operations (e.g., to get the current

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - rioxarray
   - hvplot
   - jupyter_bokeh
+  - h5netcdf
 
   #############################
   # Non-imported dependencies #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "seaice_ecdr"
-version = "1.0.2"
+version = "1.1.0"
 
 [tool.bumpversion]
-current_version = "1.0.2"
+current_version = "1.1.0"
 commit = false
 tag = false
 
@@ -89,5 +89,6 @@ module = [
   "cv2.*",
   "ruamel.*",
   "datatree.*",
+  "earthaccess.*",
 ]
 ignore_missing_imports = true

--- a/seaice_ecdr/__init__.py
+++ b/seaice_ecdr/__init__.py
@@ -6,7 +6,7 @@ from loguru import logger
 
 from seaice_ecdr.constants import LOGS_DIR
 
-__version__ = "v1.0.2"
+__version__ = "v1.1.0"
 
 # The standard loguru log levels, in increasing order of severity, are:
 # TRACE, DEBUG, INFO, SUCCESS, WARNING, ERROR, CRITICAL


### PR DESCRIPTION
Final `seaice_ecdr` v1 release for g02202v5/g10016v3

Since work has been progressing on v2, and I anticipated merging the v2 branch into main before I got to this, I had planned on leaving this as a branch separate from `main`. However, `v2` work (see #186 ) is still in progress, and this can be merged into `main` first.

v1 will continue to run on the `seaice_ecdr` VM at NSIDC alongside v2, which will be called `seaice_ecdr_v6`.